### PR TITLE
cosmos conversion improvements

### DIFF
--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1529,8 +1529,9 @@ convert_to_cosmos() {
         }
       ],"
     fi
-    
-    cat > "$output_dir/cosmos-compose.json" << EOF
+
+    local temp_cosmos_compose=$(mktemp)
+    cat > "$temp_cosmos_compose" << EOF
 {
   "cosmos-installer": {
     $routes
@@ -1540,6 +1541,8 @@ convert_to_cosmos() {
   }
 }
 EOF
+    # Ensure pretty formatting
+    yq -o=json "$temp_cosmos_compose" > "$output_dir/cosmos-compose.json"
 
     # Use icon URL or logo URL for icon field
     local icon_url="${APP_ICON:-${APP_LOGO:-https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/_example/logo.jpg}}"

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1540,57 +1540,50 @@ convert_to_cosmos() {
   }
 }
 EOF
+
+    # Use icon URL or logo URL for icon field
+    local icon_url="${APP_ICON:-${APP_LOGO:-https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/_example/logo.jpg}}"
     
-    # Use icon URL or logo URL for image and icon fields
-    local image_url="${APP_ICON:-${APP_LOGO:-https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/_example/logo.jpg}}"
+    # Use container image name/URI to create URL
+    local main_image=${APP_MAIN_IMAGE}
+    local base_url1="https://hub.docker.com/r/"
+    local base_url2="https://hub.docker.com/_/"
+    if [[ "$main_image" == ghcr.io* ]]; then
+        main_image="https://${main_image}"
+    elif [[ "$main_image" == lscr.io/linuxserver* ]]; then
+        main_image=$(echo $main_image | sed 's/lscr\.io\/linuxserver\///')
+        main_image="https://docs.linuxserver.io/images/docker-${main_image}"
+    elif [[ "$main_image" == registry.gitlab.com* ]]; then
+        main_image=$(echo $main_image | sed 's/registry\.//')
+        main_image="https://$main_image/container_registry"
+    elif [[ "$main_image" == */* ]]; then
+        main_image="${base_url1}${main_image}"
+    else
+        main_image="${base_url2}${main_image}"
+    fi
     
     # Create description.json using jq to properly escape all strings
     jq -n \
         --arg name "$APP_NAME" \
+        --arg tagline "$APP_TAGLINE" \
         --arg description "$APP_DESCRIPTION" \
         --arg url "$APP_HOMEPAGE" \
         --argjson tags "$APP_TAGS" \
         --arg repository "${APP_REPOSITORY:-https://github.com/bigbeartechworld}" \
-        --arg image "$image_url" \
+        --arg image "$main_image" \
+        --arg icon "$icon_url" \
         --argjson architectures "$APP_ARCHITECTURES" \
         '{
             name: $name,
-            description: $description,
+            description: $tagline,
             url: $url,
             longDescription: $description,
             tags: $tags,
             repository: $repository,
             image: $image,
             supported_architectures: $architectures,
-            icon: $image
+            icon: $icon
         }' > "$output_dir/description.json"
-    
-    # Create config.json using jq
-    jq -n \
-        --arg id "$app_name" \
-        --arg version "$APP_VERSION" \
-        --arg image "$APP_MAIN_IMAGE" \
-        --arg youtube "${APP_YOUTUBE:-}" \
-        --arg docs_link "${APP_DOCUMENTATION:-}" \
-        '{
-            id: $id,
-            version: $version,
-            image: $image,
-            youtube: $youtube,
-            docs_link: $docs_link,
-            big_bear_cosmos_youtube: ""
-        }' > "$output_dir/config.json"
-    
-    # Create docker-compose.yml for Cosmos
-    # Start with the temp compose and prepend cosmos-installer
-    {
-        echo "cosmos-installer: null"
-        cat "$temp_compose"
-        echo "minVersion: 0.14.0"
-    } > "$output_dir/docker-compose.yml"
-    
-    # Clean up temporary file - do this AFTER using it for docker-compose.yml
-    rm -f "$temp_compose"
     
     # Download icon
     if [[ -n "$APP_ICON" ]]; then
@@ -1641,21 +1634,7 @@ EOF
         return 1
     fi
     
-    if ! jq empty "$output_dir/config.json" 2>/dev/null; then
-        print_error "Generated config.json for $app_name (Cosmos) has invalid JSON!"
-        print_error "Validation error:"
-        jq empty "$output_dir/config.json" 2>&1
-        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
-        return 1
-    fi
-    
-    if ! yq eval '.' "$output_dir/docker-compose.yml" > /dev/null 2>&1; then
-        print_error "Generated docker-compose.yml for $app_name (Cosmos) has invalid YAML!"
-        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
-        return 1
-    fi
-    
-    print_success "Converted $app_name for Cosmos (config.json, description.json, docker-compose.yml, cosmos-compose.json)"
+    print_success "Converted $app_name for Cosmos (description.json, cosmos-compose.json, icon.png)"
 }
 
 # Convert to Umbrel format

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1498,8 +1498,9 @@ convert_to_cosmos() {
     mkdir -p "$output_dir"
     
     # Create temporary compose file with big-bear- prefix
-    local temp_compose=$(mktemp)
-    trap 'rm -rf -- "$temp_compose"' EXIT
+    TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf -- "$TEMP_DIR"' EXIT
+    local temp_compose=$(mktemp -p $TEMP_DIR)
     adjust_compose_for_platform "$app_dir/docker-compose.yml" "$temp_compose" "cosmos" "$app_name"
     
     # Escape APP_NAME for JSON in routes
@@ -1531,8 +1532,7 @@ convert_to_cosmos() {
       ],"
     fi
 
-    local temp_cosmos_compose=$(mktemp)
-    trap 'rm -rf -- "$temp_cosmos_compose"' EXIT
+    local temp_cosmos_compose=$(mktemp -p $TEMP_DIR)
     cat > "$temp_cosmos_compose" << EOF
 {
   "cosmos-installer": {
@@ -1551,16 +1551,20 @@ EOF
     
     # Use container image name/URI to create URL
     local main_image=${APP_MAIN_IMAGE%:*}
+    main_image="${main_image%@*}"
     local base_url1="https://hub.docker.com/r/"
     local base_url2="https://hub.docker.com/_/"
     if [[ "$main_image" == ghcr.io* ]]; then
         main_image="https://${main_image}"
     elif [[ "$main_image" == lscr.io/linuxserver* ]]; then
-        main_image=$(echo $main_image | sed 's/lscr\.io\/linuxserver\///')
+        main_image="${main_image#lscr.io/linuxserver/}"
         main_image="https://docs.linuxserver.io/images/docker-${main_image}"
     elif [[ "$main_image" == registry.gitlab.com* ]]; then
-        main_image=$(echo $main_image | sed 's/registry\.//')
+        main_image="${main_image#registry.}"
         main_image="https://$main_image/container_registry"
+    elif [[ "$main_image" == codeberg.org* ]]; then
+        main_image="${main_image#codeberg.org/}"
+        main_image="https://codeberg.org/${main_image}/packages"
     elif [[ "$main_image" == */* ]]; then
         main_image="${base_url1}${main_image}"
     else

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1596,30 +1596,21 @@ EOF
         }' > "$output_dir/description.json"
     
     # Download icon
