### PR TITLE
Fix automerge for scheduled and workflow dispatch runs

### DIFF
--- a/.github/workflows/convert-and-sync.yml
+++ b/.github/workflows/convert-and-sync.yml
@@ -279,7 +279,7 @@ jobs:
           labels: |
             automated
             sync
-            ${{ github.event_name == 'push' && 'automerge' || '' }}
+            ${{ (github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.auto_merge == 'true')) && 'automerge' || '' }}
           draft: ${{ github.event.inputs.create_draft == 'true' }}
 
       - name: Setup pnpm
@@ -396,7 +396,11 @@ jobs:
         working-directory: big-bear-${{ matrix.platform }}
 
       - name: Enable auto-merge
-        if: steps.check-platform.outputs.should_sync == 'true' && steps.create-pr.outputs.pull-request-number && steps.run-tests.outputs.test_status == 'passed' && (github.event.inputs.auto_merge == 'true' || github.event_name == 'push')
+        if: |
+          steps.check-platform.outputs.should_sync == 'true' &&
+          steps.create-pr.outputs.pull-request-number &&
+          (steps.run-tests.outputs.test_status == 'passed' || steps.run-tests.outputs.test_status == 'skipped') &&
+          (github.event.inputs.auto_merge == 'true' || github.event_name == 'push' || github.event_name == 'schedule')
         run: |
           gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
         env:


### PR DESCRIPTION
## Summary

- Enable `automerge` label for scheduled runs (daily cron)
- Enable `automerge` label for workflow dispatch when `auto_merge` input is `true`
- Allow auto-merge when tests are skipped (no tests configured for platform)

## Problem

PRs created by the convert-and-sync workflow were stacking up in platform repos because automerge wasn't being enabled consistently.

**Root Cause:**
- The `automerge` label was only added for push events
- The `gh pr merge --auto` command required `test_status == 'passed'`, which excluded platforms with no tests (status: `skipped`)

## Changes

### File: `.github/workflows/convert-and-sync.yml`

**1. Labels condition (line 282):**
- Now adds `automerge` label for push, schedule, and workflow_dispatch with `auto_merge: true`

**2. Auto-merge condition (line 399):**
- Allows auto-merge when tests pass OR are skipped
- Triggers for push, schedule, and workflow_dispatch with `auto_merge: true`

## Test Plan

- [x] Changes reviewed and tested locally
- [ ] Verify scheduled runs get automerge enabled
- [ ] Verify workflow dispatch with `auto_merge: true` works
- [ ] Verify platforms without tests can auto-merge

---

Fixes the issue where scheduled runs create PRs but don't auto-merge them.