### PR TITLE
Update documentation and docker images

### DIFF
--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "celestory",
     "name": "Celestory & Voltask",
-    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available.\n Purchase a license at https://celestory.io/pricing.\n Here is the installation guide: https://documentation.celestory.io/en/article/celestoryvoltask-self-host-11855bd/",
+    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available.\nPurchase a license at https://celestory.io/pricing.\nHere is the installation guide: https://documentation.celestory.io/en/article/celestoryvoltask-self-host-11855bd/",
     "tagline": "No-code interactive storytelling & automation",
     "version": "1.1.2",
     "author": "Celestory",

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -29,10 +29,7 @@
     "support": "https://github.com/celestory/celestory/issues"
   },
   "technical": {
-    "architectures": [
-      "amd64",
-      "arm64"
-    ],
+    "architectures": ["amd64", "arm64"],
     "platform": "linux",
     "main_service": "gateway",
     "default_port": "1500",
@@ -138,20 +135,14 @@
     "portainer": {
       "supported": true,
       "template_type": 2,
-      "categories": [
-        "BigBearCasaOS",
-        "selfhosted"
-      ],
+      "categories": ["BigBearCasaOS", "selfhosted"],
       "administrator_only": false,
       "port": "1500"
     },
     "runtipi": {
       "supported": true,
       "tipi_version": 1,
-      "supported_architectures": [
-        "amd64",
-        "arm64"
-      ],
+      "supported_architectures": ["amd64", "arm64"],
       "volume_mappings": {
         "celestory-project-files": "projectFiles",
         "celestory-voltask-uploads": "uploads",

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "celestory",
     "name": "Celestory & Voltask",
-    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available. Purchase a license at https://celestory.io/pricing",
+    "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available.\n Purchase a license at https://celestory.io/pricing.\n Here is the installation guide: https://documentation.celestory.io/en/article/celestoryvoltask-self-host-11855bd/",
     "tagline": "No-code interactive storytelling & automation",
     "version": "1.1.2",
     "author": "Celestory",
@@ -23,7 +23,7 @@
   },
   "resources": {
     "youtube": "",
-    "documentation": "",
+    "documentation": "https://documentation.celestory.io/en/",
     "repository": "https://github.com/celestory/celestory",
     "issues": "https://github.com/celestory/celestory/issues",
     "support": "https://github.com/celestory/celestory/issues"

--- a/apps/celestory/app.json
+++ b/apps/celestory/app.json
@@ -5,7 +5,7 @@
     "name": "Celestory & Voltask",
     "description": "The all-in-one no-code platform for interactive storytelling and Voltask automation engine. Paid license required, no free tier available.\nPurchase a license at https://celestory.io/pricing.\nHere is the installation guide: https://documentation.celestory.io/en/article/celestoryvoltask-self-host-11855bd/",
     "tagline": "No-code interactive storytelling & automation",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "author": "Celestory",
     "developer": "celestory",
     "category": "Development",

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -118,9 +118,9 @@ services:
       - celestory-project-files:/usr/src/app/projectFiles
     environment:
       PORT: 80
-      celestory-project-files_PATH: /usr/src/app/projectFiles
+      PROJECT_FILES_PATH: /usr/src/app/projectFiles
       STORAGE_SOLUTION: filesystem
-      celestory-project-files_PREFIX: /celestory/api/filesystem/
+      PROJECT_FILES_PREFIX: /celestory/api/filesystem/
     depends_on:
       api:
         condition: service_healthy

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: celestory/frontend:1.1.2
+    image: celestory/frontend:1.1.3
     container_name: celestory-frontend
     environment:
       CLOUD_API_URL: http://api

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -118,9 +118,9 @@ services:
       - celestory-project-files:/usr/src/app/projectFiles
     environment:
       PORT: 80
-      PROJECT_FILES_PATH: /usr/src/app/projectFiles
+      celestory-project-files_PATH: /usr/src/app/projectFiles
       STORAGE_SOLUTION: filesystem
-      PROJECT_FILES_PREFIX: /celestory/api/filesystem/
+      celestory-project-files_PREFIX: /celestory/api/filesystem/
     depends_on:
       api:
         condition: service_healthy

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: celestory/frontend:1.1.1
+    image: celestory/frontend:1.1.2
     container_name: celestory-frontend
     environment:
       CLOUD_API_URL: http://api
@@ -81,7 +81,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: celestory/api:1.1.2
+    image: celestory/api:1.1.3
     container_name: celestory-api
     volumes:
       - celestory-project-files:/app/projectFiles
@@ -132,7 +132,7 @@ services:
     restart: unless-stopped
 
   auth:
-    image: celestory/auth:1.1.0
+    image: celestory/auth:1.1.1
     container_name: celestory-auth
     environment:
       PORT: 80


### PR DESCRIPTION
Added a link to the documentation of Celestory and updated images for the following services:

- Celestory Frontend
- Celestory API
- Authentication

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps three Celestory service images (`frontend` 1.1.1→1.1.3, `api` 1.1.2→1.1.3, `auth` 1.1.0→1.1.1), adds the official documentation URL to `app.json`, and increments the manifest version to `1.1.3`.

- `docker-compose.yml`: Three service image tags updated; remaining services (`gateway`, `generator`, `hub`, `voltask`, etc.) intentionally left at their current versions per the PR description.
- `app.json`: Documentation field populated, installation guide link embedded in the description, version bumped to `1.1.3`, and several multi-line arrays reformatted to single-line style.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward image version bump for three services plus documentation metadata updates.

All three updated image tags follow the existing versioning pattern used across this compose file, the manifest version was correctly incremented, and no configuration logic or environment variables were altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/celestory/docker-compose.yml | Three service image versions bumped (frontend, api, auth); all other services unchanged as expected. |
| apps/celestory/app.json | Documentation URL added, description updated with installation guide link, manifest version bumped to 1.1.3, array formatting made consistent. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant gateway as gateway:1.1.2
    participant frontend as frontend:1.1.3 (updated)
    participant api as api:1.1.3 (updated)
    participant auth as auth:1.1.1 (updated)
    participant hub as hub:1.1.0
    participant db as postgres:1.0.0

    Client->>gateway: HTTP request :1500
    gateway->>frontend: proxy /
    gateway->>api: proxy /celestory/api
    gateway->>hub: proxy /hub

    frontend->>api: CLOUD_API_URL
    frontend->>auth: ACCOUNT_API_URL

    api->>auth: validate JWT (JWKS)
    api->>db: DB_URL (celestory)
    api->>hub: depends_on

    auth->>db: DB_HOST (auth schema)

    hub->>db: DB_VOLTASK_URL / DB_HUB_URL
```

<sub>Reviews (4): Last reviewed commit: ["chore: update frontend image version to ..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/027aa79d9d8fd6547881366d0e0e31d072458065) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37302873)</sub>

<!-- /greptile_comment -->