### PR TITLE
🔧 fix(paperless-ngx): Update Tika image to official Apache release

### DIFF
--- a/apps/paperless-ngx/docker-compose.yml
+++ b/apps/paperless-ngx/docker-compose.yml
@@ -93,7 +93,7 @@ services:
   # Apache Tika project and is configured to use the minimal image.
   big-bear-paperless-ngx-tika:
     container_name: big-bear-paperless-ngx-tika
-    image: ghcr.io/paperless-ngx/tika:2.9.1-minimal
+    image: apache/tika:2.9.1.0
     restart: unless-stopped
     # The Tika service is connected to the big-bear-paperless-ngx-network
     # network.


### PR DESCRIPTION
• Updated Tika container image to official Apache release
• Switched from GitHub-hosted to upstream source image
• Ensures version consistency with latest Tika release