### PR TITLE
Add Celestory & Voltask configuration and docker setup

### DIFF
--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "celestory",
     "name": "Celestory & Voltask",
-    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine.",
+    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available. Purchase a license at https://celestory.io/pricing",
     "tagline": "No-code interactive storytelling & automation",
     "version": "1.0.0",
     "author": "Celestory",

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -126,9 +126,9 @@
       "supported": true,
       "port_map": "1500",
       "volume_mappings": {
-        "project_files": "/DATA/AppData/$AppID/projectFiles",
-        "voltask_uploads": "/DATA/AppData/$AppID/uploads",
-        "postgres_data": "/DATA/AppData/$AppID/db"
+        "celestory_project_files": "/DATA/AppData/$AppID/projectFiles",
+        "celestory_voltask_uploads": "/DATA/AppData/$AppID/uploads",
+        "celestory_postgres_data": "/DATA/AppData/$AppID/db"
       },
       "port": "1500"
     },
@@ -144,9 +144,9 @@
       "tipi_version": 1,
       "supported_architectures": ["amd64", "arm64"],
       "volume_mappings": {
-        "project_files": "projectFiles",
-        "voltask_uploads": "uploads",
-        "postgres_data": "db"
+        "celestory_project_files": "projectFiles",
+        "celestory_voltask_uploads": "uploads",
+        "celestory_postgres_data": "db"
       },
       "port": "1500"
     },
