### PR TITLE
feat: add kanidm app

### DIFF
--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -5,7 +5,7 @@
     "name": "Kanidm",
     "description": "Kanidm is a simple and secure identity management platform, allowing other applications and services to offload the challenge of authenticating and storing identities to Kanidm. The goal of this project is to be a complete identity provider, covering the broadest possible set of requirements and integrations.",
     "tagline": "Kanidm is a modern and simple identity management platform written in rust.",
-    "version": "latest",
+    "version": "1.10.4",
     "author": "ByteSquire",
     "developer": "kanidm",
     "category": "Security",

--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -1,0 +1,165 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "kandim",
+    "name": "Kanidm",
+    "description": "Kanidm is a simple and secure identity management platform, allowing other applications and services to offload the challenge of authenticating and storing identities to Kanidm. The goal of this project is to be a complete identity provider, covering the broadest possible set of requirements and integrations.",
+    "tagline": "Kanidm is a modern and simple identity management platform written in rust.",
+    "version": "latest",
+    "author": "ByteSquire",
+    "developer": "kanidm",
+    "category": "Security",
+    "license": "MPL-2.0",
+    "homepage": "https://kanidm.com/",
+    "source": "big-bear-universal",
+    "created": "2026-06-23T10:42:22Z",
+    "updated": "2026-06-23T10:42:22Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/kanidm/kanidm/artwork/logo-small.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/kanidm/kanidm/artwork/logo-small.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://kanidm.github.io/kanidm/stable",
+    "repository": "https://github.com/kanidm/kanidm",
+    "issues": "https://github.com/kanidm/kanidm/issues",
+    "support": "https://community.bigbeartechworld.com"
+  },
+  "technical": {
+    "architectures": ["amd64", "arm64"],
+    "platform": "linux",
+    "main_service": "app",
+    "default_port": "443",
+    "main_image": "kanidm/server",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "KANIDM_LOG_LEVEL",
+        "default": "info",
+        "description": "Kanidm log level",
+        "required": false
+      },
+      {
+        "name": "KANIDM_LDAPBINDADDRESS",
+        "default": "[::]:3636",
+        "description": "Kanidm ldap bind address",
+        "required": false
+      },
+      {
+        "name": "KANIDM_BINDADDRESS",
+        "default": "[::]:8443",
+        "description": "Kanidm bind address",
+        "required": false
+      },
+      {
+        "name": "KANIDM_DB_PATH",
+        "default": "/data/kanidm.db",
+        "description": "Kanidm database path (inside container)",
+        "required": true
+      },
+      {
+        "name": "KANIDM_TLS_CHAIN",
+        "default": "",
+        "description": "Kanidm certificate chain file path (inside container)",
+        "required": false
+      },
+      {
+        "name": "KANIDM_TLS_KEY",
+        "default": "",
+        "description": "Kanidm private key file path (inside container)",
+        "required": false
+      },
+      {
+        "name": "KANIDM_DOMAIN",
+        "default": "idm.example.com",
+        "description": "Kanidm domain FQDN",
+        "required": true
+      },
+      {
+        "name": "KANIDM_ORIGIN",
+        "default": "https://idm.example.com:44300",
+        "description": "Kanidm url, including port if non-standard",
+        "required": true
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Data directory"
+      },
+      {
+        "container": "/backups",
+        "description": "Backup directory"
+      }
+    ],
+    "ports": [
+      {
+        "container": "443",
+        "host": "44300",
+        "protocol": "tcp",
+        "description": "Web UI"
+      },
+      {
+        "container": "3636",
+        "host": "3636",
+        "protocol": "ldap",
+        "description": "LDAPS"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "44300",
+      "port": "44300"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": ["Security", "Network", "selfhosted"],
+      "administrator_only": false,
+      "port": "44300"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": ["amd64", "arm64"],
+      "port": "44300"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "44300"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "44300"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "44300"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "idm",
+    "security",
+    "network",
+    "container"
+  ]
+}

--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -85,6 +85,30 @@
         "default": "https://idm.example.com:44300",
         "description": "Kanidm url, including port if non-standard",
         "required": true
