### PR TITLE
fix(playit-docker-web): update docker tag to 1.0.4

### DIFF
--- a/apps/playit-docker-web/app.json
+++ b/apps/playit-docker-web/app.json
@@ -5,7 +5,7 @@
     "name": "Playit Docker Web",
     "description": "Playit.gg is a global proxy that allows anyone to host a server without port forwarding. We use tunneling. Only the server needs to run the program, not every player!",
     "tagline": "Playit.gg is a global proxy that allows anyone to host a server without port forwarding.",
-    "version": "1.2",
+    "version": "1.0.4",
     "author": "BigBearTechWorld",
     "developer": "wisdomsky",
     "category": "BigBearCasaOS",
@@ -13,7 +13,7 @@
     "homepage": "https://hub.docker.com/r/wisdomsky/playit-docker-web",
     "source": "big-bear-universal",
     "created": "2025-10-27T02:42:13Z",
-    "updated": "2026-02-11T20:10:41.756Z"
+    "updated": "2026-05-29T00:00:00.000Z"
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/playit-docker-web/logo.png",

--- a/apps/playit-docker-web/docker-compose.yml
+++ b/apps/playit-docker-web/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-playit-docker-web
     # Image to be used for the container
-    image: wisdomsky/playit-docker-web:1.2
+    image: wisdomsky/playit-docker-web:1.0.4
     # Container restart policy
     restart: unless-stopped
     # Network mode


### PR DESCRIPTION
`wisdomsky/playit-docker-web:1.2` is broken. Bumps image tag to `1.0.4` (verified on Docker Hub).

Closes #2162

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the broken `wisdomsky/playit-docker-web:1.2` Docker image tag with `1.0.4`, which is confirmed to exist on Docker Hub. Both the compose file and the `app.json` metadata are updated consistently.

- `docker-compose.yml` image tag changed from `:1.2` → `:1.0.4`; the `1.0.4` tag is present on Docker Hub and was verified by the contributor.
- `app.json` `version` and `updated` fields are updated to match the new tag and today's date, keeping the metadata in sync.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two-line change that pins both the compose image and app.json metadata to a confirmed-working Docker Hub tag.

The change is minimal and consistent: the image tag in docker-compose.yml and the version/updated fields in app.json all point to the same value (1.0.4), and Docker Hub confirms the tag exists. The apparent version downgrade (1.2 → 1.0.4) reflects upstream non-sequential tagging, not a regression in this repo.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/playit-docker-web/app.json | Version field and updated timestamp updated from 1.2 / Feb 2026 to 1.0.4 / 2026-05-29; change is internally consistent and matches docker-compose.yml |
| apps/playit-docker-web/docker-compose.yml | Image tag bumped from wisdomsky/playit-docker-web:1.2 to wisdomsky/playit-docker-web:1.0.4; tag confirmed present on Docker Hub |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CasaOS/Portainer
    participant DockerHub
    participant Container

    User->>CasaOS/Portainer: Install playit-docker-web
    CasaOS/Portainer->>DockerHub: Pull wisdomsky/playit-docker-web:1.0.4
    DockerHub-->>CasaOS/Portainer: "Image (138.5 MB, linux/amd64|arm64)"
    CasaOS/Portainer->>Container: Start (network_mode: host, port 8008)
    Container-->>User: Web UI available at :8008
```

<sub>Reviews (1): Last reviewed commit: ["fix(playit-docker-web): update docker ta..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/ca4d33fdc55d3e57830a2dd763c029a2ea07840c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34599316)</sub>

<!-- /greptile_comment -->