### PR TITLE
Add Sentinel Ops v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [2026.05.1]
+
+### Added
+- `apps/sentinel-ops/` — Sentinel Ops v2.0.0. Open-source Threat Intelligence and Vulnerability Monitor for Node.js (NPM/Yarn/PNPM) powered by Google's OSV-Scanner with an embedded SQLite tracking engine. amd64 only. Port 9393.
+
 ## [2026.04.1]
 
 [Blog post](https://community.bigbeartechworld.com/t/2026-04-1-major-version-app-updates-in-big-bear-universal-apps/5262?u=dragonfire1119)

--- a/apps/sentinel-ops/app.json
+++ b/apps/sentinel-ops/app.json
@@ -55,10 +55,6 @@
     ],
     "volumes": [
       {
-        "container": "/ssh",
-        "description": "SSH keys directory (read-only, for accessing private registries)"
-      },
-      {
         "container": "/data",
         "description": "SQLite database and scan results"
       }
@@ -77,7 +73,7 @@
     "path": "/",
     "tips": {
       "before_install": {
-        "en_us": "Sentinel Ops is amd64 only. The /ssh volume is optional — mount your SSH keys there if you need to scan private registries."
+        "en_us": "Sentinel Ops is amd64 only. For private repository scanning, use a deploy key or personal access token configured via the SYS_CONFIG panel — do not mount SSH private keys into this container."
       }
     }
   },
@@ -87,7 +83,6 @@
       "port_map": "9393",
       "port": "9393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "/DATA/AppData/$AppID/ssh",
         "sentinel-ops_data": "/DATA/AppData/$AppID/data"
       }
     },
@@ -109,7 +104,6 @@
       ],
       "port": "9393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     },
@@ -129,7 +123,6 @@
       "manifest_version": 1,
       "port": "10393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     }

--- a/apps/sentinel-ops/app.json
+++ b/apps/sentinel-ops/app.json
@@ -1,0 +1,147 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "sentinel-ops",
+    "name": "Sentinel Ops",
+    "description": "Sentinel Ops is an open-source Threat Intelligence and Vulnerability Monitor for Node.js environments (NPM, Yarn, PNPM). Powered by Google's OSV-Scanner and an embedded SQLite tracking engine, it provides an Executive SecOps Dashboard with MTTR tracking and auto-governance via Docker Hub.",
+    "tagline": "Threat Intelligence & Vulnerability Monitor for Node.js",
+    "version": "2.0.0",
+    "author": "BigBearTechWorld",
+    "developer": "Chavatte Security",
+    "category": "Security",
+    "license": "MIT",
+    "homepage": "https://hub.docker.com/r/chavatte/sentinel-ops",
+    "source": "big-bear-universal",
+    "created": "2026-05-05T00:00:00Z",
+    "updated": "2026-05-05T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://raw.githubusercontent.com/chavatte/sentinel-ops/main/src/static/assets/favicon.png",
+    "thumbnail": "https://raw.githubusercontent.com/chavatte/sentinel-ops/main/assets/logo.png",
+    "screenshots": [],
+    "logo": "https://raw.githubusercontent.com/chavatte/sentinel-ops/main/assets/logo.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/chavatte/sentinel-ops",
+    "repository": "https://github.com/chavatte/sentinel-ops",
+    "issues": "https://github.com/chavatte/sentinel-ops/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64"
+    ],
+    "platform": "linux",
+    "main_service": "sentinel-ops",
+    "default_port": "9393",
+    "main_image": "chavatte/sentinel-ops",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "SCAN_INTERVAL",
+        "default": "21600",
+        "description": "Vulnerability scan interval in seconds (default: 6 hours)",
+        "required": false
+      },
+      {
+        "name": "TZ",
+        "default": "UTC",
+        "description": "Timezone for the application",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/ssh",
+        "description": "SSH keys directory (read-only, for accessing private registries)"
+      },
+      {
+        "container": "/data",
+        "description": "SQLite database and scan results"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8080",
+        "host": "9393",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "/",
+    "tips": {
+      "before_install": {
+        "en_us": "Sentinel Ops is amd64 only. The /ssh volume is optional — mount your SSH keys there if you need to scan private registries."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "9393",
+      "port": "9393",
+      "volume_mappings": {
+        "sentinel-ops_ssh": "/DATA/AppData/$AppID/ssh",
+        "sentinel-ops_data": "/DATA/AppData/$AppID/data"
+      }
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "Security",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "9393"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64"
+      ],
+      "port": "9393",
+      "volume_mappings": {
+        "sentinel-ops_ssh": "sentinel-ops/ssh",
+        "sentinel-ops_data": "sentinel-ops/data"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "9393"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "9393"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "10393",
+      "volume_mappings": {
+        "sentinel-ops_ssh": "sentinel-ops/ssh",
+        "sentinel-ops_data": "sentinel-ops/data"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "security",
+    "vulnerability",
+    "nodejs",
+    "npm",
+    "osv-scanner"
+  ]
+}

--- a/apps/sentinel-ops/app.json
+++ b/apps/sentinel-ops/app.json
@@ -55,10 +55,6 @@
     ],
     "volumes": [
       {
-        "container": "/ssh",
-        "description": "SSH keys directory (read-only, for accessing private registries)"
-      },
-      {
         "container": "/data",
         "description": "SQLite database and scan results"
       }
@@ -87,7 +83,6 @@
       "port_map": "9393",
       "port": "9393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "/DATA/AppData/$AppID/ssh",
         "sentinel-ops_data": "/DATA/AppData/$AppID/data"
       }
     },
