### PR TITLE
🔧 config(couchdb): Add local configuration for Obsidian

### DIFF
--- a/apps/obsidian/local.ini
+++ b/apps/obsidian/local.ini
@@ -1,0 +1,22 @@
+[couchdb]
+single_node=true
+max_document_size = 50000000
+
+[chttpd]
+require_valid_user = true
+max_http_request_size = 4294967296
+
+[chttpd_auth]
+require_valid_user = true
+authentication_redirect = /e=_/_utils/session.html
+
+[httpd]
+WWW-Authenticate = Basic realm="couchdb"
+enable_cors = true
+
+[cors]
+origins = app://obsidian.md,capacitor://localhost,http://localhost
+credentials = true
+headers = accept, authorization, content-type, origin, referer
+methods = GET, PUT, POST, HEAD, DELETE
+max_age = 3600


### PR DESCRIPTION
• Configured CouchDB for single node mode
• Added authentication settings
• Enabled CORS support
• Increased document and request size limits
• Optimized CouchDB configuration for Obsidian compatibility