### PR TITLE
🐛 fix(sync): Skip essential directories in orphan cleanup

### DIFF
--- a/scripts/sync-to-platforms.sh
+++ b/scripts/sync-to-platforms.sh
@@ -307,8 +307,11 @@ clean_orphaned_apps() {
     while IFS= read -r -d '' dest_app_dir; do
         local app_name=$(basename "$dest_app_dir")
         
-        # Skip special directories
-        if [[ "$app_name" == "__tests__" ]]; then
+        # Skip special directories (hidden dirs like .git, .github, and known non-app dirs)
+        if [[ "$app_name" == "__tests__" ]] || \
+           [[ "$app_name" =~ ^\. ]] || \
+           [[ "$app_name" == "scripts" ]] || \
+           [[ "$app_name" == "templates" ]]; then
             continue
         fi
         


### PR DESCRIPTION
## Summary
- Fix sync workflow failure for umbrel platform by preserving essential directories (.git, .github, scripts, templates) during orphan cleanup
- Prevents cascade failures that were cancelling all other platform syncs

## Test plan
- [x] Run workflow manually with `--dry-run` to verify .git and other essential dirs are skipped
- [x] Trigger full sync workflow and confirm umbrel and all other platforms complete successfully