### PR TITLE
feat: add Gitea app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [Unreleased]
+
+### Added
+- `apps/gitea/` — Gitea v1.26.1. Self-hosted Git service with SSH (port 2222), web UI (port 3000), and platform compatibility for CasaOS, Portainer, RunTipi, Dockge, Cosmos, and Umbrel.
+
 ## [2026.04.1]
 
 [Blog post](https://community.bigbeartechworld.com/t/2026-04-1-major-version-app-updates-in-big-bear-universal-apps/5262?u=dragonfire1119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within
 
 ## [Unreleased]
 
+## [2026.05.0]
+
 ### Added
 - `apps/gitea/` — Gitea v1.26.1. Self-hosted Git service with SSH (port 2222), web UI (port 3000), and platform compatibility for CasaOS, Portainer, RunTipi, Dockge, Cosmos, and Umbrel.
 

--- a/apps/gitea/app.json
+++ b/apps/gitea/app.json
@@ -10,14 +10,14 @@
     "developer": "gitea",
     "category": "BigBearCasaOS",
     "license": "MIT",
-    "homepage": "https://hub.docker.com/r/gitea/gitea",
+    "homepage": "https://gitea.com",
     "source": "big-bear-universal",
     "created": "2026-04-29T00:00:00Z",
     "updated": "2026-04-29T00:00:00Z"
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
+    "thumbnail": "",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png"
   },

--- a/apps/gitea/app.json
+++ b/apps/gitea/app.json
@@ -1,0 +1,154 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "gitea",
+    "name": "Gitea",
+    "description": "Gitea is a painless self-hosted all-in-one software development service. It includes Git hosting, code review, team collaboration, package registry, and CI/CD. It is similar to GitHub, Bitbucket and GitLab.",
+    "tagline": "Self-hosted Git service",
+    "version": "1.22.6",
+    "author": "BigBearTechWorld",
+    "developer": "gitea",
+    "category": "BigBearCasaOS",
+    "license": "MIT",
+    "homepage": "https://hub.docker.com/r/gitea/gitea",
+    "source": "big-bear-universal",
+    "created": "2026-04-29T00:00:00Z",
+    "updated": "2026-04-29T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://docs.gitea.com/",
+    "repository": "https://github.com/go-gitea/gitea",
+    "issues": "https://github.com/go-gitea/gitea/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "big-bear-gitea",
+    "default_port": "3000",
+    "main_image": "gitea/gitea",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "USER_UID",
+        "default": "1000",
+        "description": "UID of the user running Gitea inside the container",
+        "required": false
+      },
+      {
+        "name": "USER_GID",
+        "default": "1000",
+        "description": "GID of the user running Gitea inside the container",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Gitea data directory"
+      },
+      {
+        "container": "/etc/timezone",
+        "description": "Host timezone (read-only)"
+      },
+      {
+        "container": "/etc/localtime",
+        "description": "Host localtime (read-only)"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Gitea web UI"
+      },
+      {
+        "container": "22",
+        "host": "2222",
+        "protocol": "tcp",
+        "description": "Gitea SSH"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": {
+        "en_us": ""
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3000",
+      "volume_mappings": {
+        "gitea_data": "/DATA/AppData/$AppID/data"
+      },
+      "port": "3000"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted",
+        "development"
+      ],
+      "administrator_only": false,
+      "port": "3000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "gitea_data": "data"
+      },
+      "port": "3000"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "gitea_data": "data"
+      },
+      "port": "3000"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "git",
+    "development"
+  ]
+}

--- a/apps/gitea/app.json
+++ b/apps/gitea/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
-    "thumbnail": "",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png"
   },
@@ -51,6 +51,12 @@
         "name": "USER_GID",
         "default": "1000",
         "description": "GID of the user running Gitea inside the container",
+        "required": false
+      },
+      {
+        "name": "GITEA__server__SSH_PORT",
+        "default": "2222",
+        "description": "Advertised SSH port for Gitea",
         "required": false
       }
     ],

--- a/apps/gitea/app.json
+++ b/apps/gitea/app.json
@@ -13,7 +13,7 @@
     "homepage": "https://gitea.com",
     "source": "big-bear-universal",
     "created": "2026-04-29T00:00:00Z",
-    "updated": "2026-04-29T00:00:00Z"
+    "updated": "2026-05-11T00:00:00Z"
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
@@ -57,6 +57,18 @@
         "default": "2222",
         "description": "Advertised SSH port for Gitea",
         "required": false
