### PR TITLE
Remove minimumReleaseAge from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "minimumReleaseAge": "3 days",
   "automerge": true,
   "dependencyDashboard": true,
   "enabledManagers": [


### PR DESCRIPTION
• Removed "minimumReleaseAge": "3 days" setting from renovate.json
• Allows Renovate to consider newer releases immediately
• Simplifies configuration by relying on existing settings like automerge and dependency dashboard