### PR TITLE
Add Seerr app and update jellyseerr config

### DIFF
--- a/apps/seerr/app.json
+++ b/apps/seerr/app.json
@@ -5,7 +5,7 @@
     "name": "Seerr",
     "description": "Seerr is a free and open source software application for managing requests for your media library. It is the successor to Overseerr and Jellyseerr, bringing support for Jellyfin, Plex, and Emby media servers.",
     "tagline": "Media request management for Jellyfin, Plex, and Emby",
-    "version": "3.1.1",
+    "version": "3.1.0",
     "author": "BigBearCommunity",
     "developer": "Seerr Team",
     "category": "BigBearCasaOS",

--- a/apps/seerr/app.json
+++ b/apps/seerr/app.json
@@ -1,31 +1,31 @@
 {
   "spec_version": "1.0",
   "metadata": {
-    "id": "jellyseerr",
-    "name": "Jellyseerr (Legacy)",
-    "description": "Jellyseerr is a free and open source software application for managing requests for your media library. It is a fork of Overseerr built to bring support for Jellyfin & Emby media servers! Note: Jellyseerr is no longer actively maintained. New users should use Seerr instead.",
-    "tagline": "Legacy media request manager - new users should use Seerr instead",
-    "version": "2.7.3",
+    "id": "seerr",
+    "name": "Seerr",
+    "description": "Seerr is a free and open source software application for managing requests for your media library. It is the successor to Overseerr and Jellyseerr, bringing support for Jellyfin, Plex, and Emby media servers.",
+    "tagline": "Media request management for Jellyfin, Plex, and Emby",
+    "version": "3.1.1",
     "author": "BigBearCommunity",
-    "developer": "Fallenbagel",
+    "developer": "Seerr Team",
     "category": "BigBearCasaOS",
-    "license": "",
-    "homepage": "https://hub.docker.com/r/fallenbagel/jellyseerr",
+    "license": "MIT",
+    "homepage": "https://github.com/seerr-team/seerr",
     "source": "big-bear-universal",
-    "created": "2025-10-27T02:54:16Z",
-    "updated": "2025-10-27T02:54:16Z"
+    "created": "2026-04-13T00:00:00Z",
+    "updated": "2026-04-13T00:00:00Z"
   },
   "visual": {
-    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyseerr/thumbnail.jpg",
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/seerr.png",
+    "thumbnail": "",
     "screenshots": [],
-    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png"
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/seerr.png"
   },
   "resources": {
     "youtube": "",
-    "documentation": "",
-    "repository": "",
-    "issues": "",
+    "documentation": "https://docs.seerr.dev",
+    "repository": "https://github.com/seerr-team/seerr",
+    "issues": "https://github.com/seerr-team/seerr/issues",
     "support": "https://community.bigbeartechworld.com/"
   },
   "technical": {
@@ -35,15 +35,15 @@
     ],
     "platform": "linux",
     "main_service": "app",
-    "default_port": "5055",
-    "main_image": "fallenbagel/jellyseerr",
+    "default_port": "5056",
+    "main_image": "ghcr.io/seerr-team/seerr",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {
     "environment_variables": [
       {
         "name": "LOG_LEVEL",
-        "default": "",
+        "default": "debug",
         "description": "Log level",
         "required": false
       },
@@ -63,7 +63,7 @@
     "ports": [
       {
         "container": "5055",
-        "host": "5055",
+        "host": "5056",
         "protocol": "tcp",
         "description": "Container Port: 5055"
       }
@@ -73,19 +73,19 @@
     "scheme": "http",
     "path": "",
     "tips": {
-      "before_install": {
-        "en_us": "Jellyseerr is no longer actively maintained. Consider installing Seerr instead, which is the official successor with automatic migration support."
+      "after_install": {
+        "en_us": "Migrating from Jellyseerr? Seerr auto-migrates your data on first startup. Ensure the config directory is owned by UID 1000 (the node user)."
       }
     }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "5055",
+      "port_map": "5056",
       "volume_mappings": {
-        "jellyseerr_config": "/DATA/AppData/$AppID/config"
+        "seerr_config": "/DATA/AppData/$AppID/config"
       },
-      "port": "5055"
+      "port": "5056"
     },
     "portainer": {
       "supported": true,
@@ -95,7 +95,7 @@
         "selfhosted"
       ],
       "administrator_only": false,
-      "port": "5055"
+      "port": "5056"
     },
     "runtipi": {
       "supported": true,
@@ -105,28 +105,28 @@
         "arm64"
       ],
       "volume_mappings": {
-        "jellyseerr_config": "config"
+        "seerr_config": "config"
       },
-      "port": "5055"
+      "port": "5056"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "5055"
+      "port": "5056"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "5055"
+      "port": "5056"
     },
     "umbrel": {
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "jellyseerr_config": "config"
+        "seerr_config": "config"
       },
-      "port": "10076"
+      "port": "5056"
     }
   },
   "tags": [
@@ -134,6 +134,8 @@
     "docker",
     "bigbear",
     "bigbearcasaos",
-    "container"
+    "container",
+    "media",
+    "requests"
   ]
 }

