### PR TITLE
fix(seerr): use official docker hub image instead of ghcr

### DIFF
--- a/apps/seerr/app.json
+++ b/apps/seerr/app.json
@@ -5,7 +5,7 @@
     "name": "Seerr",
     "description": "Seerr is a free and open source software application for managing requests for your media library. It is the successor to Overseerr and Jellyseerr, bringing support for Jellyfin, Plex, and Emby media servers.",
     "tagline": "Media request management for Jellyfin, Plex, and Emby",
-    "version": "3.1.1",
+    "version": "v3.1.1",
     "author": "BigBearCommunity",
     "developer": "Seerr Team",
     "category": "BigBearCasaOS",
@@ -36,7 +36,7 @@
     "platform": "linux",
     "main_service": "app",
     "default_port": "5056",
-    "main_image": "ghcr.io/seerr-team/seerr",
+    "main_image": "seerr/seerr",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {

--- a/apps/seerr/app.json
+++ b/apps/seerr/app.json
@@ -5,7 +5,7 @@
     "name": "Seerr",
     "description": "Seerr is a free and open source software application for managing requests for your media library. It is the successor to Overseerr and Jellyseerr, bringing support for Jellyfin, Plex, and Emby media servers.",
     "tagline": "Media request management for Jellyfin, Plex, and Emby",
-    "version": "v3.1.1",
+    "version": "3.1.1",
     "author": "BigBearCommunity",
     "developer": "Seerr Team",
     "category": "BigBearCasaOS",

--- a/apps/seerr/docker-compose.yml
+++ b/apps/seerr/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-seerr # Name of the compose project
 services:
   app:
-    image: ghcr.io/seerr-team/seerr:3.1.1 # Image to use for the seerr service
+    image: seerr/seerr:v3.1.1 # Image to use for the seerr service
     init: true # Enable init process
     container_name: big-bear-seerr
     ports:


### PR DESCRIPTION
## Summary

- Switched Seerr Docker image from GHCR (`ghcr.io/seerr-team/seerr`) to official Docker Hub registry (`seerr/seerr`)
- Normalized version tag format to `v3.1.1` (with `v` prefix) for consistency

## Changes

- `apps/seerr/app.json` — Updated main_image registry and version format
- `apps/seerr/docker-compose.yml` — Updated image reference and version tag

## Test Plan

- [ ] Verify the official Docker Hub image is available and pulls correctly
- [ ] Confirm application starts and functions normally with the new image

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches the Seerr Docker image source from GHCR (`ghcr.io/seerr-team/seerr`) to the official Docker Hub registry (`seerr/seerr:v3.1.1`), and aligns `metadata.version` in `app.json` to the semver format (`3.1.1`, no `v` prefix) consistent with other apps in this repo. The `v`-prefixed tag in `docker-compose.yml` matches Seerr's official tagging convention as documented at `docs.seerr.dev`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a clean registry migration with correct tag formatting and no logic changes.
- The Docker Hub image `seerr/seerr` is confirmed to exist and is the recommended source per Seerr's official docs. The `v3.1.1` tag follows the upstream tagging convention. `metadata.version` `3.1.1` aligns with the repo's convention (no `v` prefix). No functional logic was altered; all remaining considerations are informational.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/seerr/app.json | Updated `main_image` from `ghcr.io/seerr-team/seerr` to `seerr/seerr` (Docker Hub) and `metadata.version` is correctly formatted as `3.1.1` (no `v` prefix), consistent with repo convention. |
| apps/seerr/docker-compose.yml | Image updated from `ghcr.io/seerr-team/seerr` to `seerr/seerr:v3.1.1`; the `v`-prefixed tag is correct per Seerr's official Docker documentation. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker Pull Request] --> B{Registry}
    B -->|Before| C["ghcr.io/seerr-team/seerr:3.1.1\n(GitHub Container Registry)"]
    B -->|After| D["seerr/seerr:v3.1.1\n(Docker Hub — Official)"]
    D --> E[Container: big-bear-seerr]
    E --> F["Port 5056:5055"]
    E --> G["Volume: seerr_config → /app/config"]
    E --> H["Healthcheck: /api/v1/settings/public"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(seerr): correct metadata.version to ..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/84cdf5c198ec0738a6e540ddc14c6ec78c55e023) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28364977)</sub>

<!-- /greptile_comment -->