### PR TITLE
feat: add major-update label for major version PRs

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -185,6 +185,15 @@ jobs:
               console.log('Label does not exist or already removed');
             }
 
+            // Add major-update label for easy filtering
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["major-update"]
+            });
+            console.log('Added major-update label');
+
             // Add a comment to explain why automerge was skipped
             await github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary

Adds a `major-update` label to Renovate PRs that contain major version bumps.

## Problem

When a Renovate PR is blocked due to a major version bump, there's no easy way to filter and find these PRs that need manual testing.

## Solution

When a major version bump is detected:
1. Remove the `automerge` label (existing behavior)
2. **Add `major-update` label** (new)
3. Add a comment explaining why automerge was skipped (existing behavior)

## Usage

Filter PRs needing testing with: `label:major-update`

## Test plan

1. Merge this PR
2. Wait for a Renovate PR with a major version bump
3. Verify the `major-update` label is added