--- a/apps/seerr/docker-compose.yml
+++ b/apps/seerr/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-seerr # Name of the compose project
 services:
   app:
-    image: ghcr.io/seerr-team/seerr:3.1.1 # Image to use for the seerr service
+    image: ghcr.io/seerr-team/seerr:3.1.0 # Image to use for the seerr service
     init: true # Enable init process
     container_name: big-bear-seerr
     ports:
@@ -13,6 +13,9 @@ services:
       - TZ=$TZ # Sets the timezone, using host's timezone variable
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3
       start_period: 20s
     restart: unless-stopped # Service will restart unless it is explicitly stopped
     network_mode: bridge # Uses bridge network mode

--- a/apps/seerr/docker-compose.yml
+++ b/apps/seerr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: big-bear-seerr # Name of the compose project
+services:
+  app:
+    image: ghcr.io/seerr-team/seerr:3.1.1 # Image to use for the seerr service
+    init: true # Enable init process
+    container_name: big-bear-seerr
+    ports:
+      - "5056:5055" # Maps port 5056 on the host to port 5055 on the container
+    volumes:
+      - seerr_config:/app/config # Binds a volume from host to container for configuration
+    environment:
+      - LOG_LEVEL=debug # Sets the log level to debug
+      - TZ=$TZ # Sets the timezone, using host's timezone variable
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:5055/api/v1/settings/public || exit 1
+      start_period: 20s
+    restart: unless-stopped # Service will restart unless it is explicitly stopped
+    network_mode: bridge # Uses bridge network mode
+volumes:
+  seerr_config:
+    name: seerr_config
+    driver: local


### PR DESCRIPTION
## Summary

Added the Seerr application to the big-bear-universal-apps catalog with its complete Docker configuration. Updated jellyseerr configuration to align with the new setup.

### Added
- New Seerr app with `app.json` configuration
- Docker Compose configuration for Seerr deployment
- Updated jellyseerr app.json with configuration changes

## Changes
- `apps/jellyseerr/app.json` — Updated configuration (12 insertions, 4 deletions)
- `apps/seerr/app.json` — New app configuration file (141 lines)
- `apps/seerr/docker-compose.yml` — Docker deployment configuration (22 lines)

## Test Plan
- [ ] Tested locally
- [ ] Verified Seerr configuration loads correctly
- [ ] Verified jellyseerr configuration is compatible
- [ ] Tested Docker deployment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Seerr as the official successor to Jellyseerr in the app catalog, with a complete Docker Compose config and app metadata, and updates the Jellyseerr entry to mark it as legacy with migration guidance. The previously flagged version mismatch (3.1.1) and missing healthcheck fields have both been resolved — image tag and `version` are now consistently `3.1.0`, and the healthcheck includes `interval`, `timeout`, and `retries`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged blocking issues are resolved; remaining findings are P2 style suggestions.

