### PR TITLE
docs: add Celestory & Voltask to CHANGELOG [2026.06.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [2026.06.2]
+
+### Added
+- `apps/celestory/` — Celestory & Voltask (10-service stack: gateway, frontend, hub, api, generator, auth, voltask, plugins-bun, plugins-deno, orchestrator + Postgres). Port 1500 via gateway.
+
 ## [2026.06.1]
 
 ### Added


### PR DESCRIPTION
Adds changelog entry for PR #2096 (Celestory & Voltask 10-service stack, port 1500).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `[2026.06.2]` CHANGELOG entry documenting the Celestory & Voltask 10-service stack introduced in PR #2096. The change is documentation-only and touches no application code.

- The new entry follows the established CalVer ordering (newest first) and matches the prose style of all surrounding entries.
- Service names, port, and app path (`apps/celestory/`) are clearly described, consistent with how other multi-service stacks are documented in the file.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no impact on application code or configuration.

The change adds a single CHANGELOG entry that is correctly ordered, properly formatted, and accurately describes the referenced application stack. There is nothing here that could affect runtime behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a new [2026.06.2] entry documenting the Celestory & Voltask 10-service stack; format, ordering, and content are consistent with existing entries. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CHANGELOG.md] --> B["[2026.06.2] — Added"]
    B --> C["apps/celestory/ — Celestory & Voltask"]
    C --> D["10-service stack"]
    D --> E[gateway]
    D --> F[frontend]
    D --> G[hub]
    D --> H[api]
    D --> I[generator]
    D --> J[auth]
    D --> K[voltask]
    D --> L[plugins-bun]
    D --> M[plugins-deno]
    D --> N[orchestrator]
    D --> O[Postgres]
    E --> P["Port 1500 (entry point)"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: add Celestory &amp; Voltask to CHANGEL..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/864c5fdf80b59dab6284f602d1e7e86c8416c4f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35974270)</sub>

<!-- /greptile_comment -->