@@ -109,7 +104,6 @@
       ],
       "port": "9393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     },
@@ -129,7 +123,6 @@
       "manifest_version": 1,
       "port": "10393",
       "volume_mappings": {
-        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     }

--- a/apps/sentinel-ops/app.json
+++ b/apps/sentinel-ops/app.json
@@ -55,6 +55,10 @@
     ],
     "volumes": [
       {
+        "container": "/ssh",
+        "description": "SSH keys directory (read-only, for accessing private registries)"
+      },
+      {
         "container": "/data",
         "description": "SQLite database and scan results"
       }
@@ -83,6 +87,7 @@
       "port_map": "9393",
       "port": "9393",
       "volume_mappings": {
+        "sentinel-ops_ssh": "/DATA/AppData/$AppID/ssh",
         "sentinel-ops_data": "/DATA/AppData/$AppID/data"
       }
     },
@@ -104,6 +109,7 @@
       ],
       "port": "9393",
       "volume_mappings": {
+        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     },
@@ -123,6 +129,7 @@
       "manifest_version": 1,
       "port": "10393",
       "volume_mappings": {
+        "sentinel-ops_ssh": "sentinel-ops/ssh",
         "sentinel-ops_data": "sentinel-ops/data"
       }
     }

--- a/apps/sentinel-ops/docker-compose.yml
+++ b/apps/sentinel-ops/docker-compose.yml
@@ -1,0 +1,29 @@
+name: sentinel-ops
+
+services:
+  sentinel-ops:
+    image: chavatte/sentinel-ops:2.0.0
+    container_name: sentinel-ops
+    restart: unless-stopped
+    ports:
+      - "9393:8080"
+    environment:
+      - SCAN_INTERVAL=21600
+      - TZ=UTC
+    volumes:
+      - sentinel-ops_ssh:/ssh:ro
+      - sentinel-ops_data:/data
+    networks:
+      - sentinel-ops-network
+
+networks:
+  sentinel-ops-network:
+    driver: bridge
+
+volumes:
+  sentinel-ops_ssh:
+    name: sentinel-ops_ssh
+    driver: local
+  sentinel-ops_data:
+    name: sentinel-ops_data
+    driver: local

--- a/apps/sentinel-ops/docker-compose.yml
+++ b/apps/sentinel-ops/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - SCAN_INTERVAL=21600
       - TZ=UTC
     volumes:
-      - sentinel-ops_ssh:/ssh:ro
+      - /DATA/AppData/sentinel-ops/ssh:/ssh:ro
       - sentinel-ops_data:/data
     networks:
       - sentinel-ops-network
@@ -21,9 +21,6 @@ networks:
     driver: bridge
 
 volumes:
-  sentinel-ops_ssh:
-    name: sentinel-ops_ssh
-    driver: local
   sentinel-ops_data:
     name: sentinel-ops_data
     driver: local

--- a/apps/sentinel-ops/docker-compose.yml
+++ b/apps/sentinel-ops/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - SCAN_INTERVAL=21600
       - TZ=UTC
     volumes:
-      - /DATA/AppData/sentinel-ops/ssh:/ssh:ro
+      - sentinel-ops_ssh:/ssh:ro
       - sentinel-ops_data:/data
     networks:
       - sentinel-ops-network
