### PR TITLE
fix: add RENOVATE_REPOSITORIES to specify target repo

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,4 +41,5 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && 'full' || '' }}


### PR DESCRIPTION
## Summary

Adds `RENOVATE_REPOSITORIES` environment variable to tell Renovate which repository to process.

## Problem

Without this setting, Renovate logs:
```
WARN: No repositories found - did you want to run with flag --autodiscover?
```

## Solution

Set `RENOVATE_REPOSITORIES: ${{ github.repository }}` to explicitly specify the target repository.

## Test plan

- Merge this PR
- Manually trigger the Renovate workflow
- Verify it processes the repository and creates/updates PRs