### PR TITLE
Update FileBrowser icon to the correct one

### DIFF
--- a/apps/filebrowser/app.json
+++ b/apps/filebrowser/app.json
@@ -16,10 +16,10 @@
     "updated": "2025-11-04T12:44:50.341Z"
   },
   "visual": {
-    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/filebrowser-quantum.png",
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/file-browser.png",
     "thumbnail": "",
     "screenshots": [],
-    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/filebrowser-quantum.png"
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/file-browser.png"
   },
   "resources": {
     "youtube": "",


### PR DESCRIPTION
The icon previously assigned to FileBrowser was incorrectly sourced from the FileBrowser Quantum fork. This PR replaces it with the official FileBrowser icon.