### PR TITLE
Add PsiTransfer app definition and compose file

### DIFF
--- a/apps/psitransfer/app.json
+++ b/apps/psitransfer/app.json
@@ -104,7 +104,7 @@
     "path": "",
     "tips": {
       "before_install": {
-        "en_us": "Note: The data volume requires UID 1000. If you encounter permission issues, run: sudo chown -R 1000 ./data\n\nTo enable the admin dashboard, set PSITRANSFER_ADMIN_PASS to your desired password."
+        "en_us": "Read more here: https://community.bigbeartechworld.com/t/added-psitransfer-to-bigbearuniversal-apps/5142#p-7883-documentation-5"
       }
     }
   },

--- a/apps/psitransfer/docker-compose.yml
+++ b/apps/psitransfer/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     image: psitrax/psitransfer:v2.3.0
     # Name of the container
     container_name: big-bear-psitransfer
+    # Run as UID 1000 (node user) to match the image's default user
+    user: "1000:1000"
     # Environment variables
     environment:
       # Admin password for /admin page (leave empty to disable)


### PR DESCRIPTION
This pull request introduces a new configuration for deploying the PsiTransfer application. It adds all necessary metadata, environment variables, and compatibility information in `app.json`, along with a complete `docker-compose.yml` setup for containerized deployment. The main focus is on enabling easy self-hosted file sharing with customizable settings and broad platform support.

**PsiTransfer application definition and deployment configuration:**

* Added a comprehensive `apps/psitransfer/app.json` file with metadata, technical details, supported environment variables, volume and port mappings, UI tips, and compatibility information for various platforms (CasaOS, Portainer, Runtipi, Dockge, Cosmos, Umbrel).
* Introduced a full `apps/psitransfer/docker-compose.yml` file to define the `app` service, including container image, environment variables, port mapping, persistent volume setup, and restart policy for reliable deployment.