@@ -165,9 +165,9 @@
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "project_files": "projectFiles",
-        "voltask_uploads": "uploads",
-        "postgres_data": "db"
+        "celestory_project_files": "projectFiles",
+        "celestory_voltask_uploads": "uploads",
+        "celestory_postgres_data": "db"
       },
       "port": "1500"
     }

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -126,9 +126,9 @@
       "supported": true,
       "port_map": "1500",
       "volume_mappings": {
-        "celestory_project_files": "/DATA/AppData/$AppID/projectFiles",
-        "celestory_voltask_uploads": "/DATA/AppData/$AppID/uploads",
-        "celestory_postgres_data": "/DATA/AppData/$AppID/db"
+        "celestory-project-files": "/DATA/AppData/$AppID/projectFiles",
+        "celestory-voltask-uploads": "/DATA/AppData/$AppID/uploads",
+        "celestory-postgres-data": "/DATA/AppData/$AppID/db"
       },
       "port": "1500"
     },

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -1,0 +1,197 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "celestory",
+    "name": "Celestory & Voltask",
+    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine.",
+    "tagline": "No-code interactive storytelling & automation",
+    "version": "1.0.0",
+    "author": "Celestory",
+    "developer": "celestory",
+    "category": "Development",
+    "license": "Celestory Self-Hosted License",
+    "homepage": "https://www.celestory.io",
+    "source": "big-bear-universal",
+    "created": "2025-10-27T02:42:00Z",
+    "updated": "2026-05-16T00:00:00.000Z"
+  },
+  "visual": {
+    "icon": "https://storage.googleapis.com/voltask-assets/celestory.png",
+    "thumbnail": "https://storage.googleapis.com/voltask-assets/celestory.png",
+    "screenshots": [],
+    "logo": "https://storage.googleapis.com/voltask-assets/celestory.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "",
+    "repository": "https://github.com/celestory/celestory",
+    "issues": "https://github.com/celestory/celestory/issues",
+    "support": "https://github.com/celestory/celestory/issues"
+  },
+  "technical": {
+    "architectures": ["amd64", "arm64"],
+    "platform": "linux",
+    "main_service": "gateway",
+    "default_port": "1500",
+    "main_image": "celestory/gateway",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "ADMIN_USERNAME",
+        "default": "admin@celestory.io",
+        "description": "Main Admin Username",
+        "required": true
+      },
+      {
+        "name": "ADMIN_PASSWORD",
+        "default": "password_celestory",
+        "description": "Main Admin Password",
+        "required": true
+      },
+      {
+        "name": "VOLTASK_ADMIN_EMAIL",
+        "default": "admin@voltask.tech",
+        "description": "Voltask Admin Email",
+        "required": true
+      },
+      {
+        "name": "VOLTASK_ADMIN_PASSWORD",
+        "default": "password_voltask",
+        "description": "Voltask Admin Password",
+        "required": true
+      },
+      {
+        "name": "AUTH_AUTHORITY_SECRET",
+        "default": "a_long_random_string_123",
+        "description": "JWT Authority Secret",
+        "required": false
+      },
+      {
+        "name": "API_ORIGIN",
+        "default": "http://localhost:1500/celestory/api",
+        "description": "Full URL to the API service (e.g. http://yourdomain.com/celestory/api)",
+        "required": true
+      },
+      {
+        "name": "AUTH_REDIRECT_URI",
+        "default": "http://localhost:1500/celestory/callback",
+        "description": "Full URL for authentication callback (e.g. http://yourdomain.com/celestory/callback)",
+        "required": true
+      },
+      {
+        "name": "HUB_ORIGIN",
+        "default": "http://localhost:1500/hub",
+        "description": "Full URL to the Hub service (e.g. http://yourdomain.com/hub)",
+        "required": true
+      },
+      {
+        "name": "VOLTASK_WEBHOOK_URL",
+        "default": "http://localhost:1500/voltask",
+        "description": "Full URL for Voltask webhooks (e.g. http://yourdomain.com/voltask)",
+        "required": true
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/app/projectFiles",
+        "description": "Project files storage"
+      },
+      {
+        "container": "/app/uploads",
+        "description": "Voltask uploads storage"
+      },
+      {
+        "container": "/var/lib/postgresql/data",
+        "description": "PostgreSQL data"
+      }
+    ],
+    "ports": [
+      {
+        "container": "80",
+        "host": "1500",
+        "protocol": "tcp",
+        "description": "Gateway"
+      },
+      {
+        "container": "1401",
+        "host": "1401",
+        "protocol": "tcp",
+        "description": "Voltask service"
+      },
+      {
+        "container": "1402",
+        "host": "1402",
+        "protocol": "tcp",
+        "description": "Hub service"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "1500",
+      "volume_mappings": {
+        "celestory_project_files": "/DATA/AppData/$AppID/projectFiles",
+        "celestory_voltask_uploads": "/DATA/AppData/$AppID/uploads",
+        "celestory_db": "/DATA/AppData/$AppID/db"
+      },
+      "port": "1500"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": ["BigBearCasaOS", "selfhosted"],
+      "administrator_only": false,
+      "port": "1500"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": ["amd64", "arm64"],
+      "volume_mappings": {
+        "celestory_project_files": "projectFiles",
+        "celestory_voltask_uploads": "uploads",
+        "celestory_db": "db"
+      },
+      "port": "1500"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "1500"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "1500"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "celestory_project_files": "projectFiles",
+        "celestory_voltask_uploads": "uploads",
+        "celestory_db": "db"
+      },
+      "port": "1500"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "container",
+    "development",
+    "storytelling",
+    "automation"
+  ]
+}

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -126,9 +126,9 @@
       "supported": true,
       "port_map": "1500",
       "volume_mappings": {
-        "celestory_project_files": "/DATA/AppData/$AppID/projectFiles",
-        "celestory_voltask_uploads": "/DATA/AppData/$AppID/uploads",
-        "celestory_db": "/DATA/AppData/$AppID/db"
+        "project_files": "/DATA/AppData/$AppID/projectFiles",
+        "voltask_uploads": "/DATA/AppData/$AppID/uploads",
+        "postgres_data": "/DATA/AppData/$AppID/db"
       },
       "port": "1500"
     },
@@ -144,9 +144,9 @@
       "tipi_version": 1,
       "supported_architectures": ["amd64", "arm64"],
       "volume_mappings": {
-        "celestory_project_files": "projectFiles",
-        "celestory_voltask_uploads": "uploads",
-        "celestory_db": "db"
+        "project_files": "projectFiles",
+        "voltask_uploads": "uploads",
+        "postgres_data": "db"
       },
       "port": "1500"
     },
@@ -165,9 +165,9 @@
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "celestory_project_files": "projectFiles",
-        "celestory_voltask_uploads": "uploads",
-        "celestory_db": "db"
+        "project_files": "projectFiles",
+        "voltask_uploads": "uploads",
+        "postgres_data": "db"
       },
       "port": "1500"
     }

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -46,7 +46,7 @@
       },
       {
         "name": "ADMIN_PASSWORD",
-        "default": "password_celestory",
+        "default": "",
         "description": "Main Admin Password",
         "required": true
       },
