### PR TITLE
chore(immich): update to v3.0.0

### DIFF
--- a/apps/immich/app.json
+++ b/apps/immich/app.json
@@ -5,7 +5,7 @@
     "name": "Immich",
     "description": "Self-hosted photo and video storage.",
     "tagline": "Immich",
-    "version": "v2.7.5",
+    "version": "v3.0.0",
     "author": "BigBearTechWorld",
     "developer": "immich-app",
     "category": "BigBearCasaOS",
@@ -13,7 +13,7 @@
     "homepage": "https://hub.docker.com/r/immich-app/immich-server",
     "source": "big-bear-universal",
     "created": "2025-10-27T02:41:53Z",
-    "updated": "2026-04-13T17:35:43.407Z"
+    "updated": "2026-07-02T00:00:00.000Z"
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png",

--- a/apps/immich/docker-compose.yml
+++ b/apps/immich/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v2.7.5 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v3.0.0 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -31,7 +31,7 @@ services:
   # Configuration for Immich Machine Learning service
   immich-machine-learning:
     container_name: immich-machine-learning # Name of the running container
-    image: ghcr.io/immich-app/immich-machine-learning:v2.7.5 # Image to be used
+    image: ghcr.io/immich-app/immich-machine-learning:v3.0.0 # Image to be used
     volumes: # Mounting directories for persistent data storage
       - immich_model-cache:/cache
     environment: # Setting environment variables


### PR DESCRIPTION
Bumps Immich to v3.0.0 (server + machine-learning). Existing app already ships the VectorChord postgres image, so no pgvecto.rs migration is needed — in-place upgrade.

Closes [#6278](https://github.com/bigbeartechworld/big-bear-casaos/issues/6278)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Immich application from v2.7.5 to v3.0.0, bumping both the `immich-server` and `immich-machine-learning` container images and reflecting the new version in `app.json`. The upgrade is a major-version jump that carries automatic database migrations (including the `album_owner` → `album_user` schema change) on first startup.

- Both `ghcr.io/immich-app/immich-server` and `ghcr.io/immich-app/immich-machine-learning` are updated to `v3.0.0`; `app.json` metadata (`version`, `updated`) is updated consistently.
- The VectorChord-enabled postgres image (`ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0`) is **not** updated alongside the server, while the official Immich v3.0.0 compose files ship `14-vectorchord0.4.3-pgvectors0.2.0`.
- The Immich-managed postgres image is still within the documented supported range (`>= 0.3, < 2.0`), so this is a suggestion to align with the official recommendation.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the version bump is straightforward and the existing VectorChord postgres image is within Immich's documented compatibility range, though the postgres image can be updated to match what Immich officially ships for v3.0.0.

Both immich-server and immich-machine-learning are correctly bumped to v3.0.0 with consistent metadata in app.json. The only gap is that the bundled postgres image stays on vectorchord0.3.0 while the official Immich v3.0.0 compose uses vectorchord0.4.3; since 0.3.0 is still within the documented acceptance window the app will start and run, but new installs and upgrades would benefit from tracking the upstream recommendation.

apps/immich/docker-compose.yml — the postgres image version is one minor release behind what Immich officially distributes for v3.0.0.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/immich/docker-compose.yml | Bumps immich-server and immich-machine-learning images to v3.0.0; postgres image remains at vectorchord0.3.0 while the official Immich v3.0.0 compose uses vectorchord0.4.3. |
| apps/immich/app.json | Version bumped to v3.0.0 and updated timestamp set to 2026-07-02; consistent with the compose changes. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User starts upgrade\nv2.7.5 → v3.0.0] --> B[Docker pulls\nimmich-server:v3.0.0\nimmich-machine-learning:v3.0.0]
    B --> C[immich-redis starts\nredis:6.2.20-alpine]
    B --> D[immich-postgres starts\npostgres:14-vectorchord0.3.0]
    C --> E[immich-server starts]
    D --> E
    E --> F{Auto DB migrations\nrun on startup}
    F -->|album_owner → album_user\n& other schema changes| G[Immich v3.0.0\nReady ✓]
    F -->|Migration failure| H[Container exits\nCheck logs]
    E --> I[immich-machine-learning:v3.0.0\nstarts independently]
    I --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User starts upgrade\nv2.7.5 → v3.0.0] --> B[Docker pulls\nimmich-server:v3.0.0\nimmich-machine-learning:v3.0.0]
    B --> C[immich-redis starts\nredis:6.2.20-alpine]
    B --> D[immich-postgres starts\npostgres:14-vectorchord0.3.0]
    C --> E[immich-server starts]
    D --> E
    E --> F{Auto DB migrations\nrun on startup}
    F -->|album_owner → album_user\n& other schema changes| G[Immich v3.0.0\nReady ✓]
    F -->|Migration failure| H[Container exits\nCheck logs]
    E --> I[immich-machine-learning:v3.0.0\nstarts independently]
    I --> G
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/immich/docker-compose.yml`, line 58 ([link](https://github.com/bigbeartechworld/big-bear-universal-apps/blob/a7c573233d1787d23a3e95b4c42bc4e0bca3e0db/apps/immich/docker-compose.yml#L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The postgres image uses `vectorchord0.3.0`, but the official Immich v3.0.0 docker-compose ships `14-vectorchord0.4.3-pgvectors0.2.0`. While `0.3.0` is within the documented accepted range (`>= 0.3, < 2.0`) and will technically allow the server to start, aligning with the officially distributed image is safer and ensures users benefit from VectorChord 0.4.x performance improvements and any bug fixes included in that release.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/immich/docker-compose.yml
   Line: 58

   Comment:
   The postgres image uses `vectorchord0.3.0`, but the official Immich v3.0.0 docker-compose ships `14-vectorchord0.4.3-pgvectors0.2.0`. While `0.3.0` is within the documented accepted range (`>= 0.3, < 2.0`) and will technically allow the server to start, aligning with the officially distributed image is safer and ensures users benefit from VectorChord 0.4.x performance improvements and any bug fixes included in that release.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/immich/docker-compose.yml:58
The postgres image uses `vectorchord0.3.0`, but the official Immich v3.0.0 docker-compose ships `14-vectorchord0.4.3-pgvectors0.2.0`. While `0.3.0` is within the documented accepted range (`>= 0.3, < 2.0`) and will technically allow the server to start, aligning with the officially distributed image is safer and ensures users benefit from VectorChord 0.4.x performance improvements and any bug fixes included in that release.

```suggestion
    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0 # Image to be used
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(immich): update to v3.0.0"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/a7c573233d1787d23a3e95b4c42bc4e0bca3e0db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41436828)</sub>

<!-- /greptile_comment -->