-    if [[ -n "$APP_ICON" ]]; then
-        if curl -fsSL "$APP_ICON" -o "$output_dir/icon_temp" 2>/dev/null; then
-            # Try to convert to PNG if ImageMagick is available
-            if command -v convert &> /dev/null; then
-                if convert "$output_dir/icon_temp" "$output_dir/icon.png" 2>/dev/null; then
-                    rm -f "$output_dir/icon_temp"
-                else
-                    # If conversion fails, just rename to .png
-                    mv "$output_dir/icon_temp" "$output_dir/icon.png"
-                fi
+    if curl -fsSL "$icon_url" -o "$output_dir/icon_temp" 2>/dev/null; then
+        # Try to convert to PNG if ImageMagick is available
+        if command -v convert &> /dev/null; then
+            if convert "$output_dir/icon_temp" "$output_dir/icon.png" 2>/dev/null; then
+                rm -f "$output_dir/icon_temp"
             else
-                # No ImageMagick, just rename to .png
+                # If conversion fails, just rename to .png
                 mv "$output_dir/icon_temp" "$output_dir/icon.png"
             fi
         else
-            # If download fails, create placeholder
-            if command -v convert &> /dev/null; then
-                convert -size 512x512 xc:gray "$output_dir/icon.png" 2>/dev/null || touch "$output_dir/icon.png"
-            else
-                touch "$output_dir/icon.png"
-            fi
+            # No ImageMagick, just rename to .png
+            mv "$output_dir/icon_temp" "$output_dir/icon.png"
         fi
     else
