### PR TITLE
🌐 feat(browsers): Migrate from Kasm to LinuxServer images

### DIFF
--- a/apps/brave/app.json
+++ b/apps/brave/app.json
@@ -95,7 +95,7 @@
       "routes_required": true
     },
     "umbrel": {
-      "supported": true,
+      "supported": false,
       "manifest_version": 1
     }
   },

--- a/apps/chrome/app.json
+++ b/apps/chrome/app.json
@@ -49,7 +49,7 @@
   },
   {
     "name": "LAUNCH_URL",
-    "default": "",
+    "default": "https://community.bigbeartechworld.com/",
     "description": "Launch URL",
     "required": false
   }
@@ -95,7 +95,7 @@
       "routes_required": true
     },
     "umbrel": {
-      "supported": true,
+      "supported": false,
       "manifest_version": 1
     }
   },

--- a/apps/chromium/app.json
+++ b/apps/chromium/app.json
@@ -5,9 +5,9 @@
     "name": "chromium",
     "description": "This Image contains a browser-accessible version of chromium.",
     "tagline": "chromium",
-    "version": "1.15.0-rolling",
+    "version": "version-6ae43f81",
     "author": "BigBearTechWorld",
-    "developer": "kasmweb",
+    "developer": "linuxserver",
     "category": "BigBearCasaOS",
     "license": "",
     "homepage": "",
@@ -35,22 +35,34 @@
 ],
     "platform": "linux",
     "main_service": "chromium",
-    "default_port": "6902",
-    "main_image": "kasmweb/chromium",
+    "default_port": "3000",
+    "main_image": "lscr.io/linuxserver/chromium",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {
     "environment_variables": [
   {
-    "name": "VNC_PW",
-    "default": "",
-    "description": "VNC Password",
+    "name": "PUID",
+    "default": "1000",
+    "description": "User ID",
     "required": false
   },
   {
-    "name": "LAUNCH_URL",
-    "default": "",
-    "description": "Launch URL",
+    "name": "PGID",
+    "default": "1000",
+    "description": "Group ID",
+    "required": false
+  },
+  {
+    "name": "TZ",
+    "default": "Etc/UTC",
+    "description": "Timezone",
+    "required": false
+  },
+  {
+    "name": "CHROME_CLI",
+    "default": "https://community.bigbeartechworld.com/",
+    "description": "Default URL to open",
     "required": false
   }
 ],
@@ -62,14 +74,14 @@
     "path": "",
     "tips": {
   "before_install": {
-    "en_us": "Username: kasm_user\n"
+    "en_us": "Access the browser at http://your-server:3000 or https://your-server:3001\n"
   }
 }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "6902"
+      "port_map": "3000"
     },
     "portainer": {
       "supported": true,

--- a/apps/chromium/docker-compose.yml
+++ b/apps/chromium/docker-compose.yml
@@ -2,16 +2,19 @@ name: big-bear-chromium # Name of the CasaOS application
 services:
   chromium:
     container_name: big-bear-chromium # Name of the Docker container
-    image: kasmweb/chromium:1.15.0-rolling # Docker image for the chromium browser
+    image: linuxserver/chromium:version-6ae43f81 # Docker image for the chromium browser
     ports:
-      - "6902:6901" # Expose port 6901 for VNC access
+      - "3000:3000" # Expose port 3000 for HTTP VNC access
+      - "3001:3001" # Expose port 3001 for HTTPS VNC access
     environment:
-      - VNC_PW=casaos # Set the VNC password to 'casaos'
-      - LAUNCH_URL=https://community.bigbeartechworld.com/ # Set the default URL to Big Bear Tech World
-    shm_size: 512m # Allocate 512 MB of shared memory
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - CHROME_CLI=https://community.bigbeartechworld.com/ # Set the default URL to Big Bear Tech World
+    shm_size: 1gb # Allocate 1 GB of shared memory
     volumes:
-      - chromium_Downloads:/home/kasm-user/Downloads # Mount the host directory to the container's Downloads directory
+      - chromium_config:/config # Mount the config directory for persistent data
 volumes:
-  chromium_Downloads:
-    name: chromium_Downloads
+  chromium_config:
+    name: chromium_config
     driver: local

--- a/apps/firefox/app.json
+++ b/apps/firefox/app.json
@@ -5,9 +5,9 @@
     "name": "Firefox",
     "description": "This Image contains a browser-accessible version of Firefox.",
     "tagline": "Firefox",
-    "version": "1.15.0-rolling",
+    "version": "1.2404.1",
     "author": "BigBearTechWorld",
-    "developer": "kasmweb",
+    "developer": "linuxserver",
     "category": "BigBearCasaOS",
     "license": "",
     "homepage": "",
@@ -35,22 +35,34 @@
 ],
     "platform": "linux",
     "main_service": "firefox",