+      },
+      {
+        "name": "KANIDM_HTTP_CLIENT_ADDRESS_INFO_X-FORWARD-FOR",
+        "default": "",
+        "description": "Kanidm trusted ips that append x-forward-for header",
+        "required": false
+      },
+      {
+        "name": "KANIDM_ONLINE_BACKUP_PATH",
+        "default": "/backups/",
+        "description": "Kanidm backups path (inside container)",
+        "required": true
+      },
+      {
+        "name": "KANIDM_ONLINE_BACKUP_SCHEDULE",
+        "default": "@daily",
+        "description": "When to create a backup (cron syntax)",
+        "required": false
+      },
+      {
+        "name": "KANIDM_ONLINE_BACKUP_VERSION",
+        "default": "7",
+        "description": "How many backups to keep",
+        "required": false
       }
     ],
     "volumes": [

--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -31,8 +31,8 @@
   "technical": {
     "architectures": ["amd64", "arm64"],
     "platform": "linux",
-    "main_service": "app",
-    "default_port": "443",
+    "main_service": "kanidm",
+    "default_port": "8443",
     "main_image": "kanidm/server",
     "compose_file": "docker-compose.yml"
   },
@@ -45,16 +45,16 @@
         "required": false
       },
       {
-        "name": "KANIDM_LDAPBINDADDRESS",
-        "default": "[::]:3636",
-        "description": "Kanidm ldap bind address (inside container)",
-        "required": false
-      },
-      {
         "name": "KANIDM_BINDADDRESS",
         "default": "[::]:8443",
         "description": "Kanidm bind address (inside container)",
         "required": true
+      },
+      {
+        "name": "KANIDM_LDAPBINDADDRESS",
+        "default": "[::]:3636",
+        "description": "Kanidm ldap bind address (inside container)",
+        "required": false
       },
       {
         "name": "KANIDM_DB_PATH",
@@ -137,7 +137,7 @@
       {
         "container": "3636",
         "host": "3636",
-        "protocol": "ldap",
+        "protocol": "tcp",
         "description": "LDAPS"
       }
     ]