-        # No icon URL, create placeholder
+        # If download fails, create placeholder
         if command -v convert &> /dev/null; then
             convert -size 512x512 xc:gray "$output_dir/icon.png" 2>/dev/null || touch "$output_dir/icon.png"
         else

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1498,9 +1498,7 @@ convert_to_cosmos() {
     mkdir -p "$output_dir"
     
     # Create temporary compose file with big-bear- prefix
-    TEMP_DIR=$(mktemp -d)
-    trap 'rm -rf -- "$TEMP_DIR"' EXIT
-    local temp_compose=$(mktemp -p $TEMP_DIR)
+    local temp_compose=$(mktemp)
     adjust_compose_for_platform "$app_dir/docker-compose.yml" "$temp_compose" "cosmos" "$app_name"
     
     # Escape APP_NAME for JSON in routes
@@ -1543,8 +1541,11 @@ convert_to_cosmos() {
   }
 }
 EOF
+
+    rm -f $temp_compose
     # Ensure pretty formatting
     yq -o=json "$temp_cosmos_compose" > "$output_dir/cosmos-compose.json"
+    rm -f $temp_cosmos_compose
 
     # Use icon URL or logo URL for icon field
     local icon_url="${APP_ICON:-${APP_LOGO:-https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/_example/logo.jpg}}"

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1499,6 +1499,7 @@ convert_to_cosmos() {
     
     # Create temporary compose file with big-bear- prefix
     local temp_compose=$(mktemp)
+    trap 'rm -rf -- "$temp_compose"' EXIT
     adjust_compose_for_platform "$app_dir/docker-compose.yml" "$temp_compose" "cosmos" "$app_name"
     
     # Escape APP_NAME for JSON in routes
@@ -1531,6 +1532,7 @@ convert_to_cosmos() {
     fi
 
     local temp_cosmos_compose=$(mktemp)
+    trap 'rm -rf -- "$temp_cosmos_compose"' EXIT
     cat > "$temp_cosmos_compose" << EOF
 {
   "cosmos-installer": {
@@ -1548,7 +1550,7 @@ EOF
     local icon_url="${APP_ICON:-${APP_LOGO:-https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/_example/logo.jpg}}"
     
     # Use container image name/URI to create URL
-    local main_image=${APP_MAIN_IMAGE}
+    local main_image=${APP_MAIN_IMAGE%:*}
     local base_url1="https://hub.docker.com/r/"
     local base_url2="https://hub.docker.com/_/"
     if [[ "$main_image" == ghcr.io* ]]; then
@@ -1568,7 +1570,7 @@ EOF
     # Create description.json using jq to properly escape all strings
     jq -n \
         --arg name "$APP_NAME" \
-        --arg tagline "$APP_TAGLINE" \
+        --arg tagline "${APP_TAGLINE:-$APP_DESCRIPTION}" \
         --arg description "$APP_DESCRIPTION" \
         --arg url "$APP_HOMEPAGE" \
         --argjson tags "$APP_TAGS" \


### PR DESCRIPTION
- indent the services in the cosmos-compose.json
- cosmos apps do not have a config.json
- cosmos apps do not need a docker-compose file, they only use cosmos-compose
- image description is supposed to be a link to the container image, as seen in the offical Cosmos AppMarket (I have handled all sources currently used)
- use the app's tagline as description and description as longDescription

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates how apps are converted for Cosmos. The main changes are:

- Cosmos output now skips `config.json` and `docker-compose.yml`.
- `cosmos-compose.json` is written through a formatted temp file.
- Image metadata now points to container image pages.
- Short and long descriptions now use tagline and description separately.
- Icon download uses the selected icon or logo URL.

<h3>Confidence Score: 4/5</h3>

This is close, but the temp-file cleanup should be fixed before merging.

- Compose extraction or formatting failures can exit before temporary files are removed.
- Registry link and tagline handling look addressed for the changed Cosmos output path.

scripts/convert-to-platforms.sh

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/convert-to-platforms.sh | Cosmos conversion was simplified, but temp-file cleanup can still be skipped when compose extraction or formatting fails. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/convert-to-platforms.sh:1533-1548
**Cleanup skips errors** The temporary compose files are still removed only on the success path. With `set -e` enabled, a failure while extracting services into `temp_cosmos_compose` exits before `temp_compose` is removed, and a failure in `yq -o=json "$temp_cosmos_compose"` exits before `temp_cosmos_compose` is removed. A malformed compose file can still leave generated compose contents behind during Cosmos conversion, so the cleanup needs to run from an error-safe cleanup path installed before these commands run.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(convert): apply icon fallback to dow..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/e17c1d767396e7ad218fc3baf4203689ee46dd3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40447850)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->