### PR TITLE
Fix Home Assistant Bluetooth capability requirements

### DIFF
--- a/apps/home-assistant/docker-compose.yml
+++ b/apps/home-assistant/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     image: ghcr.io/home-assistant/home-assistant:2026.4.3
     # Container restart policy
     restart: unless-stopped
+    # Required capabilities for Bluetooth management introduced in 2026.4.x
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local home-assistant_config directory to /config inside the container

--- a/apps/home-assistant/docker-compose.yml
+++ b/apps/home-assistant/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: ghcr.io/home-assistant/home-assistant:2026.4.3
     # Container restart policy
     restart: unless-stopped
-    # Required capabilities for Bluetooth management introduced in 2026.4.x
+    # Required capabilities for Bluetooth management in Home Assistant Docker containers
     cap_add:
       - NET_ADMIN
       - NET_RAW


### PR DESCRIPTION
## Summary

Adds `NET_ADMIN` and `NET_RAW` Linux capabilities to the Home Assistant container. Home Assistant 2026.4.x requires these capabilities for mandatory Bluetooth management checks, which previously caused container startup failures on updates.

## Changes

- `apps/home-assistant/docker-compose.yml`: Added `cap_add` block with `NET_ADMIN` and `NET_RAW` capabilities

## Test Plan

- [ ] Container starts successfully with updated compose file
- [ ] Home Assistant UI is accessible on port 8123
- [ ] No Bluetooth capability errors in logs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `NET_ADMIN` and `NET_RAW` Linux capabilities to the Home Assistant Docker container to resolve startup failures introduced in Home Assistant 2026.4.x, which performs mandatory Bluetooth HCI socket checks on startup. The change is minimal, well-commented, and the selected capabilities are appropriate for the stated problem.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the one-file change correctly addresses the reported startup failure with appropriate capabilities.

Only finding is a P2 note about the breadth of NET_ADMIN in a host-network context, which is a documentation/awareness suggestion and does not block merge.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/home-assistant/docker-compose.yml | Adds NET_ADMIN and NET_RAW capabilities to fix HA 2026.4.x Bluetooth startup failures; change is minimal, well-commented, and correct for the stated purpose. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker
    participant HA as Home Assistant Container
    participant Kernel as Linux Kernel
    participant BT as Bluetooth (HCI)

    Docker->>HA: Start container with NET_ADMIN + NET_RAW caps
    HA->>Kernel: Open HCI socket (requires NET_ADMIN / NET_RAW)
    Kernel-->>HA: Socket granted ✓
    HA->>BT: Bluetooth management check
    BT-->>HA: Check passed ✓
    HA-->>Docker: Container startup successful
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/home-assistant/docker-compose.yml
Line: 17-19

Comment:
**NET_ADMIN scope with host networking**

`NET_ADMIN` is a broad capability (reconfigure interfaces, routing, firewall rules) and is already more permissive in a `network_mode: host` container since the container shares the host's network namespace. Users who have no Bluetooth hardware but still run Home Assistant will now carry these extra privileges with no benefit.

If the Bluetooth check failure is the only driver, it may be worth noting in the compose file that these caps can be removed when no Bluetooth adapter is present, or linking to the upstream HA 2026.4.x release notes so users understand the trade-off.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(home-assistant): clarify Bluetooth ..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/b5c54434576b9f2b86c1c48f5f69305ae836c6e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29046477)</sub>

<!-- /greptile_comment -->