### PR TITLE
fix: enable config migration for self-hosted Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "config:best-practices"
   ],
+  "configMigration": true,
   "stabilityDays": 3,
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
## Summary

Enables config migration for self-hosted Renovate.

## Problem

The config migration checkbox on the Dependency Dashboard only works with the Mend-hosted Renovate app, not the self-hosted GitHub Action.

## Solution

- Add `configMigration: true` to allow Renovate to create config migration PRs
- Add `config:best-practices` preset for recommended settings

## Test plan

1. Merge this PR
2. Run the Renovate workflow
3. Renovate will create a PR to migrate any deprecated config options