### PR TITLE
🔧 ci: Add daily scheduled sync trigger

### DIFF
--- a/.github/workflows/convert-and-sync.yml
+++ b/.github/workflows/convert-and-sync.yml
@@ -6,6 +6,8 @@ permissions:
   pull-requests: write # Required for creating and auto-merging PRs
 
 on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Adds a cron schedule to run the convert-and-sync workflow daily at midnight UTC
- Ensures platform repos stay up-to-date even when changes don't trigger the path-based push trigger

## Test plan
- [x] Verify workflow shows up with schedule trigger in GitHub Actions
- [x] Wait for scheduled run or manually trigger to confirm it works