-    "default_port": "6902",
-    "main_image": "kasmweb/firefox",
+    "default_port": "3000",
+    "main_image": "lscr.io/linuxserver/firefox",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {
     "environment_variables": [
   {
-    "name": "VNC_PW",
-    "default": "",
-    "description": "VNC Password",
+    "name": "PUID",
+    "default": "1000",
+    "description": "User ID",
     "required": false
   },
   {
-    "name": "LAUNCH_URL",
-    "default": "",
-    "description": "Launch URL",
+    "name": "PGID",
+    "default": "1000",
+    "description": "Group ID",
+    "required": false
+  },
+  {
+    "name": "TZ",
+    "default": "Etc/UTC",
+    "description": "Timezone",
+    "required": false
+  },
+  {
+    "name": "FIREFOX_CLI",
+    "default": "https://community.bigbeartechworld.com/",
+    "description": "Default URL to open",
     "required": false
   }
 ],
@@ -62,14 +74,14 @@
     "path": "",
     "tips": {
   "before_install": {
-    "en_us": "Username: kasm_user\n"
+    "en_us": "Access the browser at http://your-server:3000 or https://your-server:3001\n"
   }
 }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "6902"
+      "port_map": "3000"
     },
     "portainer": {
       "supported": true,

--- a/apps/firefox/docker-compose.yml
+++ b/apps/firefox/docker-compose.yml
@@ -2,16 +2,19 @@ name: big-bear-firefox # Name of the CasaOS application
 services:
   firefox:
     container_name: big-bear-firefox # Name of the Docker container
-    image: kasmweb/firefox:1.15.0-rolling # Docker image for the Firefox browser
+    image: linuxserver/firefox:1.2404.1 # Docker image for the Firefox browser
     ports:
-      - "6902:6901" # Expose port 6901 for VNC access
+      - "3000:3000" # Expose port 3000 for HTTP VNC access
+      - "3001:3001" # Expose port 3001 for HTTPS VNC access
     environment:
-      - VNC_PW=casaos # Set the VNC password to 'casaos'
-      - LAUNCH_URL=https://community.bigbeartechworld.com/ # Set the default URL to Big Bear Tech World
-    shm_size: 512m # Allocate 512 MB of shared memory
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - FIREFOX_CLI=https://community.bigbeartechworld.com/ # Set the default URL to Big Bear Tech World
+    shm_size: 1gb # Allocate 1 GB of shared memory
     volumes:
-      - firefox_Downloads:/home/kasm-user/Downloads # Mount the host directory to the container's Downloads directory
+      - firefox_config:/config # Mount the config directory for persistent data
 volumes:
-  firefox_Downloads:
-    name: firefox_Downloads
+  firefox_config:
+    name: firefox_config
     driver: local


### PR DESCRIPTION
- Migrated Chromium, Firefox, and Brave apps from Kasm to LinuxServer images
- Updated default ports from 6902 to 3000/3001
- Added PUID, PGID, and TZ environment variables for better container management
- Updated default launch URLs and configuration
- Increased shared memory allocation to improve browser performance