### PR TITLE
🔧 Fix: Correct CasaOS folder name casing

### DIFF
--- a/apps/GemDigest/app.json
+++ b/apps/GemDigest/app.json
@@ -74,7 +74,7 @@
       "template_type": 2,
       "categories": ["BigBearCasaOS", "selfhosted"],
       "administrator_only": false,
-      "folder_name": "GemDigest"
+      "folder_name": "gemdigest"
     },
     "runtipi": {
       "supported": true,
@@ -83,18 +83,18 @@
   "amd64",
   "arm64"
 ],
-      "folder_name": "GemDigest"
+      "folder_name": "gemdigest"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "folder_name": "GemDigest"
+      "folder_name": "gemdigest"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "folder_name": "GemDigest"
+      "folder_name": "gemdigest"
     },
     "umbrel": {
       "supported": true,

--- a/apps/Homepage/app.json
+++ b/apps/Homepage/app.json
@@ -69,14 +69,14 @@
     "casaos": {
       "supported": true,
       "port_map": "3000",
-      "folder_name": "Homepage"
+      "folder_name": "homepage"
     },
     "portainer": {
       "supported": true,
       "template_type": 2,
       "categories": ["BigBearCasaOS", "selfhosted"],
       "administrator_only": false,
-      "folder_name": "Homepage"
+      "folder_name": "homepage"
     },
     "runtipi": {
       "supported": true,
@@ -85,18 +85,18 @@
   "amd64",
   "arm64"
 ],
-      "folder_name": "Homepage"
+      "folder_name": "homepage"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "folder_name": "Homepage"
+      "folder_name": "homepage"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "folder_name": "Homepage"
+      "folder_name": "homepage"
     },
     "umbrel": {
       "supported": true,

--- a/apps/maybe-finance/app.json
+++ b/apps/maybe-finance/app.json
@@ -118,14 +118,14 @@
     "casaos": {
       "supported": true,
       "port_map": "4000",
-      "folder_name": "MaybeFinance"
+      "folder_name": "maybe-finance"
     },
     "portainer": {
       "supported": true,
       "template_type": 2,
       "categories": ["BigBearCasaOS", "selfhosted"],
       "administrator_only": false,
-      "folder_name": "MaybeFinance"
+      "folder_name": "maybe-finance"
     },
     "runtipi": {
       "supported": true,
@@ -134,18 +134,18 @@
         "amd64",
         "arm64"
       ],
-      "folder_name": "MaybeFinance"
+      "folder_name": "maybe-finance"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "folder_name": "MaybeFinance"
+      "folder_name": "maybe-finance"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "folder_name": "MaybeFinance"
+      "folder_name": "maybe-finance"
     },
     "umbrel": {
       "supported": true,


### PR DESCRIPTION
• Corrected CasaOS folder name casing to align with standard naming conventions
• Ensured lowercase folder naming for consistency in configuration