### PR TITLE
fix: pass Docker secrets to Renovate via RENOVATE_SECRETS env

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,3 +43,4 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && 'full' || '' }}
+          RENOVATE_SECRETS: '{"DOCKER_USERNAME":"${{ secrets.DOCKER_USERNAME }}","DOCKER_PASSWORD":"${{ secrets.DOCKER_PASSWORD }}"}'


### PR DESCRIPTION
## Summary

Passes Docker Hub credentials to Renovate via the `RENOVATE_SECRETS` environment variable.

## Problem

Renovate's `{{ secrets.X }}` syntax in `renovate.json` requires secrets to be passed via the `RENOVATE_SECRETS` environment variable as a JSON object. Without this, Renovate errors:

```
Unknown secrets name: DOCKER_USERNAME
```

## Solution

Add `RENOVATE_SECRETS` env var with the Docker credentials as JSON.

## Test plan

1. Merge this PR
2. Run the Renovate workflow
3. Verify no more secrets or rate limit errors