+      },
+      {
+        "name": "GITEA__server__DOMAIN",
+        "default": "",
+        "description": "Domain or IP used to access Gitea (e.g. git.example.com). Required behind a reverse proxy.",
+        "required": false
+      },
+      {
+        "name": "GITEA__server__ROOT_URL",
+        "default": "",
+        "description": "Full public URL of Gitea (e.g. https://git.example.com/). Required behind a reverse proxy to fix clone URLs and webhooks.",
+        "required": false
       }
     ],
     "volumes": [
@@ -90,7 +102,7 @@
   },
   "ui": {
     "scheme": "http",
-    "path": "",
+    "path": "/",
     "tips": {
       "before_install": {
         "en_us": ""
@@ -137,7 +149,8 @@
     "cosmos": {
       "supported": true,
       "servapp": true,
-      "routes_required": true
+      "routes_required": true,
+      "port": "3000"
     },
     "umbrel": {
       "supported": true,

--- a/apps/gitea/app.json
+++ b/apps/gitea/app.json
@@ -5,7 +5,7 @@
     "name": "Gitea",
     "description": "Gitea is a painless self-hosted all-in-one software development service. It includes Git hosting, code review, team collaboration, package registry, and CI/CD. It is similar to GitHub, Bitbucket and GitLab.",
     "tagline": "Self-hosted Git service",
-    "version": "1.22.6",
+    "version": "1.26.1",
     "author": "BigBearTechWorld",
     "developer": "gitea",
     "category": "BigBearCasaOS",
@@ -17,12 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png",
+    "thumbnail": "",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gitea.png"
   },
   "resources": {
-    "youtube": "",
     "documentation": "https://docs.gitea.com/",
     "repository": "https://github.com/go-gitea/gitea",
     "issues": "https://github.com/go-gitea/gitea/issues",

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
+      - GITEA__server__SSH_PORT=2222
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=3", "--spider", "http://localhost:3000"]
       interval: 30s

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -1,0 +1,27 @@
+name: big-bear-gitea
+services:
+  big-bear-gitea:
+    container_name: big-bear-gitea
+    image: gitea/gitea:1.22.6
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+      - "2222:22"
+    volumes:
+      - gitea_data:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=3", "--spider", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  gitea_data:
+    name: gitea_data
+    driver: local

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - USER_UID=1000
       - USER_GID=1000
       - GITEA__server__SSH_PORT=2222
+      - GITEA__server__DOMAIN=
+      - GITEA__server__ROOT_URL=
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=3", "--spider", "http://localhost:3000"]
       interval: 30s

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - USER_UID=1000
       - USER_GID=1000
       - GITEA__server__SSH_PORT=2222
-      - GITEA__server__DOMAIN=
-      - GITEA__server__ROOT_URL=
+      # - GITEA__server__DOMAIN=git.example.com
+      # - GITEA__server__ROOT_URL=https://git.example.com/
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=3", "--spider", "http://localhost:3000"]
       interval: 30s

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-gitea
 services:
   big-bear-gitea:
     container_name: big-bear-gitea
-    image: gitea/gitea:1.22.6
+    image: gitea/gitea:1.26.1
     restart: unless-stopped
     ports:
       - "3000:3000"


### PR DESCRIPTION
Adds Gitea self-hosted Git service with app.json manifest and docker-compose.yml.
Includes SSH port mapping (2222:22), healthcheck, and platform compatibility (CasaOS, Portainer, RunTipi, Dockge, Cosmos, Umbrel).
Replaces #1975 (closed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Gitea self-hosted Git service app, including an `app.json` manifest and `docker-compose.yml`. All issues flagged in the previous review round have been addressed: `ui.path` is now `"/"`, the `cosmos` block includes a `port` field, and `GITEA__server__DOMAIN`/`GITEA__server__ROOT_URL` are commented out in the compose file (avoiding empty-string overrides of Gitea's defaults) while being documented in `app.json` for users who need them.

- **`apps/gitea/docker-compose.yml`**: Pins `gitea/gitea:1.26.1`, maps SSH to port `2222`, includes a `wget --spider` healthcheck with a 60 s start period, and keeps the reverse-proxy env vars commented out.
- **`apps/gitea/app.json`**: Declares all six platform compatibility blocks (CasaOS, Portainer, RunTipi, Dockge, Cosmos, Umbrel) with correct port fields, proper `ui.path`, and documents the optional DOMAIN/ROOT_URL vars.
- **`CHANGELOG.md`**: Introduces the `[Unreleased]` section (adopting Keep a Changelog format) and adds a `[2026.05.0]` entry for this app.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all previously flagged issues have been resolved and no new defects were found.

The change adds a self-contained new app directory with no modifications to shared infrastructure. The previously reported concerns (empty ui.path, missing cosmos port, empty-string env-var overrides) are all corrected. The docker-compose is straightforward: a pinned image, correct port mappings, a working healthcheck, and reverse-proxy vars safely commented out. The app.json is consistent with other apps in the repo across all six platform compatibility blocks.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/gitea/docker-compose.yml | New Gitea docker-compose with correct SSH port mapping (2222:22), healthcheck, and commented-out DOMAIN/ROOT_URL env vars to avoid overriding Gitea defaults |
| apps/gitea/app.json | New Gitea app manifest with correct ui.path "/", cosmos port field, all six platform compatibility blocks, and optional DOMAIN/ROOT_URL env vars documented with empty defaults |
| CHANGELOG.md | Adds [Unreleased] header (adopting Keep a Changelog format) and [2026.05.0] entry for the Gitea app |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User -->|"HTTP :3000"| GiteaWeb["Gitea Web UI\n(big-bear-gitea)"]
    User -->|"SSH :2222"| GiteaSSH["Gitea SSH\n(container port 22)"]
    GiteaWeb --> Volume["gitea_data volume\n(/data)"]
    GiteaWeb --> TZ["/etc/timezone\n/etc/localtime (ro)"]
    GiteaWeb -->|"wget --spider\nhttp://localhost:3000"| HC["Docker Healthcheck\n(30s interval, 60s start_period)"]

    subgraph Platforms
        CasaOS
        Portainer
        RunTipi
        Dockge
        Cosmos
        Umbrel
    end

    Platforms -->|"reads app.json"| Manifest["app.json manifest\n(spec_version 1.0)"]
    Manifest --> GiteaWeb
```

<sub>Reviews (4): Last reviewed commit: ["fix: comment out DOMAIN and ROOT\_URL env..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/21146fae2bb3d11db3334adef1bdb07427aa7535) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31544813)</sub>

<!-- /greptile_comment -->