@@ -58,15 +58,15 @@
       },
       {
         "name": "VOLTASK_ADMIN_PASSWORD",
-        "default": "password_voltask",
+        "default": "",
         "description": "Voltask Admin Password",
         "required": true
       },
       {
         "name": "AUTH_AUTHORITY_SECRET",
-        "default": "a_long_random_string_123",
+        "default": "",
         "description": "JWT Authority Secret",
-        "required": false
+        "required": true
       },
       {
         "name": "API_ORIGIN",
@@ -113,18 +113,6 @@
         "host": "1500",
         "protocol": "tcp",
         "description": "Gateway"
-      },
-      {
-        "container": "1401",
-        "host": "1401",
-        "protocol": "tcp",
-        "description": "Voltask service"
-      },
-      {
-        "container": "1402",
-        "host": "1402",
-        "protocol": "tcp",
-        "description": "Hub service"
       }
     ]
   },

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -144,9 +144,9 @@
       "tipi_version": 1,
       "supported_architectures": ["amd64", "arm64"],
       "volume_mappings": {
-        "celestory_project_files": "projectFiles",
-        "celestory_voltask_uploads": "uploads",
-        "celestory_postgres_data": "db"
+        "celestory-project-files": "projectFiles",
+        "celestory-voltask-uploads": "uploads",
+        "celestory-postgres-data": "db"
       },
       "port": "1500"
     },
@@ -165,9 +165,9 @@
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "celestory_project_files": "projectFiles",
-        "celestory_voltask_uploads": "uploads",
-        "celestory_postgres_data": "db"
+        "celestory-project-files": "projectFiles",
+        "celestory-voltask-uploads": "uploads",
+        "celestory-postgres-data": "db"
       },
       "port": "1500"
     }

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -269,11 +269,11 @@ services:
 
 volumes:
   postgres_data:
-    name: celestory-postgres-data
+    name: postgres-data
     driver: local
   project_files:
-    name: celestory-project-files
+    name: project-files
     driver: local
   voltask_uploads:
-    name: celestory-voltask-uploads
+    name: voltask-uploads
     driver: local

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -1,0 +1,277 @@
+name: celestory-voltask
+
+services:
+
+  gateway:
+    image: celestory/gateway:1.1.2
+    container_name: celestory-gateway
+    ports:
+      - "1500:80"
+    environment:
+      SERVER_NAME: localhost
+      FRONTEND_HOST: frontend
+      FRONTEND_PORT: 80
+      VOLTASK_HOST: voltask
+      VOLTASK_PORT: 1401
+      HUB_HOST: hub
+      HUB_PORT: 1402
+    depends_on:
+      frontend:
+        condition: service_healthy
+      voltask:
+        condition: service_healthy
+      hub:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+      auth:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  frontend:
+    image: celestory/frontend:1.1.1
+    container_name: celestory-frontend
+    environment:
+      CLOUD_API_URL: http://api
+      ACCOUNT_API_URL: http://auth
+      AUTH_CLIENT_ID: self_hosted_client
+      AUTH_CLIENT_SECRET: self_hosted_secret
+      AUTH_AUDIENCE: self_hosted
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  hub:
+    image: celestory/hub:1.1.0
+    container_name: celestory-hub
+    environment:
+      AUTH_ORIGIN: http://auth
+      AUTH_CLIENT_ID: celestory_client
+      AUTH_CLIENT_SECRET: client_secret_xyz
+      AUTH_AUDIENCE: self_hosted
+      AUTH_AUTHORITY_SECRET: a_long_random_string_123
+      AUTH_JWKS_URI: http://auth/.well-known/jwks.json
+      DB_VOLTASK_URL: postgres://celestory_admin:celestory_postgres_password_@db/voltask
+      DB_HUB_URL: postgres://celestory_admin:celestory_postgres_password_@db/hub
+      ADMIN_USERNAME: admin@celestory.io
+      ADMIN_PASSWORD: password_celestory
+      PORT: 1402
+      ORIGIN: http://192.168.0.1/hub
+    depends_on:
+      db:
+        condition: service_healthy
+      auth:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:1402/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  api:
+    image: celestory/api:1.1.2
+    container_name: celestory-api
+    volumes:
+      - project_files:/app/projectFiles
+    environment:
+      PORT: 80
+      SELF_HOSTED: "true"
+      STORAGE_SOLUTION: filesystem
+      AUTH_DOMAIN: http://auth
+      DB_URL: postgres://celestory_admin:celestory_postgres_password_@db/celestory
+      AUTH_JWKS_URI: http://auth/.well-known/jwks.json
+      AUTH_CLIENT_ID: self_hosted_client
+      AUTH_CLIENT_SECRET: self_hosted_secret
+      AUTH_AUDIENCE: self_hosted
+      GENERATOR_URL: http://generator
+      ORIGIN: http://192.168.0.1/celestory/api
+    depends_on:
+      db:
+        condition: service_healthy
+      auth:
+        condition: service_healthy
+      hub:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  generator:
+    image: celestory/generator:1.1.2
+    container_name: celestory-generator
+    volumes:
+      - project_files:/usr/src/app/projectFiles
+    environment:
+      PORT: 80
+      PROJECT_FILES_PATH: /usr/src/app/projectFiles
+      STORAGE_SOLUTION: filesystem
+      PROJECT_FILES_PREFIX: /celestory/api/filesystem/
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  auth:
+    image: celestory/auth:1.1.0
+    container_name: celestory-auth
+    environment:
+      PORT: 80
+      DB_HOST: db
+      DB_DATABASE: auth
+      DB_USERNAME: celestory_admin
+      DB_PASSWORD: celestory_postgres_password_
+      API_AUTHORITY_SECRET: a_long_random_string_123
+      API_OAUTH_ISSUER: celestory_auth
+      SELF_HOSTED_REDIRECT_URI: http://192.168.0.1/celestory/callback
+      GENERATE_KEYS: true
+      API_ACCESS_TOKEN_TTL: 604800
+      API_REFRESH_TOKEN_TTL: 1209600
+      USE_SELF_HOSTED_CLIENT: true
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  voltask:
+    image: celestory/voltask:1.0.8
+    container_name: voltask
+    environment:
+      PORT:  1401
+      DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/voltask?schema=voltask
+      ORCHESTRATOR_URL: http://orchestrator:3003
+      VOLTASK_URL: http://voltask:1401
+      WEBHOOK_URL: http://192.168.0.1/voltask
+      CELESTORY_AUTH_URL: http://auth
+      CELESTORY_AUTH_CLIENT_ID: self_hosted_client
+      CELESTORY_AUTH_CLIENT_SECRET: self_hosted_secret
+      LICENSE_API_URL: http://hub:1402/hub
+      PLUGINS_BUN_URL: http://plugins-bun:8001
+      PLUGINS_DENO_URL: http://plugins-deno:8002
+      PREMISE: on-premise
+      PREMISE_USER_EMAIL: admin@voltask.tech
+      PREMISE_USER_PASSWORD: password_voltask
+      STORAGE_DIR: /app/uploads
+    volumes:
+      - voltask_uploads:/app/uploads
+    depends_on:
+      hub:
+        condition: service_healthy
+      plugins-bun:
+        condition: service_healthy
+      plugins-deno:
+        condition: service_healthy
+      orchestrator:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:1401/voltask')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  plugins-bun:
+    image: celestory/voltask-plugins-bun:1.0.8
+    container_name: plugins-bun
+    restart: unless-stopped
+    environment:
+      PORT: 8001
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "30m"
+        max-file: "1"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/imap"]
+      retries: 3
+      timeout: 60s
+      interval: 10s
+      start_period: 10s
+      start_interval: 10s
+
+  plugins-deno:
+    image: celestory/voltask-plugins-deno:1.0.8
+    container_name: plugins-deno
+    restart: unless-stopped
+    environment:
+      PORT: 8002
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "30m"
+        max-file: "1"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/deno"]
+      retries: 3
+      timeout: 60s
+      interval: 10s
+      start_period: 10s
+      start_interval: 10s
+
+  orchestrator:
+    image: celestory/voltask-orchestrator:1.0.8
+    container_name: orchestrator
+    environment:
+      PORT: 3003
+      DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/orchestrator?sslmode=disable
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3003/statements"]
+      retries: 3
+      timeout: 60s
+      interval: 10s
+      start_period: 10s
+      start_interval: 10s
+    restart: unless-stopped
+
+  db:
+    image: celestory/postgres:latest
+    container_name: celestory-db
+    environment:
+      POSTGRES_USER: celestory_admin
+      POSTGRES_PASSWORD: celestory_postgres_password_
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U celestory_admin"]
+      interval: 10s
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+    name: celestory-postgres-data
+    driver: local
+  project_files:
+    name: celestory-project-files
+    driver: local
+  voltask_uploads:
+    name: celestory-voltask-uploads
+    driver: local

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -26,6 +26,8 @@ services:
         condition: service_healthy
       auth:
         condition: service_healthy