--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -93,6 +93,12 @@
         "required": false
       },
       {
+        "name": "KANIDM_HTTP_CLIENT_ADDRESS_INFO_PROXY-V2",
+        "default": "",
+        "description": "Kanidm trusted ips allowed to use proxy protocol",
+        "required": false
+      },
+      {
         "name": "KANIDM_ONLINE_BACKUP_PATH",
         "default": "/backups/",
         "description": "Kanidm backups path (inside container)",

--- a/apps/kanidm/app.json
+++ b/apps/kanidm/app.json
@@ -1,7 +1,7 @@
 {
   "spec_version": "1.0",
   "metadata": {
-    "id": "kandim",
+    "id": "kanidm",
     "name": "Kanidm",
     "description": "Kanidm is a simple and secure identity management platform, allowing other applications and services to offload the challenge of authenticating and storing identities to Kanidm. The goal of this project is to be a complete identity provider, covering the broadest possible set of requirements and integrations.",
     "tagline": "Kanidm is a modern and simple identity management platform written in rust.",
@@ -47,14 +47,14 @@
       {
         "name": "KANIDM_LDAPBINDADDRESS",
         "default": "[::]:3636",
-        "description": "Kanidm ldap bind address",
+        "description": "Kanidm ldap bind address (inside container)",
         "required": false
       },
       {
         "name": "KANIDM_BINDADDRESS",
         "default": "[::]:8443",
-        "description": "Kanidm bind address",
-        "required": false
+        "description": "Kanidm bind address (inside container)",
+        "required": true
       },
       {
         "name": "KANIDM_DB_PATH",
@@ -64,25 +64,25 @@
       },
       {
         "name": "KANIDM_TLS_CHAIN",
-        "default": "",
+        "default": "/data/chain.pem",
         "description": "Kanidm certificate chain file path (inside container)",
-        "required": false
+        "required": true
       },
       {
         "name": "KANIDM_TLS_KEY",
-        "default": "",
+        "default": "/data/key.pem",
         "description": "Kanidm private key file path (inside container)",
-        "required": false
+        "required": true
       },
       {
         "name": "KANIDM_DOMAIN",
         "default": "idm.example.com",
-        "description": "Kanidm domain FQDN",
+        "description": "Kanidm instance FQDN",
         "required": true
       },
       {
         "name": "KANIDM_ORIGIN",
-        "default": "https://idm.example.com:44300",
+        "default": "https://idm.example.com",
         "description": "Kanidm url, including port if non-standard",
         "required": true
       },
@@ -111,7 +111,7 @@
         "required": false
       },
       {
-        "name": "KANIDM_ONLINE_BACKUP_VERSION",
+        "name": "KANIDM_ONLINE_BACKUP_VERSIONS",
         "default": "7",
         "description": "How many backups to keep",
         "required": false
@@ -129,7 +129,7 @@
     ],
     "ports": [
       {
-        "container": "443",
+        "container": "8443",
         "host": "44300",
         "protocol": "tcp",
         "description": "Web UI"

--- a/apps/kanidm/docker-compose.yml
+++ b/apps/kanidm/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  kanidm:
+    container_name: big-bear-kanidm
+    restart: "always"
+    image: kanidm/server:1.10.4
+    stop_grace_period: 30s
+    volumes:
+      - kanidm_data:/data
+      - kanidm_backups:/backups
+volumes:
+  kanidm_data:
+  kanidm_backups:

--- a/apps/kanidm/docker-compose.yml
+++ b/apps/kanidm/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     stop_grace_period: 30s
     volumes:
       - kanidm_data:/data
+      - ./server.toml:/data/server.toml
       - kanidm_backups:/backups
 volumes:
   kanidm_data:

--- a/apps/kanidm/docker-compose.yml
+++ b/apps/kanidm/docker-compose.yml
@@ -4,10 +4,26 @@ services:
     restart: "always"
     image: kanidm/server:1.10.4
     stop_grace_period: 30s
+    ports:
+      - "44300:8443"
+      - "3636:3636"
     volumes:
       - kanidm_data:/data
-      - ./server.toml:/data/server.toml
       - kanidm_backups:/backups
+    environment:
+      - KANIDM_LOG_LEVEL=info
+      - KANIDM_BINDADDRESS="[::]:8443"
+      - KANIDM_LDAPBINDADDRESS="[::]:3636"
+      - KANIDM_DB_PATH="/data/kanidm.db"
+      - KANIDM_TLS_CHAIN="/data/chain.pem"
+      - KANIDM_TLS_KEY="/data/key.pem"
+      - KANIDM_DOMAIN="idm.example.com"
+      - KANIDM_ORIGIN="https://idm.example.com"
+      - KANIDM_HTTP_CLIENT_ADDRESS_INFO_X-FORWARD-FOR=""
+      - KANIDM_HTTP_CLIENT_ADDRESS_INFO_PROXY-V2=""
+      - KANIDM_ONLINE_BACKUP_PATH="/backups/"
+      - KANIDM_ONLINE_BACKUP_SCHEDULE="@daily"
+      - KANIDM_ONLINE_BACKUP_VERSIONS=7
 volumes:
   kanidm_data:
   kanidm_backups:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Kanidm as a new app. The main changes are:

- New app metadata for Kanidm, including ports, platform compatibility, and UI settings.
- Runtime configuration defaults for Kanidm environment variables.
- A Docker Compose service with published HTTPS and LDAPS ports.
- Named volumes for Kanidm data and backups.

<h3>Confidence Score: 4/5</h3>

This is close, but the fresh-install startup path should be fixed before merging.

- The compose service references required TLS files in `/data`.
- A first-run named volume does not contain those files.
- Kanidm can fail before exposing the web UI.

apps/kanidm/docker-compose.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/kanidm/app.json | Adds Kanidm metadata, compatibility data, port declarations, and runtime setting defaults. |
| apps/kanidm/docker-compose.yml | Adds the Kanidm service, published ports, named volumes, and environment-based configuration. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/kanidm/docker-compose.yml:18-19
**TLS Files Missing** The service now points Kanidm at `/data/chain.pem` and `/data/key.pem`, but `/data` is only a fresh named volume on first install. Kanidm requires those TLS files before the server can start, so a new deployment can start with an empty volume, fail to open the certificate or key, and loop under `restart: "always"` with no UI available. The compose file needs to provision these files, run the Kanidm certificate generation step, or mount user-provided TLS material at the configured paths.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(kanidm): minor app fixes, add ports ..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/1c368f77e91d31e63176fa13b30039fbe1ea65a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40461240)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->