### PR TITLE
feat: add OpenClaw app

### DIFF
--- a/apps/openclaw/app.json
+++ b/apps/openclaw/app.json
@@ -93,10 +93,10 @@
     "path": "",
     "tips": {
       "before_install": {
-        "en_us": "Generate a secure gateway token using: openssl rand -hex 32. Run onboarding after install: docker compose run --rm big-bear-openclaw onboard"
+        "en_us": "Generate a secure gateway token using: openssl rand -hex 32. Set OPENCLAW_GATEWAY_TOKEN in your environment before starting."
       },
       "after_install": {
-        "en_us": "Access OpenClaw gateway at http://your-server:18789. Complete onboarding: docker compose run --rm big-bear-openclaw onboard"
+        "en_us": "Complete onboarding: docker compose run --rm big-bear-openclaw-cli onboard. Then access the gateway at http://your-server:18789."
       }
     }
   },

--- a/apps/openclaw/docker-compose.yml
+++ b/apps/openclaw/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - HOME=/home/node
       - TERM=xterm-256color
-      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:?Gateway token required. Generate with: openssl rand -hex 32}"
       - CLAUDE_AI_SESSION_KEY=${CLAUDE_AI_SESSION_KEY:-}
       - CLAUDE_WEB_SESSION_KEY=${CLAUDE_WEB_SESSION_KEY:-}
       - CLAUDE_WEB_COOKIE=${CLAUDE_WEB_COOKIE:-}
@@ -30,6 +30,28 @@ services:
         "--port",
         "18789"
       ]
+
+  big-bear-openclaw-cli:
+    image: ghcr.io/openclaw/openclaw:2026.1.29
+    container_name: big-bear-openclaw-cli
+    environment:
+      - HOME=/home/node
+      - TERM=xterm-256color
+      - BROWSER=echo
+      - "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:?Gateway token required. Generate with: openssl rand -hex 32}"
+      - CLAUDE_AI_SESSION_KEY=${CLAUDE_AI_SESSION_KEY:-}
+      - CLAUDE_WEB_SESSION_KEY=${CLAUDE_WEB_SESSION_KEY:-}
+      - CLAUDE_WEB_COOKIE=${CLAUDE_WEB_COOKIE:-}
+    volumes:
+      - openclaw_config:/home/node/.openclaw
+      - openclaw_workspace:/home/node/.openclaw/workspace
+    init: true
+    stdin_open: true
+    tty: true
+    network_mode: bridge
+    entrypoint: ["node", "dist/index.js"]
+    profiles:
+      - tools
 
 volumes:
   openclaw_config:


### PR DESCRIPTION
## Summary
- Add OpenClaw, a self-hosted AI agent platform with Claude integration
- Provides local gateway for running AI assistants with tool execution and workspace management

## What is OpenClaw?
OpenClaw enables running Claude AI agents locally with:
- WebSocket gateway for Claude integration
- Local tool execution and file access
- Workspace management
- Browser automation support
- Extensible command framework

## Implementation Details
- **Image**: `ghcr.io/openclaw/openclaw:2026.1.29` (official multi-arch: amd64/arm64)
- **Ports**: 18789 (gateway), 18790 (bridge)
- **Volumes**: Named volumes for config and workspace
- **Required Env**: `OPENCLAW_GATEWAY_TOKEN` (generate with: `openssl rand -hex 32`)
- **Optional Env**: Claude AI session keys for API integration

## Platform Support
Full Universal Apps spec v1.0 compatibility:
- ✅ CasaOS
- ✅ Portainer
- ✅ Runtipi
- ✅ Dockge
- ✅ Cosmos
- ✅ Umbrel

## Files Changed
```
apps/openclaw/app.json           | 161 ++++++++++++++++
apps/openclaw/docker-compose.yml |  40 ++++
```

## Validation
- ✅ `./scripts/validate-apps.sh -a openclaw` - PASSED
- ✅ `./scripts/convert-to-platforms.sh -a openclaw` - All platforms converted successfully
- ✅ `docker compose config` - Valid syntax
- ✅ Ports 18789/18790 - Unique, no conflicts
- ✅ Naming convention - `big-bear-openclaw` prefix applied consistently

## Test Plan
- [x] Validated app.json schema
- [x] Validated docker-compose syntax
- [x] Verified port uniqueness
- [x] Tested platform conversions
- [x] Verified naming conventions
- [ ] Manual deployment test (ready for reviewer)

## Resources
- **Documentation**: https://docs.openclaw.ai/install/docker
- **Repository**: https://github.com/openclaw/openclaw
- **License**: MIT