### PR TITLE
🤖 feat(ci): Add Renovate automerge workflow with version check

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,134 @@
+name: Renovate Automerge
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-version-bump:
+    if: contains(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Check for major version bump
+        id: check-version
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const semver = require('semver')
+            
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const dockerComposeFiles = files.filter(file => 
+              file.filename.includes('docker-compose.yml')
+            );
+
+            let hasMajorBump = false;
+
+            for (const file of dockerComposeFiles) {
+              try {
+                // Get base content
+                const baseContent = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: file.filename,
+                  ref: context.payload.pull_request.base.ref
+                });
+                
+                // Get head content
+                const headContent = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: file.filename,
+                  ref: context.payload.pull_request.head.ref
+                });
+
+                const baseYaml = Buffer.from(baseContent.data.content, 'base64').toString('utf-8');
+                const headYaml = Buffer.from(headContent.data.content, 'base64').toString('utf-8');
+
+                // Extract image versions using regex
+                const imageRegex = /image:\s*([^:\s]+):([^\s]+)/g;
+                
+                const baseMatches = [...baseYaml.matchAll(imageRegex)];
+                const headMatches = [...headYaml.matchAll(imageRegex)];
+
+                for (let i = 0; i < baseMatches.length; i++) {
+                  if (headMatches[i]) {
+                    const baseVersion = baseMatches[i][2];
+                    const headVersion = headMatches[i][2];
+                    
+                    // Skip if versions are 'latest' or similar tags
+                    if (baseVersion === 'latest' || headVersion === 'latest') {
+                      continue;
+                    }
+
+                    const baseSemver = semver.coerce(baseVersion);
+                    const headSemver = semver.coerce(headVersion);
+
+                    if (baseSemver && headSemver) {
+                      console.log(`Comparing ${baseVersion} -> ${headVersion}`);
+                      
+                      if (headSemver.major > baseSemver.major) {
+                        console.log(`Major version bump detected: ${baseVersion} -> ${headVersion}`);
+                        hasMajorBump = true;
+                        break;
+                      }
+                    }
+                  }
+                }
+
+                if (hasMajorBump) break;
+              } catch (error) {
+                console.log(`Error processing ${file.filename}: ${error.message}`);
+              }
+            }
+
+            core.setOutput('major_bump', hasMajorBump.toString());
+
+      - name: Add automerge label for non-major updates
+        if: steps.check-version.outputs.major_bump == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["automerge"]
+            });
+            console.log('Added automerge label - this is a non-major update');
+
+      - name: Remove automerge label for major updates
+        if: steps.check-version.outputs.major_bump == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "automerge"
+              });
+              console.log('Removed automerge label - this is a major update');
+            } catch (error) {
+              console.log('Label does not exist or already removed');
+            }
+
+            // Add a comment to explain why automerge was skipped
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Automerge skipped**: This PR contains a major version update and requires manual review.'
+            });


### PR DESCRIPTION
## Description

- Implemented a GitHub Actions workflow for Renovate PR management
- Added version bump semantic checks for docker-compose files
- Introduced dynamic labeling based on update type
  - Automatically adds 'automerge' label for non-major updates
  - Removes 'automerge' label for major version updates
- Enhanced dependency upgrade control and automation