### PR TITLE
📝 Update Discord invite link in README

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -219,4 +219,4 @@ Maintained by [BigBearTechWorld](https://github.com/bigbeartechworld) and the Bi
 
 ---
 
-**Questions?** Open an issue or join our [Discord](https://discord.gg/bigbeartech)!
+**Questions?** Open an issue or join our [Discord](https://discord.gg/dExAgnrWH3)!


### PR DESCRIPTION
• Updated Discord server invite link in README to a new permanent invitation URL
• Ensures users can easily access the community support channel