### PR TITLE
fix: add Docker Hub authentication to avoid rate limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,11 +13,15 @@
   "hostRules": [
     {
       "matchHost": "docker.io",
-      "concurrentRequestLimit": 2
+      "concurrentRequestLimit": 2,
+      "username": "{{ secrets.DOCKER_USERNAME }}",
+      "password": "{{ secrets.DOCKER_PASSWORD }}"
     },
     {
       "matchHost": "index.docker.io",
-      "concurrentRequestLimit": 2
+      "concurrentRequestLimit": 2,
+      "username": "{{ secrets.DOCKER_USERNAME }}",
+      "password": "{{ secrets.DOCKER_PASSWORD }}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

Adds Docker Hub credentials to Renovate's hostRules to avoid rate limiting.

## Problem

Renovate is hitting Docker Hub's unauthenticated rate limit:
```
429 Too Many Requests
You have reached your unauthenticated pull rate limit.
```

## Solution

Add `username` and `password` fields to the docker.io and index.docker.io host rules using Renovate's secrets syntax.

## Required Secrets

You need to add these secrets to the repository:
- `DOCKER_USERNAME`: Your Docker Hub username
- `DOCKER_PASSWORD`: Your Docker Hub access token (not password)

A free Docker Hub account works fine (200 requests/6 hours vs 100 for anonymous).

Create an access token at: https://hub.docker.com/settings/security

## Test plan

1. Add the secrets to the repository
2. Merge this PR
3. Run the Renovate workflow
4. Verify no more 429 errors