Prior P0/P1 concerns (non-existent image tag 3.1.1, missing healthcheck fields) are fully addressed. The three remaining comments are all P2: defaulting LOG_LEVEL to debug instead of info, a stale updated timestamp in jellyseerr/app.json, and alignment of the LOG_LEVEL default between app.json and docker-compose.yml. None of these block correct deployment.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/seerr/docker-compose.yml | New Seerr service definition; image tag corrected to 3.1.0 and healthcheck now fully specified, but LOG_LEVEL defaults to debug which is inappropriate for production. |
| apps/seerr/app.json | New app config for Seerr; version aligns with docker-compose (3.1.0), default_port/deployment ports are consistent, but LOG_LEVEL default is set to debug. |
| apps/jellyseerr/app.json | Marks Jellyseerr as legacy and adds a before_install tip directing users to Seerr; the updated timestamp was not bumped to reflect this modification. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User installs from catalog] --> B{Which app?}
    B -->|New install| C[Seerr\nghcr.io/seerr-team/seerr:3.1.0\nPort 5056]
    B -->|Existing / Legacy| D[Jellyseerr Legacy\nfallenbagel/jellyseerr:2.7.3\nPort 5055]
    D -->|before_install tip| E[Warning: no longer maintained\nConsider Seerr instead]
    C -->|after_install tip| F[Auto-migration from Jellyseerr\non first startup]
    C --> G[Health: GET /api/v1/settings/public\non localhost:5055]
    G -->|healthy| H[App ready on :5056]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/jellyseerr/app.json`, line 16 ([link](https://github.com/bigbeartechworld/big-bear-universal-apps/blob/6cebe3dad1325a75c5aca8a86cb8e2025ee45b79/apps/jellyseerr/app.json#L16)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`updated` timestamp not refreshed**

   The `updated` field is still `2025-10-27T02:54:16Z` despite the app being modified in this PR (name, description, tagline, and `tips` were all changed). Other apps in the repo use this field to reflect the last modification date.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/jellyseerr/app.json
   Line: 16

   Comment:
   **`updated` timestamp not refreshed**

   The `updated` field is still `2025-10-27T02:54:16Z` despite the app being modified in this PR (name, description, tagline, and `tips` were all changed). Other apps in the repo use this field to reflect the last modification date.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/seerr/docker-compose.yml
Line: 12

Comment:
**Debug log level as production default**

`LOG_LEVEL=debug` will be the out-of-the-box default for every user who deploys Seerr from this catalog entry. Debug logging produces highly verbose output (full request/response details, internal state), can expose sensitive data such as API keys or session tokens in container logs, and adds non-trivial I/O overhead. Jellyseerr uses an empty-string default (which falls back to the app's own default, typically `info`). The same approach is recommended here.

```suggestion
      - LOG_LEVEL=info # Sets the log level
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/seerr/app.json
Line: 50

Comment:
**LOG_LEVEL default should match docker-compose**

The `default` value here is `"debug"`, which will pre-populate the UI form with debug level for every new installation. This should be aligned with whatever default is set in `docker-compose.yml` — ideally `"info"` or `""` (to defer to the application's own default).

```suggestion
        "default": "info",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/jellyseerr/app.json
Line: 16

Comment:
**`updated` timestamp not refreshed**

The file was meaningfully modified (name, description, tagline, and tips all changed), but `"updated"` still reflects the original creation date `2025-10-27T02:54:16Z`. If catalog tooling or UIs rely on this field to detect newer versions, users may not see the updated legacy warning.

```suggestion
    "updated": "2026-04-13T00:00:00Z"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update Seerr app configuration and docke..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/06602d719178adcee11713280b3d69f6eca25f06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28267563)</sub>

<!-- /greptile_comment -->