### PR TITLE
refine: align Dockhand app with repo standards

### DIFF
--- a/apps/dockhand/app.json
+++ b/apps/dockhand/app.json
@@ -44,11 +44,11 @@
     "volumes": [
       {
         "container": "/var/run/docker.sock",
-        "description": "Docker socket access for container management"
+        "description": "Access to Docker socket for container management"
       },
       {
         "container": "/app/data",
-        "description": "Persistent data storage"
+        "description": "Dockhand application data and configuration"
       }
     ],
     "ports": [

--- a/apps/dockhand/docker-compose.yml
+++ b/apps/dockhand/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-dockhand
 # Service definitions for the big-bear-dockhand application
 services:
   # Service name: app
-  # The `app` service definition
+  # The main Dockhand application service
   app:
     # Name of the container
     container_name: big-bear-dockhand
@@ -19,8 +19,8 @@ services:
 
     # Volumes to be mounted to the container
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - dockhand_data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock  # Docker socket access
+      - dockhand_data:/app/data                     # Application data
 
     # Ports mapping between host and container
     ports:


### PR DESCRIPTION
## Summary

Align the Dockhand app configuration with established repository standards used by other Docker management tools (Portainer, Dockge, What's Up Docker).

## Changes

**apps/dockhand/app.json:**
- Updated `/var/run/docker.sock` description for consistency with similar apps
- Enhanced `/app/data` volume description to be more specific

**apps/dockhand/docker-compose.yml:**
- Improved service comment to better describe the main application service
- Added inline comments to volume mappings for clarity

## Notes

The Dockhand app was already 95% correct and following repo standards. These refinements improve consistency with the descriptive style used across other Docker management tools in the repository.

All structural patterns (service naming `app`, container naming `big-bear-dockhand`, volume naming `dockhand_data`, restart policy `unless-stopped`) were already correct.

## Test Plan

- [x] Verified changes align with Portainer/Dockge patterns
- [x] Ran version mismatch check (0 mismatches found)
- [x] Confirmed volume documentation follows repo standards