### PR TITLE
fix(nexterm): update docker image to nexterm/aio:1.2.1-BETA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [2026.06.3]
+
+### Updated
+- `apps/nexterm/` — v1.0.9-OPEN-PREVIEW → v1.2.1-BETA. Docker image moved from `germannewsmaker/nexterm` to `nexterm/aio` per upstream release.
+
 ## [2026.06.2]
 
 ### Added

--- a/apps/nexterm/app.json
+++ b/apps/nexterm/app.json
@@ -44,8 +44,7 @@
       {
         "name": "ENCRYPTION_KEY",
         "description": "Key used to encrypt stored credentials. Generate with: openssl rand -hex 32",
-        "required": true,
-        "default": "changeme"
+        "required": true
       }
     ],
     "volumes": [

--- a/apps/nexterm/app.json
+++ b/apps/nexterm/app.json
@@ -5,15 +5,15 @@
     "name": "Nexterm",
     "description": "The open source server management software for SSH, VNC & RDP. This is in Preview Release.",
     "tagline": "Nexterm",
-    "version": "1.0.9-OPEN-PREVIEW",
+    "version": "1.2.1-BETA",
     "author": "BigBearTechWorld",
-    "developer": "germannewsmaker",
+    "developer": "gnmyt",
     "category": "BigBearCasaOS",
     "license": "",
-    "homepage": "https://hub.docker.com/r/germannewsmaker/nexterm",
+    "homepage": "https://hub.docker.com/r/nexterm/aio",
     "source": "big-bear-universal",
     "created": "2025-10-27T02:42:04Z",
-    "updated": "2026-01-03T21:43:03.156Z"
+    "updated": "2026-06-19T00:00:00.000Z"
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/nexterm/logo.png",
@@ -36,7 +36,7 @@
     "platform": "linux",
     "main_service": "big-bear-nexterm",
     "default_port": "6989",
-    "main_image": "germannewsmaker/nexterm",
+    "main_image": "nexterm/aio",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {

--- a/apps/nexterm/app.json
+++ b/apps/nexterm/app.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "nexterm",
     "name": "Nexterm",
-    "description": "The open source server management software for SSH, VNC & RDP. This is in Preview Release.",
+    "description": "The open source server management software for SSH, VNC & RDP. This is in BETA.",
     "tagline": "Nexterm",
     "version": "1.2.1-BETA",
     "author": "BigBearTechWorld",
@@ -40,7 +40,14 @@
     "compose_file": "docker-compose.yml"
   },
   "deployment": {
-    "environment_variables": [],
+    "environment_variables": [
+      {
+        "name": "ENCRYPTION_KEY",
+        "description": "Key used to encrypt stored credentials. Generate with: openssl rand -hex 32",
+        "required": true,
+        "default": "changeme"
+      }
+    ],
     "volumes": [
       {
         "container": "/app/data",

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # Environment variables for the big-bear-nexterm container
     environment:
       # Generate with: openssl rand -hex 32
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local nexterm_data directory to /app/data inside the container

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # Environment variables for the big-bear-nexterm container
     environment:
       # Generate with: openssl rand -hex 32
-      - ENCRYPTION_KEY=changeme
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local nexterm_data directory to /app/data inside the container

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-nexterm
     # Image to be used for the container
-    image: germannewsmaker/nexterm:1.0.9-OPEN-PREVIEW
+    image: nexterm/aio:1.2.1-BETA
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # Environment variables for the big-bear-nexterm container
     environment:
       # Generate with: openssl rand -hex 32
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - ENCRYPTION_KEY=changeme
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local nexterm_data directory to /app/data inside the container

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     restart: unless-stopped
     # Environment variables for the big-bear-nexterm container
     environment:
+      # REQUIRED: Replace with a strong random key before deploying
       # Generate with: openssl rand -hex 32
-      - ENCRYPTION_KEY=changeme
+      - ENCRYPTION_KEY=
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local nexterm_data directory to /app/data inside the container

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     image: nexterm/aio:1.2.1-BETA
     # Container restart policy
     restart: unless-stopped
+    # Environment variables for the big-bear-nexterm container
+    environment:
+      # Generate with: openssl rand -hex 32
+      - ENCRYPTION_KEY=changeme
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local nexterm_data directory to /app/data inside the container


### PR DESCRIPTION
## Summary

### Fixed
- Docker image updated from `germannewsmaker/nexterm:1.0.9-OPEN-PREVIEW` to `nexterm/aio:1.2.1-BETA`
- Updated developer, homepage, and main_image references in app.json

Closes https://github.com/bigbeartechworld/big-bear-casaos/issues/6241

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the Nexterm app definition from the old `germannewsmaker/nexterm:1.0.9-OPEN-PREVIEW` image to the new official `nexterm/aio:1.2.1-BETA` image, updating all associated metadata (developer, homepage, version, description) across `app.json` and `docker-compose.yml`.

- `app.json` is comprehensively updated: image namespace, developer (`gnmyt`), homepage, version string, description, `main_image`, and `updated` timestamp are all corrected; `ENCRYPTION_KEY` is added as a `required` deployment variable with a generation hint.
- `docker-compose.yml` switches the image tag and introduces the `ENCRYPTION_KEY` environment variable, though it is set to an empty string (`ENCRYPTION_KEY=`) rather than a placeholder value — users installing via compose directly will need to fill this in manually before the container starts correctly.
- `CHANGELOG.md` is updated with a properly formatted `[2026.06.3]` entry documenting the migration.

<h3>Confidence Score: 5/5</h3>

The change is a straightforward image migration with fully updated metadata; no new blocking issues were introduced beyond what prior review rounds have already surfaced.

All three files change consistently and in lockstep — the image reference, developer attribution, homepage, version string, and CHANGELOG entry all point to the same upstream migration. The `app.json` correctly marks `ENCRYPTION_KEY` as required with generation instructions, and the compose file now at least declares the variable (even if empty), which is an improvement over the earlier state. No logic errors, data-loss paths, or security regressions were introduced by this diff.

No files require special attention beyond `apps/nexterm/docker-compose.yml`, where the empty `ENCRYPTION_KEY=` value means users who deploy directly via compose (Dockge, Portainer) will need to fill it in themselves before the container will function correctly.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/nexterm/docker-compose.yml | Image updated to nexterm/aio:1.2.1-BETA; ENCRYPTION_KEY env var added but set to an empty string, which may cause startup failure or silent no-encryption behavior |
| apps/nexterm/app.json | Metadata fully updated: image namespace, developer, homepage, version, and updated timestamp all corrected; ENCRYPTION_KEY added as a required deployment variable with generation instructions |
| CHANGELOG.md | New [2026.06.3] entry added correctly documenting the image migration from germannewsmaker/nexterm to nexterm/aio |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Deploys Nexterm] --> B{Install Method}
    B -->|CasaOS UI / app.json| C[UI prompts for ENCRYPTION_KEY\nrequired: true]
    B -->|docker-compose.yml directly\nDockge / Portainer| D[ENCRYPTION_KEY= empty string\npassed to container]
    C --> E[User provides key\nopenssl rand -hex 32]
    D --> F{Nexterm startup}
    E --> G[Container starts with\nstrong encryption key]
    F -->|App validates key| H[Startup error / warning]
    F -->|App accepts empty key| I[Starts with no/empty encryption]
    G --> J[nexterm/aio:1.2.1-BETA\nRunning on :6989]
    H --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User Deploys Nexterm] --> B{Install Method}
    B -->|CasaOS UI / app.json| C[UI prompts for ENCRYPTION_KEY\nrequired: true]
    B -->|docker-compose.yml directly\nDockge / Portainer| D[ENCRYPTION_KEY= empty string\npassed to container]
    C --> E[User provides key\nopenssl rand -hex 32]
    D --> F{Nexterm startup}
    E --> G[Container starts with\nstrong encryption key]
    F -->|App validates key| H[Startup error / warning]
    F -->|App accepts empty key| I[Starts with no/empty encryption]
    G --> J[nexterm/aio:1.2.1-BETA\nRunning on :6989]
    H --> J
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix(nexterm): set ENCRYPTION\_KEY to empt..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/831ec96ab446f8e86d9289a80dcf3e4ca6ec8da2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38718464)</sub>

<!-- /greptile_comment -->