+      generator:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/"]
       interval: 10s

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -159,7 +159,7 @@ services:
 
   voltask:
     image: celestory/voltask:1.0.8
-    container_name: voltask
+    container_name: celestory-voltask
     environment:
       PORT:  1401
       DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/voltask?schema=voltask
@@ -198,7 +198,7 @@ services:
 
   plugins-bun:
     image: celestory/voltask-plugins-bun:1.0.8
-    container_name: plugins-bun
+    container_name: celestory-plugins-bun
     restart: unless-stopped
     environment:
       PORT: 8001
@@ -217,7 +217,7 @@ services:
 
   plugins-deno:
     image: celestory/voltask-plugins-deno:1.0.8
-    container_name: plugins-deno
+    container_name: celestory-plugins-deno
     restart: unless-stopped
     environment:
       PORT: 8002
@@ -236,7 +236,7 @@ services:
 
   orchestrator:
     image: celestory/voltask-orchestrator:1.0.8
-    container_name: orchestrator
+    container_name: celestory-orchestrator
     environment:
       PORT: 3003
       DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/orchestrator?sslmode=disable

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -118,9 +118,9 @@ services:
       - celestory-project-files:/usr/src/app/projectFiles
     environment:
       PORT: 80
-      celestory-project-files_PATH: /usr/src/app/projectFiles
+      PROJECT_FILES_PATH: /usr/src/app/projectFiles
       STORAGE_SOLUTION: filesystem
