### PR TITLE
feat: add Fireshare app

### DIFF
--- a/apps/fireshare/app.json
+++ b/apps/fireshare/app.json
@@ -1,0 +1,202 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "fireshare",
+    "name": "Fireshare",
+    "description": "Fireshare lets you host your own video and image content and share it with others via public or private links — no third-party services required. Drop videos into a watched folder and Fireshare automatically scans, generates thumbnails, and organizes them into a clean, searchable library with folder support. Great for game clips, screen recordings, screenshots, and home videos. Features include public/private share links, an admin login, automatic video scanning, OpenGraph link previews, and optional GPU transcoding.",
+    "tagline": "Store and share your video game clips and screenshots",
+    "version": "1.7.1",
+    "author": "BigBearCommunity",
+    "developer": "Shane Israel",
+    "category": "Media",
+    "license": "MIT",
+    "homepage": "https://github.com/ShaneIsrael/fireshare",
+    "source": "big-bear-universal",
+    "created": "2026-06-18T00:00:00Z",
+    "updated": "2026-06-18T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/fireshare.png",
+    "thumbnail": "",
+    "screenshots": [
+      "https://raw.githubusercontent.com/ShaneIsrael/fireshare/master/.github/images/card-view.png",
+      "https://raw.githubusercontent.com/ShaneIsrael/fireshare/master/.github/images/folders.png",
+      "https://raw.githubusercontent.com/ShaneIsrael/fireshare/master/.github/images/folders-game.png",
+      "https://raw.githubusercontent.com/ShaneIsrael/fireshare/master/.github/images/edit-details.png",
+      "https://raw.githubusercontent.com/ShaneIsrael/fireshare/master/.github/images/uploading.png"
+    ],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/fireshare.png"
+  },
+  "resources": {
+    "documentation": "https://github.com/ShaneIsrael/fireshare#readme",
+    "repository": "https://github.com/ShaneIsrael/fireshare",
+    "issues": "https://github.com/ShaneIsrael/fireshare/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": ["amd64", "arm64"],
+    "platform": "linux",
+    "main_service": "fireshare",
+    "default_port": "8585",
+    "main_image": "shaneisrael/fireshare",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "ADMIN_USERNAME",
+        "default": "admin",
+        "description": "Administrator account username",
+        "required": true
+      },
+      {
+        "name": "ADMIN_PASSWORD",
+        "default": "admin",
+        "description": "Administrator account password (change this!)",
+        "required": true
+      },
+      {
+        "name": "SECRET_KEY",
+        "default": "replace_this_with_some_random_string",
+        "description": "Random string used to secure sessions",
+        "required": true
+      },
+      {
+        "name": "DOMAIN",
+        "default": "",
+        "description": "Public domain for OpenGraph link previews (optional)",
+        "required": false
+      },
+      {
+        "name": "MINUTES_BETWEEN_VIDEO_SCANS",
+        "default": "5",
+        "description": "How often Fireshare scans for new videos",
+        "required": false
+      },
+      {
+        "name": "PUID",
+        "default": "1000",
+        "description": "User ID for file ownership",
+        "required": false
+      },
+      {
+        "name": "PGID",
+        "default": "1000",
+        "description": "Group ID for file ownership",
+        "required": false
+      },
+      {
+        "name": "ENABLE_TRANSCODING",
+        "default": "false",
+        "description": "Enable video transcoding",
+        "required": false
+      },
+      {
+        "name": "TRANSCODE_GPU",
+        "default": "false",
+        "description": "Use NVIDIA GPU for transcoding (requires ENABLE_TRANSCODING)",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Internal database and config"
+      },
+      {
+        "container": "/processed",
+        "description": "Generated metadata, posters and thumbnails"
+      },
+      {
+        "container": "/videos",
+        "description": "Source video directory"
+      },
+      {
+        "container": "/images",
+        "description": "Source image directory"
+      }
+    ],
+    "ports": [
+      {
+        "container": "80",
+        "host": "8585",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "/",
+    "tips": {
+      "before_install": {
+        "en_us": "• Change your login credentials in the container settings using **ADMIN_USERNAME** and **ADMIN_PASSWORD**.\n\n• Set a **SECRET_KEY** if you plan to expose Fireshare publicly.\n\n• Transcoding is disabled by default. To enable it, set **ENABLE_TRANSCODING=true** (and **TRANSCODE_GPU=true** if you have an NVIDIA GPU)."
+      },
+      "after_install": {
+        "en_us": "Access the web UI at http://your-server:8585 and log in with your admin credentials. Drop videos into the /videos volume to have them scanned automatically."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8585",
+      "port": "8585",
+      "volume_mappings": {
+        "fireshare_data": "/DATA/AppData/$AppID/data",
+        "fireshare_processed": "/DATA/AppData/$AppID/processed",
+        "fireshare_videos": "/DATA/AppData/$AppID/videos",
+        "fireshare_images": "/DATA/AppData/$AppID/images"
+      }
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": ["Media", "selfhosted"],
+      "administrator_only": false,
+      "port": "8585"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": ["amd64", "arm64"],
+      "port": "8585",
+      "volume_mappings": {
+        "fireshare_data": "fireshare/data",
+        "fireshare_processed": "fireshare/processed",
+        "fireshare_videos": "fireshare/videos",
+        "fireshare_images": "fireshare/images"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8585"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8585"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "18585",
+      "volume_mappings": {
+        "fireshare_data": "fireshare/data",
+        "fireshare_processed": "fireshare/processed",
+        "fireshare_videos": "fireshare/videos",
+        "fireshare_images": "fireshare/images"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "media",
+    "video",
+    "sharing"
+  ]
+}

--- a/apps/fireshare/app.json
+++ b/apps/fireshare/app.json
@@ -68,6 +68,12 @@
         "required": false
       },
       {
+        "name": "THUMBNAIL_VIDEO_LOCATION",
+        "default": "10",
+        "description": "Percentage into each video to grab the thumbnail frame (e.g. 10 = 10% in)",
+        "required": false
+      },
+      {
         "name": "PUID",
         "default": "1000",
         "description": "User ID for file ownership",

--- a/apps/fireshare/app.json
+++ b/apps/fireshare/app.json
@@ -56,12 +56,6 @@
         "required": true
       },
       {
-        "name": "SECRET_KEY",
-        "default": "replace_this_with_some_random_string",
-        "description": "Random string used to secure sessions",
-        "required": true
-      },
-      {
         "name": "DOMAIN",
         "default": "",
         "description": "Public domain for OpenGraph link previews (optional)",
@@ -130,7 +124,7 @@
     "path": "/",
     "tips": {
       "before_install": {
-        "en_us": "• Change your login credentials in the container settings using **ADMIN_USERNAME** and **ADMIN_PASSWORD**.\n\n• Set a **SECRET_KEY** if you plan to expose Fireshare publicly.\n\n• Transcoding is disabled by default. To enable it, set **ENABLE_TRANSCODING=true** (and **TRANSCODE_GPU=true** if you have an NVIDIA GPU)."
+        "en_us": "• Change your login credentials in the container settings using **ADMIN_USERNAME** and **ADMIN_PASSWORD**.\n\n• Transcoding is disabled by default. To enable it, set **ENABLE_TRANSCODING=true** (and **TRANSCODE_GPU=true** if you have an NVIDIA GPU)."
       },
       "after_install": {
         "en_us": "Access the web UI at http://your-server:8585 and log in with your admin credentials. Drop videos into the /videos volume to have them scanned automatically."

--- a/apps/fireshare/docker-compose.yml
+++ b/apps/fireshare/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # random key (Python secrets.token_hex) when unset, so it is unique per
       # deployment. Set it explicitly only to persist sessions across restarts.
       - MINUTES_BETWEEN_VIDEO_SCANS=5
-      - THUMBNAIL_VIDEO_LOCATION=0
+      - THUMBNAIL_VIDEO_LOCATION=10
       - DOMAIN=
       - PUID=1000
       - PGID=1000

--- a/apps/fireshare/docker-compose.yml
+++ b/apps/fireshare/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     environment:
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=admin
-      - SECRET_KEY=replace_this_with_some_random_string
+      # SECRET_KEY intentionally omitted: Fireshare auto-generates a secure
+      # random key (Python secrets.token_hex) when unset, so it is unique per
+      # deployment. Set it explicitly only to persist sessions across restarts.
       - MINUTES_BETWEEN_VIDEO_SCANS=5
       - THUMBNAIL_VIDEO_LOCATION=0
       - DOMAIN=

--- a/apps/fireshare/docker-compose.yml
+++ b/apps/fireshare/docker-compose.yml
@@ -1,0 +1,45 @@
+name: fireshare
+
+services:
+  fireshare:
+    image: shaneisrael/fireshare:1.7.1
+    container_name: fireshare
+    ports:
+      - "8585:80"
+    volumes:
+      - fireshare_data:/data
+      - fireshare_processed:/processed
+      - fireshare_videos:/videos
+      - fireshare_images:/images
+    environment:
+      - ADMIN_USERNAME=admin
+      - ADMIN_PASSWORD=admin
+      - SECRET_KEY=replace_this_with_some_random_string
+      - MINUTES_BETWEEN_VIDEO_SCANS=5
+      - THUMBNAIL_VIDEO_LOCATION=0
+      - DOMAIN=
+      - PUID=1000
+      - PGID=1000
+      - ENABLE_TRANSCODING=false
+      - TRANSCODE_GPU=false
+    restart: unless-stopped
+    networks:
+      - fireshare-network
+
+networks:
+  fireshare-network:
+    driver: bridge
+
+volumes:
+  fireshare_data:
+    name: fireshare_data
+    driver: local
+  fireshare_processed:
+    name: fireshare_processed
+    driver: local
+  fireshare_videos:
+    name: fireshare_videos
+    driver: local
+  fireshare_images:
+    name: fireshare_images
+    driver: local


### PR DESCRIPTION
## Add Fireshare

Fireshare is a self-hosted video and image sharing app — great for storing and sharing video game clips and screenshots via public/private links.

- **Image:** `shaneisrael/fireshare:1.7.1` (pinned)
- **Category:** Media
- **Default port:** `8585` (chosen to avoid the common `8080` conflict)
- **Upstream:** https://github.com/ShaneIsrael/fireshare

### Testing
Test-installed and verified on **ZimaOS v1.6.1 (amd64)** via a private custom app source:
- Container starts, web UI loads, admin login works
- `PUID`/`PGID` honored
- Icon, tagline, screenshots, description, and `before_install` tips all render correctly in the store listing

### Files
- `apps/fireshare/app.json`
- `apps/fireshare/docker-compose.yml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Fireshare (v1.7.1), a self-hosted video and image sharing app, to the universal app store. The two previously-raised issues (static `SECRET_KEY` placeholder and the missing `THUMBNAIL_VIDEO_LOCATION` in `app.json`) have both been addressed — the key is now auto-generated per the upstream default, and the variable is now documented in the environment list.

- `docker-compose.yml` is well-structured: image is pinned, four named volumes are defined, env vars align with `app.json`, and the deliberate omission of `SECRET_KEY` is documented with an inline comment.
- `app.json` covers all exposed environment variables and provides `before_install` guidance, but does not surface `SECRET_KEY` for store UI users who want session persistence across restarts.
- The compose structure matches the universal-app example template (short service name, custom bridge network, no `big-bear-` prefix).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two blocking concerns from prior review rounds have been resolved, and the remaining observation is a minor usability improvement.

Both files are consistent with each other and with the universal-app template. No functional defects were found in the changed code. The only remaining gap (SECRET_KEY not exposed as an environment variable in the store UI) is a convenience issue, not a correctness or security bug — the container securely auto-generates its own key.

No files require special attention; both changed files are straightforward and consistent.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/fireshare/app.json | App metadata, environment variable definitions, volumes, ports, and compatibility mappings. All previously-flagged variables (THUMBNAIL_VIDEO_LOCATION) are now present; SECRET_KEY is intentionally omitted but not mentioned in tips, meaning store UI users can't configure session persistence. |
| apps/fireshare/docker-compose.yml | Single-service compose file. Image pinned to 1.7.1, four named volumes, restart policy set, and SECRET_KEY deliberately omitted with an explanatory comment. Env vars match app.json. Follows the universal-apps example template structure. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User["User / Browser"]
    subgraph Docker["Docker Host (port 8585)"]
        FS["fireshare container\nshaneisrael/fireshare:1.7.1\n(port 80)"]
        NET["fireshare-network\n(bridge)"]
        V1["fireshare_data\n/data — DB & config"]
        V2["fireshare_processed\n/processed — thumbnails & metadata"]
        V3["fireshare_videos\n/videos — source video files"]
        V4["fireshare_images\n/images — source image files"]
    end
    User -- "HTTP 8585→80" --> NET
    NET --> FS
    FS --- V1
    FS --- V2
    FS --- V3
    FS --- V4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    User["User / Browser"]
    subgraph Docker["Docker Host (port 8585)"]
        FS["fireshare container\nshaneisrael/fireshare:1.7.1\n(port 80)"]
        NET["fireshare-network\n(bridge)"]
        V1["fireshare_data\n/data — DB & config"]
        V2["fireshare_processed\n/processed — thumbnails & metadata"]
        V3["fireshare_videos\n/videos — source video files"]
        V4["fireshare_images\n/images — source image files"]
    end
    User -- "HTTP 8585→80" --> NET
    NET --> FS
    FS --- V1
    FS --- V2
    FS --- V3
    FS --- V4
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/fireshare/app.json:42-95
**`SECRET_KEY` not surfaced in the store UI**

`SECRET_KEY` is omitted from `deployment.environment_variables`, so users installing through a store UI have no way to configure it. Since Fireshare auto-generates a new key on every start when it's unset, every container restart (including routine updates) will invalidate all active sessions. Neither the `before_install` nor `after_install` tip mentions this behaviour, so users will get unexpectedly logged out with no explanation. Adding `SECRET_KEY` with an empty default and a description like "Session signing key — auto-generated if blank, but set this to keep sessions across restarts" would allow store users to opt into persistence without exposing a weak static default.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat: document THUMBNAIL\_VIDEO\_LOCATION ..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/56ada3bc232e91765e0c705afa339dfa709b0781) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38567791)</sub>

<!-- /greptile_comment -->