### PR TITLE
chore: add Nova DSO Tracker to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [2026.05.5]
+
+### Added
+- `apps/nova-dso-tracker/` — Nova DSO Tracker (mrantonsg/nova-dso-tracker). Astrophotography Deep Space Object tracker and imaging session planner. Port 5001. Community verified on CasaOS by j900.
+
 ## [2026.05.4]
 
 ### Added


### PR DESCRIPTION
## Summary

Adds missing CHANGELOG entry for Nova DSO Tracker app (PR #1287), which was merged but not logged.

- App: Nova DSO Tracker (mrantonsg/nova-dso-tracker)
- Astrophotography Deep Space Object tracker and imaging session planner
- Port: 5001
- Community verified on CasaOS by j900

## Changes

- Added `[2026.05.5]` section with Nova DSO Tracker entry

## Test Plan

- [x] Verified entry format matches existing entries
- [x] Confirmed version number (2026.05.5) is appropriate for post-2026.05.4 release

Closes #2077

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a missing CHANGELOG entry for the Nova DSO Tracker app (merged in PR #1287 but never logged), inserting a new `[2026.05.5]` section immediately above `[2026.05.4]`.

- The new entry follows the established CalVer format (`YYYY.MM.N`), uses the correct section heading style (`### Added`), and matches the prose/backtick conventions of all surrounding entries.
- No code, configuration, or app files are changed — the diff is documentation-only.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code, configuration, or runtime impact — safe to merge.

The single changed file is CHANGELOG.md. The new section header, version number, formatting style, and entry prose all match the conventions established by the surrounding entries. Nothing in the application code, configuration, or deployment files is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a new [2026.05.5] section for Nova DSO Tracker; format, version ordering, and entry style all match existing entries correctly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CHANGELOG.md"] --> B["## [2026.05.5] ← NEW"]
    B --> C["### Added\n- apps/nova-dso-tracker/"]
    C --> D["## [2026.05.4]"]
    D --> E["## [2026.05.3]"]
    E --> F["## [2026.05.2]"]
    F --> G["...older entries..."]
```

<sub>Reviews (1): Last reviewed commit: ["chore: add Nova DSO Tracker to CHANGELOG"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/6cf7a8abfe43898c0c3c6f730c708b19c7e2ba1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32089219)</sub>

<!-- /greptile_comment -->