### PR TITLE
chore(renovate): add 3-day minimum age for patch and minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within
 
 ## [Unreleased]
 
+## [2026.05.1]
+
+### Changed
+- `renovate.json` — Added `minimumReleaseAge: "3 days"` to patch and minor automerge rule. Docker image updates now wait 3 days after release before auto-merging, reducing supply chain attack exposure.
+
 ## [2026.05.0]
 
 ### Added

--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,8 @@
         "minor",
         "patch"
       ],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

Adds 3-day minimum release age before Renovate automerges Docker image patches and minor updates. Mitigates supply chain attack risk by allowing time for community detection of poisoned releases.

## Closes
N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `minimumReleaseAge: "3 days"` to the Renovate package rule that automerges Docker image patch and minor updates, introducing a 3-day holding period before any such update is automatically merged. This is a targeted supply-chain hardening measure that gives the community time to detect and report poisoned releases before they land in the repository.

- **`renovate.json`**: Appends `"minimumReleaseAge": "3 days"` to the existing `matchUpdateTypes: [minor, patch]` / `automerge: true` rule. No other rules are modified.
- **`CHANGELOG.md`**: Adds a `[2026.05.1]` entry documenting the change under "Changed".

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change narrows the automerge eligibility window without breaking any existing rules or disabling any updates.

The diff is a single-field addition to a Renovate package rule and a matching changelog entry. The minimumReleaseAge setting is a well-supported Renovate option and its value '3 days' is a valid duration string. All existing automerge exclusions (major updates, rocket.chat, Immich images, latest-tag packages) remain unaffected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds `minimumReleaseAge: "3 days"` to the existing patch/minor automerge rule; clean and targeted change. |
| CHANGELOG.md | Adds a new `[2026.05.1]` entry documenting the minimumReleaseAge addition; follows existing format correctly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New Docker image release detected] --> B{matchUpdateTypes?}
    B -->|major| C[automerge: false\nOpen PR, no automerge]
    B -->|minor or patch| D{minimumReleaseAge\n≥ 3 days?}
    D -->|No| E[Wait — PR opened but\nnot yet eligible for automerge]
    D -->|Yes| F{Package exclusion rule?\ne.g. rocket.chat, Immich}
    F -->|Yes| G[automerge: false\nManual merge required]
    F -->|No| H[automerge: true\nPR is auto-merged]
```

<sub>Reviews (2): Last reviewed commit: ["chore(changelog): resolve merge conflict..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/f260340d5ab2bb547ce8d958c1e3fe0431ec7aa1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31701776)</sub>

<!-- /greptile_comment -->