-      celestory-project-files_PREFIX: /celestory/api/filesystem/
+      PROJECT_FILES_PREFIX: /celestory/api/filesystem/
     depends_on:
       api:
         condition: service_healthy

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generator:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      test: [ "CMD", "curl", "-f", "http://localhost:80/" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -48,7 +48,7 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      test: [ "CMD", "curl", "-f", "http://localhost:80/" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -74,7 +74,7 @@ services:
       auth:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:1402/')"]
+      test: [ "CMD", "node", "-e", "require('http').get('http://127.0.0.1:1402/')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -105,7 +105,7 @@ services:
       hub:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      test: [ "CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -125,7 +125,7 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      test: [ "CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -151,7 +151,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')"]
+      test: [ "CMD", "node", "-e", "require('http').get('http://127.0.0.1:80/')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -161,7 +161,7 @@ services:
     image: celestory/voltask:1.0.8
     container_name: celestory-voltask
     environment:
-      PORT:  1401
+      PORT: 1401
       DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/voltask?schema=voltask
       ORCHESTRATOR_URL: http://orchestrator:3003
       VOLTASK_URL: http://voltask:1401
@@ -190,7 +190,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:1401/voltask')"]
+      test: [ "CMD", "node", "-e", "require('http').get('http://127.0.0.1:1401/voltask')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -208,7 +208,7 @@ services:
         max-size: "30m"
         max-file: "1"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/imap"]
+      test: [ "CMD", "curl", "-f", "http://localhost:8001/imap" ]
       retries: 3
       timeout: 60s
       interval: 10s
@@ -227,7 +227,7 @@ services:
         max-size: "30m"
         max-file: "1"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8002/deno"]
+      test: [ "CMD", "curl", "-f", "http://localhost:8002/deno" ]
       retries: 3
       timeout: 60s
       interval: 10s
@@ -244,7 +244,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3003/statements"]
+      test: [ "CMD", "curl", "-f", "http://localhost:3003/statements" ]
       retries: 3
       timeout: 60s
       interval: 10s
@@ -253,7 +253,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: celestory/postgres:main
+    image: celestory/postgres:1.0.0
     container_name: celestory-db
     environment:
       POSTGRES_USER: celestory_admin
@@ -261,7 +261,7 @@ services:
     volumes:
       - celestory-postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U celestory_admin"]
+      test: [ "CMD-SHELL", "pg_isready -U celestory_admin" ]
       interval: 10s
       timeout: 60s
       retries: 3

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -57,17 +57,15 @@ services:
     container_name: celestory-hub
     environment:
       AUTH_ORIGIN: http://auth
-      AUTH_CLIENT_ID: celestory_client
-      AUTH_CLIENT_SECRET: client_secret_xyz
       AUTH_AUDIENCE: self_hosted
-      AUTH_AUTHORITY_SECRET: a_long_random_string_123
+      AUTH_AUTHORITY_SECRET: ${AUTH_AUTHORITY_SECRET}
       AUTH_JWKS_URI: http://auth/.well-known/jwks.json
       DB_VOLTASK_URL: postgres://celestory_admin:celestory_postgres_password_@db/voltask
       DB_HUB_URL: postgres://celestory_admin:celestory_postgres_password_@db/hub
-      ADMIN_USERNAME: admin@celestory.io
-      ADMIN_PASSWORD: password_celestory
+      ADMIN_USERNAME: ${ADMIN_USERNAME}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       PORT: 1402
-      ORIGIN: http://192.168.0.1/hub
+      ORIGIN: ${HUB_ORIGIN}
     depends_on:
       db:
         condition: service_healthy
@@ -96,7 +94,7 @@ services:
       AUTH_CLIENT_SECRET: self_hosted_secret
       AUTH_AUDIENCE: self_hosted
       GENERATOR_URL: http://generator
-      ORIGIN: http://192.168.0.1/celestory/api
+      ORIGIN: ${API_ORIGIN}
     depends_on:
       db:
         condition: service_healthy
@@ -140,9 +138,9 @@ services:
       DB_DATABASE: auth
       DB_USERNAME: celestory_admin
       DB_PASSWORD: celestory_postgres_password_
-      API_AUTHORITY_SECRET: a_long_random_string_123
+      API_AUTHORITY_SECRET: ${AUTH_AUTHORITY_SECRET}
       API_OAUTH_ISSUER: celestory_auth
-      SELF_HOSTED_REDIRECT_URI: http://192.168.0.1/celestory/callback
+      SELF_HOSTED_REDIRECT_URI: ${AUTH_REDIRECT_URI}
       GENERATE_KEYS: true
       API_ACCESS_TOKEN_TTL: 604800
       API_REFRESH_TOKEN_TTL: 1209600
@@ -165,7 +163,7 @@ services:
       DATABASE_URL: postgresql://celestory_admin:celestory_postgres_password_@db:5432/voltask?schema=voltask
       ORCHESTRATOR_URL: http://orchestrator:3003
       VOLTASK_URL: http://voltask:1401
-      WEBHOOK_URL: http://192.168.0.1/voltask
+      WEBHOOK_URL: ${VOLTASK_WEBHOOK_URL}
       CELESTORY_AUTH_URL: http://auth
       CELESTORY_AUTH_CLIENT_ID: self_hosted_client
       CELESTORY_AUTH_CLIENT_SECRET: self_hosted_secret
@@ -173,8 +171,8 @@ services:
       PLUGINS_BUN_URL: http://plugins-bun:8001
       PLUGINS_DENO_URL: http://plugins-deno:8002
       PREMISE: on-premise
-      PREMISE_USER_EMAIL: admin@voltask.tech
-      PREMISE_USER_PASSWORD: password_voltask
+      PREMISE_USER_EMAIL: ${VOLTASK_ADMIN_EMAIL}
+      PREMISE_USER_PASSWORD: ${VOLTASK_ADMIN_PASSWORD}
       STORAGE_DIR: /app/uploads
     volumes:
       - voltask_uploads:/app/uploads
@@ -253,7 +251,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: celestory/postgres:latest
+    image: celestory/postgres:main
     container_name: celestory-db
     environment:
       POSTGRES_USER: celestory_admin
@@ -263,6 +261,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U celestory_admin"]
       interval: 10s
+      timeout: 60s
+      retries: 3
     restart: unless-stopped
 
 volumes:

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     image: celestory/api:1.1.2
     container_name: celestory-api
     volumes:
-      - project_files:/app/projectFiles
+      - celestory-project-files:/app/projectFiles
     environment:
       PORT: 80
       SELF_HOSTED: "true"
@@ -115,12 +115,12 @@ services:
     image: celestory/generator:1.1.2
     container_name: celestory-generator
     volumes:
-      - project_files:/usr/src/app/projectFiles
+      - celestory-project-files:/usr/src/app/projectFiles
     environment:
       PORT: 80
-      PROJECT_FILES_PATH: /usr/src/app/projectFiles
+      celestory-project-files_PATH: /usr/src/app/projectFiles
       STORAGE_SOLUTION: filesystem
-      PROJECT_FILES_PREFIX: /celestory/api/filesystem/
+      celestory-project-files_PREFIX: /celestory/api/filesystem/
     depends_on:
       api:
         condition: service_healthy
@@ -177,7 +177,7 @@ services:
       PREMISE_USER_PASSWORD: ${VOLTASK_ADMIN_PASSWORD}
       STORAGE_DIR: /app/uploads
     volumes:
-      - voltask_uploads:/app/uploads
+      - celestory-voltask-uploads:/app/uploads
     depends_on:
       hub:
         condition: service_healthy
@@ -259,7 +259,7 @@ services:
       POSTGRES_USER: celestory_admin
       POSTGRES_PASSWORD: celestory_postgres_password_
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - celestory-postgres-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U celestory_admin"]
       interval: 10s
@@ -268,12 +268,12 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres_data:
-    name: postgres-data
+  celestory-postgres-data:
+    name: celestory-postgres-data
     driver: local
-  project_files:
-    name: project-files
+  celestory-project-files:
+    name: celestory-project-files
     driver: local
-  voltask_uploads:
-    name: voltask-uploads
+  celestory-voltask-uploads:
+    name: celestory-voltask-uploads
     driver: local


### PR DESCRIPTION
This pull request introduces configuration files for integrating the Celestory & Voltask application into the project. The changes provide metadata, deployment details, and compatibility information for Celestory, as well as a comprehensive Docker Compose setup to enable easy local deployment across various platforms.

**Application metadata and configuration:**

- Added apps/celestory/app.json to define Celestory's metadata, technical specifications, visual assets, resource links, deployment options, UI configuration, and cross-platform compatibility (CasaOS, Portainer, Runtipi, etc.).

**Deployment setup:**

- Added apps/celestory/docker-compose.yml with a multi-service definition for running the complete Celestory suite (Gateway, Frontend, Hub, API, Auth, Voltask, and database) using specific version tags and optimized service health checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `apps/celestory/app.json` and `apps/celestory/docker-compose.yml` to add the Celestory & Voltask self-hosted suite to the repo. The compose file orchestrates a 10-service stack (gateway, frontend, hub, api, generator, auth, voltask, plugins-bun, plugins-deno, orchestrator, and a custom Postgres image) with explicit version pins, namespaced container names, and a `service_healthy`-based startup dependency chain.

- **`app.json`** declares 9 user-configurable env vars (admin credentials, JWT secret, and origin URLs), three named volumes whose keys now correctly match the compose file, and exposes only port 1500 through the gateway.
- **`docker-compose.yml`** correctly propagates all configurable env vars via `${VAR}` interpolation, pins all 10 images to explicit versions, consistently prefixes all container names with `celestory-`, and names volumes with the `celestory-` namespace to avoid host-level collisions.

<h3>Confidence Score: 3/5</h3>

Not ready to merge — the compose file still contains hardcoded database credentials and an OAuth client secret shared across six services with no supported rotation path for deployers.

The PR has made meaningful progress: env vars are now properly interpolated, all images are pinned, container names and volume names are consistently namespaced, and the startup dependency chain is correct. However, the Postgres password appears verbatim in seven places and the OAuth client secret is hardcoded in frontend, api, and voltask — neither credential appears in app.json, so every deployment worldwide shares the same publicly visible secrets with no supported way to rotate them without manually editing the compose file.

apps/celestory/docker-compose.yml — specifically the hardcoded DB password and OAuth client secret that appear across multiple services

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/celestory/app.json | Metadata and deployment configuration for the Celestory & Voltask suite; correctly declares 9 user-configurable env vars and maps three named volumes that now match the compose file keys; only port 1500 is advertised externally, consistent with the compose file. |
| apps/celestory/docker-compose.yml | 10-service compose stack; all images pinned, container names consistently prefixed with celestory-, volumes namespaced; hardcoded database password and OAuth client secret still appear across six services with no corresponding configurable env var in app.json. |

</details>

</details>

<sub>Reviews (8): Last reviewed commit: ["chore: update volume mapping keys to use..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/89f54d2f6ee4019204ef954036f7c8a1d70906f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32457186)</sub>

<!-- /greptile_comment -->