### PR TITLE
Enable Umbrel support and update sync script options

### DIFF
--- a/apps/tp-link-omada-controller/app.json
+++ b/apps/tp-link-omada-controller/app.json
@@ -204,7 +204,7 @@
       "routes_required": true
     },
     "umbrel": {
-      "supported": false,
+      "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
         "tp-link-omada-controller_data": "data",

--- a/scripts/sync-to-platforms.sh
+++ b/scripts/sync-to-platforms.sh
@@ -36,7 +36,7 @@ SPECIFIC_APP=""
 DRY_RUN=false
 FORCE=false
 REPLACE_ALL=false
-CLEAN=false
+NO_CLEAN=false
 VERBOSE=false
 
 # Counters
@@ -60,7 +60,7 @@ OPTIONS:
     --dry-run              Show what would be synced
     --force                Overwrite existing apps
     --replace-all          Delete all existing apps before syncing
-    --clean                Remove apps not in source
+    --no-clean             Skip removing orphaned apps (apps removed by default when not in source)
     -v, --verbose          Verbose output
 
 EXAMPLES:
@@ -83,7 +83,7 @@ while [[ $# -gt 0 ]]; do
         --dry-run) DRY_RUN=true; shift ;;
         --force) FORCE=true; shift ;;
         --replace-all) REPLACE_ALL=true; shift ;;
-        --clean) CLEAN=true; shift ;;
+        --no-clean) NO_CLEAN=true; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
         *) print_error "Unknown option: $1"; usage; exit 1 ;;
     esac
@@ -371,8 +371,10 @@ main() {
         sync_platform "$platform"
     done
     
-    # Clean orphaned apps if requested
-    if [[ "$CLEAN" == "true" ]]; then
+    # Always clean orphaned apps unless --no-clean is specified
+    # This ensures that when an app's "supported" flag is set to false,
+    # the app will be removed from the target platform repository
+    if [[ "$NO_CLEAN" != "true" ]]; then
         for platform in "${PLATFORMS[@]}"; do
             clean_orphaned_apps "$platform"
         done


### PR DESCRIPTION
This pull request updates the `tp-link-omada-controller` app to be supported on Umbrel and refactors the orphaned app cleaning logic in the `sync-to-platforms.sh` script. The cleaning behavior now defaults to removing orphaned apps unless explicitly disabled with a new `--no-clean` flag, replacing the previous `--clean` option.

Umbrel platform support:

* Enabled Umbrel support for the `tp-link-omada-controller` app by setting `"supported": true` in `app.json`.

Sync script option and logic changes:

* Renamed the `--clean` option to `--no-clean` in `scripts/sync-to-platforms.sh`, reversing its logic to skip orphaned app removal only when specified. [[1]](diffhunk://#diff-324f5e6ba524d82502eb3065dddea3151109b34efb2da8468026b2a16c189764L39-R39) [[2]](diffhunk://#diff-324f5e6ba524d82502eb3065dddea3151109b34efb2da8468026b2a16c189764L63-R63) [[3]](diffhunk://#diff-324f5e6ba524d82502eb3065dddea3151109b34efb2da8468026b2a16c189764L86-R86)
* Changed the default behavior to always clean orphaned apps unless `--no-clean` is used, ensuring unsupported apps are removed from target platforms.