@@ -21,6 +21,9 @@ networks:
     driver: bridge
 
 volumes:
+  sentinel-ops_ssh:
+    name: sentinel-ops_ssh
+    driver: local
   sentinel-ops_data:
     name: sentinel-ops_data
     driver: local

--- a/apps/sentinel-ops/docker-compose.yml
+++ b/apps/sentinel-ops/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - SCAN_INTERVAL=21600
       - TZ=UTC
     volumes:
-      - sentinel-ops_ssh:/ssh:ro
       - sentinel-ops_data:/data
     networks:
       - sentinel-ops-network
@@ -21,9 +20,6 @@ networks:
     driver: bridge
 
 volumes:
-  sentinel-ops_ssh:
-    name: sentinel-ops_ssh
-    driver: local
   sentinel-ops_data:
     name: sentinel-ops_data
     driver: local


### PR DESCRIPTION
## Summary
Added Sentinel Ops v2.0.0 — open-source Threat Intelligence and Vulnerability Monitor for Node.js ecosystems (NPM, Yarn, PNPM). Powered by Google's OSV-Scanner with an embedded SQLite tracking engine and Executive SecOps Dashboard.

- Port: 9393
- Architecture: amd64 only
- Updated CHANGELOG.md with new [2026.05.1] entry

Closes bigbeartechworld/big-bear-casaos#6158

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Sentinel Ops v2.0.0, a Node.js dependency vulnerability scanner powered by Google's OSV-Scanner, with a SQLite-backed dashboard served on host port 9393. The previous SSH-key exposure concern from the earlier review has been fully resolved — the named SSH volume is gone and the `before_install` tip now explicitly warns against mounting private keys.

- **`docker-compose.yml`**: Minimal and clean; single `sentinel-ops_data` volume, isolated bridge network, `unless-stopped` restart policy, and a pinned `2.0.0` image tag.
- **`app.json`**: Six-platform compatibility block with consistent 9393 host port entries and correct volume mappings. One minor inconsistency: `technical.default_port` is set to the host-mapped port (`\"9393\"`) rather than the container's internal port (`\"8080\"`) as shown in the `_example` template.
- **`CHANGELOG.md`**: New `[2026.05.1]` entry follows the existing CalVer format correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the prior SSH key exposure concern is fully resolved and the compose definition is straightforward.

The change is a new app definition with no logic shared with existing apps. The SSH volume that prompted the previous security comment has been removed, and the tip actively discourages users from re-introducing key material. The only finding is a minor port field inconsistency in app.json metadata that does not affect runtime behavior.

No files require special attention beyond the minor technical.default_port field in apps/sentinel-ops/app.json.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/sentinel-ops/docker-compose.yml | New compose file for Sentinel Ops; single data volume, custom bridge network, port 9393:8080. No SSH volume (previous concern addressed). Image is from unverified personal namespace (already flagged in prior threads). |
| apps/sentinel-ops/app.json | New app manifest covering 6 platforms. technical.default_port is set to "9393" (host-mapped port) while the container internally listens on 8080 — inconsistent with the repo example template which sets default_port to the container port. |
| CHANGELOG.md | Adds [2026.05.1] entry for Sentinel Ops; format and CalVer style match existing entries. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User Browser
    participant Host as Host (port 9393)
    participant Container as sentinel-ops container (8080)
    participant OSV as Google OSV-Scanner
    participant DB as SQLite /data

    User->>Host: HTTP GET :9393
    Host->>Container: forward to :8080
    Container->>OSV: Scan NPM/Yarn/PNPM deps (every SCAN_INTERVAL s)
    OSV-->>Container: Vulnerability results
    Container->>DB: Persist results (sentinel-ops_data volume)
    Container-->>Host: Dashboard HTML
    Host-->>User: Response
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/sentinel-ops/app.json:37
The `_example` template documents `technical.default_port` as the container-internal port (the port the app process listens on), not the host-mapped port. Here the container listens on `8080` but `default_port` is set to `"9393"` (the host-side mapping). If any tooling derives an internal routing target from this field it would try to reach a port that the container doesn't actually expose.

```suggestion
    "default_port": "8080",
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: remove SSH volume mount per securit..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/14f93f833068edca41d2f76164712864ce24af5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30875466)</sub>

<!-- /greptile_comment -->