### PR TITLE
🔧 Configure Renovate to ignore GitHub Actions bot commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "dependencyDashboard": true,
   "enabledManagers": ["docker-compose", "dockerfile"],
   "labels": ["dependencies", "renovate"],
+  "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
   "hostRules": [
     {
       "matchHost": "docker.io",


### PR DESCRIPTION
• Added `gitIgnoredAuthors` configuration to Renovate settings
• Prevent GitHub Actions bot commits from triggering dependency updates
• Reduce noise in dependency update notifications