### PR TITLE
feat: add Ente Photos app (#2416)

### DIFF
--- a/.github/scripts/check-version-mismatches.js
+++ b/.github/scripts/check-version-mismatches.js
@@ -70,8 +70,9 @@ async function checkVersionMismatches() {
       }
 
       // Skip digest-pinned images (e.g. repo:tag@sha256:...) — the digest is
-      // not a version and its hex can start with a digit, causing false mismatches
-      if (imageTag.includes('@sha256:')) {
+      // not a version and its hex can start with a digit, causing false mismatches.
+      // A tag cannot contain '@', so any '@' means a digest is present.
+      if (imageTag.includes('@')) {
         noVersion.push({ appName, dockerVersion: 'digest-pinned' });
         continue;
       }

--- a/.github/scripts/check-version-mismatches.js
+++ b/.github/scripts/check-version-mismatches.js
@@ -69,6 +69,13 @@ async function checkVersionMismatches() {
         continue;
       }
 
+      // Skip digest-pinned images (e.g. repo:tag@sha256:...) — the digest is
+      // not a version and its hex can start with a digit, causing false mismatches
+      if (imageTag.includes('@sha256:')) {
+        noVersion.push({ appName, dockerVersion: 'digest-pinned' });
+        continue;
+      }
+
       // Extract version
       const versionMatch = imageTag.match(/:([^:]+)$/);
       if (!versionMatch) {

--- a/.github/scripts/fix-version-mismatches.js
+++ b/.github/scripts/fix-version-mismatches.js
@@ -68,6 +68,12 @@ async function fixVersionMismatches() {
         continue;
       }
 
+      // Skip digest-pinned images (e.g. repo:tag@sha256:...) — the digest is
+      // not a version and its hex can start with a digit, causing false mismatches
+      if (imageTag.includes('@sha256:')) {
+        continue;
+      }
+
       // Extract version
       const versionMatch = imageTag.match(/:([^:]+)$/);
       if (!versionMatch) {

--- a/.github/scripts/fix-version-mismatches.js
+++ b/.github/scripts/fix-version-mismatches.js
@@ -69,8 +69,9 @@ async function fixVersionMismatches() {
       }
 
       // Skip digest-pinned images (e.g. repo:tag@sha256:...) — the digest is
-      // not a version and its hex can start with a digit, causing false mismatches
-      if (imageTag.includes('@sha256:')) {
+      // not a version and its hex can start with a digit, causing false mismatches.
+      // A tag cannot contain '@', so any '@' means a digest is present.
+      if (imageTag.includes('@')) {
         continue;
       }
 

--- a/apps/ente/README.md
+++ b/apps/ente/README.md
@@ -1,0 +1,57 @@
+# Ente Photos
+
+Self-hosted, end-to-end encrypted photo and video storage.
+
+## Access
+
+- Photos web UI: `http://<server>:3000`
+- Public albums: `http://<server>:3002`
+- Museum API: `http://<server>:8080`
+- MinIO object storage: `http://<server>:3200`
+
+On first launch, create an account through the web UI. The verification code (OTP) is printed in the `ente-museum` container logs:
+
+```bash
+docker logs ente-museum 2>&1 | grep -i "verification code"
+```
+
+## Multi-device access (required for use beyond the host)
+
+Ente stores object URLs and the API origin using `localhost`, which only resolves on the server itself. To use Ente from another device (phone, laptop), replace `localhost` with your server's LAN IP (e.g. `192.168.1.50`) in `docker-compose.yml`:
+
+- `museum` service: `ENTE_S3_B2_EU_CEN_ENDPOINT` -> `<LAN-IP>:3200`
+- `museum` service: `ENTE_APPS_PUBLIC_ALBUMS` -> `http://<LAN-IP>:3002`
+- `web` service: `ENTE_API_ORIGIN` -> `http://<LAN-IP>:8080`
+
+Because the web UI and object storage sit on different ports, browsers treat cross-port requests as cross-origin. For production use, front all services with a reverse proxy on a single domain, or configure MinIO CORS for your IP. See the [Ente reverse-proxy guide](https://help.ente.io/self-hosting/).
+
+## Supported platforms
+
+This app works on CasaOS, Portainer, and Dockge, which publish all container ports to the host directly. It is not supported on Umbrel, Cosmos, or Runtipi: those route a single port through a proxy, but Ente's browser client must reach the museum API (8080) and MinIO (3200) directly.
+
+## Secrets
+
+This app ships with fixed placeholder secrets so it boots out of the box. **Rotate them before real use.** In `docker-compose.yml`, change every occurrence of:
+
+- `change-me-qE7Yb2sN4wR9tK1` (database password - appears in `museum` and `postgres`)
+- `change-me-minio-vH3pL8xC0zN5` (MinIO secret - appears in `museum`, `minio`, `minio-init`)
+- `ENTE_KEY_ENCRYPTION`, `ENTE_KEY_HASH`, `ENTE_JWT_SECRET` (museum crypto keys)
+
+Generate new museum keys with Ente's tool: `go run tools/gen-random-keys/main.go` from the [ente-io/ente](https://github.com/ente-io/ente) repo.
+
+## Architecture
+
+| Service      | Purpose                                             |
+|--------------|-----------------------------------------------------|
+| `museum`     | API server (port 8080).                             |
+| `web`        | Photos web UI (3000) + public albums (3002).        |
+| `postgres`   | Application database.                               |
+| `minio`      | S3-compatible object storage (port 3200).           |
+| `socat`      | Bridges museum's `localhost:3200` to `minio:3200`.  |
+| `minio-init` | One-shot job that creates the storage buckets.      |
+
+## Links
+
+- Documentation: https://help.ente.io/self-hosting/
+- Source: https://github.com/ente-io/ente
+- Support: https://community.bigbeartechworld.com/

--- a/apps/ente/app.json
+++ b/apps/ente/app.json
@@ -61,7 +61,7 @@
       },
       {
         "name": "ENTE_JWT_SECRET",
-        "default": "",
+        "default": "i2DecQmfGreG6q1vBj5tCokhlN41gcfS2cjOs9Po-u8=",
         "description": "JWT signing secret. Rotate before real use.",
         "required": true
       }

--- a/apps/ente/app.json
+++ b/apps/ente/app.json
@@ -129,7 +129,7 @@
       "port": "3000"
     },
     "runtipi": {
-      "supported": true,
+      "supported": false,
       "tipi_version": 1,
       "supported_architectures": [
         "amd64",
@@ -147,13 +147,13 @@
       "port": "3000"
     },
     "cosmos": {
-      "supported": true,
+      "supported": false,
       "servapp": true,
       "routes_required": true,
       "port": "3000"
     },
     "umbrel": {
-      "supported": true,
+      "supported": false,
       "manifest_version": 1,
       "volume_mappings": {
         "ente_postgres_data": "postgres_data",

--- a/apps/ente/app.json
+++ b/apps/ente/app.json
@@ -1,0 +1,174 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "ente",
+    "name": "Ente Photos",
+    "description": "Ente is a self-hosted, end-to-end encrypted platform to store, share, and rediscover your photos and videos across all your devices.",
+    "tagline": "End-to-end encrypted photo storage",
+    "version": "2026.07.07",
+    "author": "BigBearTechWorld",
+    "developer": "ente-io",
+    "category": "BigBearCasaOS",
+    "license": "AGPL-3.0",
+    "homepage": "https://ente.io",
+    "source": "big-bear-universal",
+    "created": "2026-07-07T00:00:00Z",
+    "updated": "2026-07-07T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente-photos.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente-photos.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://help.ente.io/self-hosting/",
+    "repository": "https://github.com/ente-io/ente",
+    "issues": "https://github.com/ente-io/ente/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "web",
+    "default_port": "3000",
+    "main_image": "ghcr.io/ente/web",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "ENTE_S3_B2_EU_CEN_ENDPOINT",
+        "default": "localhost:3200",
+        "description": "MinIO S3 endpoint reachable by both museum and clients. Change localhost to the server LAN IP for multi-device access.",
+        "required": true
+      },
+      {
+        "name": "ENTE_API_ORIGIN",
+        "default": "http://localhost:8080",
+        "description": "URL of the museum API as reached by the web app. Change localhost to the server LAN IP for multi-device access.",
+        "required": true
+      },
+      {
+        "name": "ENTE_APPS_PUBLIC_ALBUMS",
+        "default": "http://localhost:3002",
+        "description": "Public albums URL. Change localhost to the server LAN IP for multi-device access.",
+        "required": false
+      },
+      {
+        "name": "ENTE_JWT_SECRET",
+        "default": "",
+        "description": "JWT signing secret. Rotate before real use.",
+        "required": true
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/var/lib/postgresql/data",
+        "description": "PostgreSQL database storage"
+      },
+      {
+        "container": "/data",
+        "description": "MinIO object storage (photos and videos)"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Photos web UI"
+      },
+      {
+        "container": "3002",
+        "host": "3002",
+        "protocol": "tcp",
+        "description": "Public albums"
+      },
+      {
+        "container": "8080",
+        "host": "8080",
+        "protocol": "tcp",
+        "description": "Museum API"
+      },
+      {
+        "container": "3200",
+        "host": "3200",
+        "protocol": "tcp",
+        "description": "MinIO object storage API"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3000",
+      "volume_mappings": {
+        "ente_postgres_data": "/DATA/AppData/$AppID/postgres_data",
+        "ente_minio_data": "/DATA/AppData/$AppID/minio_data"
+      },
+      "port": "3000"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "3000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "ente_postgres_data": "postgres_data",
+        "ente_minio_data": "minio_data"
+      },
+      "port": "3000"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "3000"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "ente_postgres_data": "postgres_data",
+        "ente_minio_data": "minio_data"
+      },
+      "port": "10340"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "photos",
+    "encrypted",
+    "storage"
+  ]
+}

--- a/apps/ente/docker-compose.yml
+++ b/apps/ente/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      minio:
+        condition: service_started
+      minio-init:
+        condition: service_completed_successfully
     environment:
       ENTE_DB_HOST: postgres
       ENTE_DB_PORT: "5432"

--- a/apps/ente/docker-compose.yml
+++ b/apps/ente/docker-compose.yml
@@ -1,0 +1,118 @@
+name: ente
+
+services:
+  museum:
+    image: ghcr.io/ente/server:latest@sha256:c56831e83306988b2f5ee30eee20194d6b8f848a9cc4f4afa75931722ac1086b
+    container_name: ente-museum
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ENTE_DB_HOST: postgres
+      ENTE_DB_PORT: "5432"
+      ENTE_DB_NAME: ente_db
+      ENTE_DB_USER: pguser
+      ENTE_DB_PASSWORD: change-me-qE7Yb2sN4wR9tK1
+      ENTE_DB_SSLMODE: disable
+      ENTE_S3_ARE_LOCAL_BUCKETS: "true"
+      ENTE_S3_USE_PATH_STYLE_URLS: "true"
+      ENTE_S3_B2_EU_CEN_KEY: ente-minio-access
+      ENTE_S3_B2_EU_CEN_SECRET: change-me-minio-vH3pL8xC0zN5
+      ENTE_S3_B2_EU_CEN_ENDPOINT: localhost:3200
+      ENTE_S3_B2_EU_CEN_REGION: eu-central-2
+      ENTE_S3_B2_EU_CEN_BUCKET: b2-eu-cen
+      ENTE_KEY_ENCRYPTION: yvmG/RnzKrbCb9L3mgsmoxXr9H7i2Z4qlbT0mL3ln4w=
+      ENTE_KEY_HASH: KXYiG07wC7GIgvCSdg+WmyWdXDAn6XKYJtp/wkEU7x573+byBRAYtpTP0wwvi8i/4l37uicX1dVTUzwH3sLZyw==
+      ENTE_JWT_SECRET: i2DecQmfGreG6q1vBj5tCokhlN41gcfS2cjOs9Po-u8=
+      ENTE_APPS_PUBLIC_ALBUMS: http://localhost:3002
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  socat:
+    image: alpine/socat
+    container_name: ente-socat
+    network_mode: service:museum
+    depends_on:
+      - museum
+      - minio
+    command: TCP-LISTEN:3200,fork,reuseaddr TCP:minio:3200
+    restart: unless-stopped
+
+  web:
+    image: ghcr.io/ente/web:latest@sha256:3bf4390356f57400c762dbd7ed26e5af7cc7bb2add4f627ba5481c94635f1614
+    container_name: ente-web
+    ports:
+      - "3000:3000"
+      - "3002:3002"
+    depends_on:
+      - museum
+    environment:
+      ENTE_API_ORIGIN: http://localhost:8080
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  postgres:
+    image: postgres:15
+    container_name: ente-postgres
+    environment:
+      POSTGRES_USER: pguser
+      POSTGRES_PASSWORD: change-me-qE7Yb2sN4wR9tK1
+      POSTGRES_DB: ente_db
+    volumes:
+      - ente_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pguser -d ente_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  minio:
+    image: minio/minio
+    container_name: ente-minio
+    ports:
+      - "3200:3200"
+    environment:
+      MINIO_ROOT_USER: ente-minio-access
+      MINIO_ROOT_PASSWORD: change-me-minio-vH3pL8xC0zN5
+    command: server /data --address ":3200" --console-address ":3201"
+    volumes:
+      - ente_minio_data:/data
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  minio-init:
+    image: minio/mc
+    container_name: ente-minio-init
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set ente http://minio:3200 ente-minio-access change-me-minio-vH3pL8xC0zN5; do sleep 1; done;
+      mc mb --ignore-existing ente/b2-eu-cen;
+      mc mb --ignore-existing ente/wasabi-eu-central-2-v3;
+      mc mb --ignore-existing ente/scw-eu-fr-v3;
+      exit 0;
+      "
+    networks:
+      - ente_network
+
+networks:
+  ente_network:
+    driver: bridge
+
+volumes:
+  ente_postgres_data:
+    name: ente_postgres_data
+    driver: local
+  ente_minio_data:
+    name: ente_minio_data
+    driver: local

--- a/docs/superpowers/plans/2026-07-07-ente-photos.md
+++ b/docs/superpowers/plans/2026-07-07-ente-photos.md
@@ -398,7 +398,7 @@ git commit -m "feat: add ente photos app.json (#2416)"
 
 ---
 
-### Task 3: README.md
+### Task 3: README.md ✅
 
 **Files:**
 - Create: `apps/ente/README.md`

--- a/docs/superpowers/plans/2026-07-07-ente-photos.md
+++ b/docs/superpowers/plans/2026-07-07-ente-photos.md
@@ -26,7 +26,7 @@
 
 ---
 
-### Task 1: docker-compose.yml
+### Task 1: docker-compose.yml ✅
 
 **Files:**
 - Create: `apps/ente/docker-compose.yml`
@@ -184,7 +184,7 @@ git commit -m "feat: add ente photos docker-compose (#2416)"
 
 ---
 
-### Task 2: app.json
+### Task 2: app.json ✅
 
 **Files:**
 - Create: `apps/ente/app.json`

--- a/docs/superpowers/plans/2026-07-07-ente-photos.md
+++ b/docs/superpowers/plans/2026-07-07-ente-photos.md
@@ -475,7 +475,7 @@ Expected: `README_OK`
 - [ ] **Step 3: Run the full validator (all apps) to confirm no regressions**
 
 Run: `bash scripts/validate-apps.sh 2>&1 | tail -8`
-Expected: `Passed:` count = 238, `Failed:   0 apps`.
+Expected: `Failed:   0 apps` (hard gate) and `Passed:` count = 238 (237 baseline + ente).
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-07-07-ente-photos.md
+++ b/docs/superpowers/plans/2026-07-07-ente-photos.md
@@ -1,0 +1,493 @@
+# Ente Photos App Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Ente Photos self-hosted app to the Big Bear Universal Apps catalog as `apps/ente/{docker-compose.yml,app.json,README.md}`.
+
+**Architecture:** A single clean `docker-compose.yml` with six services (museum API, web UI, postgres, minio, a socat bridge, a one-shot minio-init bucket creator), all museum config supplied inline as `ENTE_*` environment variables (no external `museum.yaml`). `app.json` carries catalog metadata + six-platform compatibility. `README.md` documents the LAN-IP edit and secret rotation.
+
+**Tech Stack:** Docker Compose, JSON (app.json), Markdown, catalog validators (`scripts/validate-apps.sh`, `.github/scripts/check-version-mismatches.js`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-07-ente-photos-design.md`.
+- App id: `ente`. Directory: `apps/ente/`.
+- No comments in `docker-compose.yml` (repo CLAUDE.md: no comments in codebase; SCHEMA.md: clean standard compose).
+- Museum image: `ghcr.io/ente/server:latest@sha256:c56831e83306988b2f5ee30eee20194d6b8f848a9cc4f4afa75931722ac1086b`.
+- Web image: `ghcr.io/ente/web:latest@sha256:3bf4390356f57400c762dbd7ed26e5af7cc7bb2add4f627ba5481c94635f1614`.
+- Infra images: `postgres:15`, `minio/minio`, `alpine/socat`, `minio/mc`.
+- Named volumes prefixed `ente_`: `ente_postgres_data`, `ente_minio_data`.
+- Network: `ente_network` (bridge).
+- `app.json` `metadata.version` = `2026.07.07`; `metadata.category` = `BigBearCasaOS`; `metadata.id` = `ente`.
+- Icon/logo URL: `https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente-photos.png` (verified 200).
+- Committed non-blank secret defaults (per repo convention): db password, minio root creds, and museum key/jwt secrets ship fixed random values, NOT blank / NOT `${VAR:-}`.
+- Restart policy `unless-stopped` on long-running services; `minio-init` carries NO restart policy.
+- Validation must show zero failed apps (baseline: 237 passed / 0 failed).
+
+---
+
+### Task 1: docker-compose.yml
+
+**Files:**
+- Create: `apps/ente/docker-compose.yml`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: service name `web` (the app.json `main_service`), main image `ghcr.io/ente/web`, ports 3000/3002/8080/3200, named volumes `ente_postgres_data` + `ente_minio_data`. Task 2's app.json references these exact names.
+
+- [ ] **Step 1: Write the compose file**
+
+Create `apps/ente/docker-compose.yml` with exactly this content:
+
+```yaml
+name: ente
+
+services:
+  museum:
+    image: ghcr.io/ente/server:latest@sha256:c56831e83306988b2f5ee30eee20194d6b8f848a9cc4f4afa75931722ac1086b
+    container_name: ente-museum
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ENTE_DB_HOST: postgres
+      ENTE_DB_PORT: "5432"
+      ENTE_DB_NAME: ente_db
+      ENTE_DB_USER: pguser
+      ENTE_DB_PASSWORD: change-me-qE7Yb2sN4wR9tK1
+      ENTE_DB_SSLMODE: disable
+      ENTE_S3_ARE_LOCAL_BUCKETS: "true"
+      ENTE_S3_USE_PATH_STYLE_URLS: "true"
+      ENTE_S3_B2_EU_CEN_KEY: ente-minio-access
+      ENTE_S3_B2_EU_CEN_SECRET: change-me-minio-vH3pL8xC0zN5
+      ENTE_S3_B2_EU_CEN_ENDPOINT: localhost:3200
+      ENTE_S3_B2_EU_CEN_REGION: eu-central-2
+      ENTE_S3_B2_EU_CEN_BUCKET: b2-eu-cen
+      ENTE_KEY_ENCRYPTION: yvmG/RnzKrbCb9L3mgsmoxXr9H7i2Z4qlbT0mL3ln4w=
+      ENTE_KEY_HASH: KXYiG07wC7GIgvCSdg+WmyWdXDAn6XKYJtp/wkEU7x573+byBRAYtpTP0wwvi8i/4l37uicX1dVTUzwH3sLZyw==
+      ENTE_JWT_SECRET: i2DecQmfGreG6q1vBj5tCokhlN41gcfS2cjOs9Po-u8=
+      ENTE_APPS_PUBLIC_ALBUMS: http://localhost:3002
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  socat:
+    image: alpine/socat
+    container_name: ente-socat
+    network_mode: service:museum
+    depends_on:
+      - museum
+      - minio
+    command: TCP-LISTEN:3200,fork,reuseaddr TCP:minio:3200
+    restart: unless-stopped
+
+  web:
+    image: ghcr.io/ente/web:latest@sha256:3bf4390356f57400c762dbd7ed26e5af7cc7bb2add4f627ba5481c94635f1614
+    container_name: ente-web
+    ports:
+      - "3000:3000"
+      - "3002:3002"
+    depends_on:
+      - museum
+    environment:
+      ENTE_API_ORIGIN: http://localhost:8080
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  postgres:
+    image: postgres:15
+    container_name: ente-postgres
+    environment:
+      POSTGRES_USER: pguser
+      POSTGRES_PASSWORD: change-me-qE7Yb2sN4wR9tK1
+      POSTGRES_DB: ente_db
+    volumes:
+      - ente_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pguser -d ente_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  minio:
+    image: minio/minio
+    container_name: ente-minio
+    ports:
+      - "3200:3200"
+    environment:
+      MINIO_ROOT_USER: ente-minio-access
+      MINIO_ROOT_PASSWORD: change-me-minio-vH3pL8xC0zN5
+    command: server /data --address ":3200" --console-address ":3201"
+    volumes:
+      - ente_minio_data:/data
+    restart: unless-stopped
+    networks:
+      - ente_network
+
+  minio-init:
+    image: minio/mc
+    container_name: ente-minio-init
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set ente http://minio:3200 ente-minio-access change-me-minio-vH3pL8xC0zN5; do sleep 1; done;
+      mc mb --ignore-existing ente/b2-eu-cen;
+      mc mb --ignore-existing ente/wasabi-eu-central-2-v3;
+      mc mb --ignore-existing ente/scw-eu-fr-v3;
+      exit 0;
+      "
+    networks:
+      - ente_network
+
+networks:
+  ente_network:
+    driver: bridge
+
+volumes:
+  ente_postgres_data:
+    name: ente_postgres_data
+    driver: local
+  ente_minio_data:
+    name: ente_minio_data
+    driver: local
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run: `yq eval '.' apps/ente/docker-compose.yml > /dev/null && echo YAML_OK`
+Expected: `YAML_OK`
+
+- [ ] **Step 3: Verify compose is structurally valid**
+
+Run: `docker compose -f apps/ente/docker-compose.yml config >/dev/null 2>&1 && echo COMPOSE_OK || echo COMPOSE_CHECK_SKIPPED`
+Expected: `COMPOSE_OK` (if docker unavailable in the sandbox, `COMPOSE_CHECK_SKIPPED` is acceptable — the yq check in Step 2 is the hard gate).
+
+- [ ] **Step 4: Verify no comments in the file**
+
+Run: `grep -c '^\s*#' apps/ente/docker-compose.yml || true`
+Expected: `0` (no comment lines).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ente/docker-compose.yml
+git commit -m "feat: add ente photos docker-compose (#2416)"
+```
+
+---
+
+### Task 2: app.json
+
+**Files:**
+- Create: `apps/ente/app.json`
+
+**Interfaces:**
+- Consumes: from Task 1 — `main_service` is `web`, `main_image` is `ghcr.io/ente/web`, ports 3000/3002/8080/3200, volumes `ente_postgres_data`/`ente_minio_data`.
+- Produces: a schema-valid app manifest that `scripts/validate-apps.sh -a ente` passes.
+
+- [ ] **Step 1: Write the app.json**
+
+Create `apps/ente/app.json` with exactly this content:
+
+```json
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "ente",
+    "name": "Ente Photos",
+    "description": "Ente is a self-hosted, end-to-end encrypted platform to store, share, and rediscover your photos and videos across all your devices.",
+    "tagline": "End-to-end encrypted photo storage",
+    "version": "2026.07.07",
+    "author": "BigBearTechWorld",
+    "developer": "ente-io",
+    "category": "BigBearCasaOS",
+    "license": "AGPL-3.0",
+    "homepage": "https://ente.io",
+    "source": "big-bear-universal",
+    "created": "2026-07-07T00:00:00Z",
+    "updated": "2026-07-07T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente-photos.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente-photos.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://help.ente.io/self-hosting/",
+    "repository": "https://github.com/ente-io/ente",
+    "issues": "https://github.com/ente-io/ente/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "web",
+    "default_port": "3000",
+    "main_image": "ghcr.io/ente/web",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "ENTE_S3_B2_EU_CEN_ENDPOINT",
+        "default": "localhost:3200",
+        "description": "MinIO S3 endpoint reachable by both museum and clients. Change localhost to the server LAN IP for multi-device access.",
+        "required": true
+      },
+      {
+        "name": "ENTE_API_ORIGIN",
+        "default": "http://localhost:8080",
+        "description": "URL of the museum API as reached by the web app. Change localhost to the server LAN IP for multi-device access.",
+        "required": true
+      },
+      {
+        "name": "ENTE_APPS_PUBLIC_ALBUMS",
+        "default": "http://localhost:3002",
+        "description": "Public albums URL. Change localhost to the server LAN IP for multi-device access.",
+        "required": false
+      },
+      {
+        "name": "ENTE_JWT_SECRET",
+        "default": "",
+        "description": "JWT signing secret. Rotate before real use.",
+        "required": true
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/var/lib/postgresql/data",
+        "description": "PostgreSQL database storage"
+      },
+      {
+        "container": "/data",
+        "description": "MinIO object storage (photos and videos)"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Photos web UI"
+      },
+      {
+        "container": "3002",
+        "host": "3002",
+        "protocol": "tcp",
+        "description": "Public albums"
+      },
+      {
+        "container": "8080",
+        "host": "8080",
+        "protocol": "tcp",
+        "description": "Museum API"
+      },
+      {
+        "container": "3200",
+        "host": "3200",
+        "protocol": "tcp",
+        "description": "MinIO object storage API"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3000",
+      "volume_mappings": {
+        "ente_postgres_data": "/DATA/AppData/$AppID/postgres_data",
+        "ente_minio_data": "/DATA/AppData/$AppID/minio_data"
+      },
+      "port": "3000"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "3000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "ente_postgres_data": "postgres_data",
+        "ente_minio_data": "minio_data"
+      },
+      "port": "3000"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "3000"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "ente_postgres_data": "postgres_data",
+        "ente_minio_data": "minio_data"
+      },
+      "port": "10340"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "photos",
+    "encrypted",
+    "storage"
+  ]
+}
+```
+
+- [ ] **Step 2: Verify JSON syntax**
+
+Run: `jq empty apps/ente/app.json && echo JSON_OK`
+Expected: `JSON_OK`
+
+- [ ] **Step 3: Run the app validator for ente**
+
+Run: `bash scripts/validate-apps.sh -a ente 2>&1 | tail -15`
+Expected: output contains `[✓] ente: PASSED` and `Failed:   0 apps`.
+
+- [ ] **Step 4: Run the version-mismatch checker**
+
+Run: `bun .github/scripts/check-version-mismatches.js 2>&1 | grep -iE "ente|mismatch" | head`
+Expected: no line reporting an `ente` mismatch (ente uses a digest-pinned `latest` tag, treated as non-semver and skipped).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ente/app.json
+git commit -m "feat: add ente photos app.json (#2416)"
+```
+
+---
+
+### Task 3: README.md
+
+**Files:**
+- Create: `apps/ente/README.md`
+
+**Interfaces:**
+- Consumes: env var names + ports from Tasks 1-2.
+- Produces: user-facing docs (no downstream consumer).
+
+- [ ] **Step 1: Write the README**
+
+Create `apps/ente/README.md` with exactly this content:
+
+````markdown
+# Ente Photos
+
+Self-hosted, end-to-end encrypted photo and video storage.
+
+## Access
+
+- Photos web UI: `http://<server>:3000`
+- Public albums: `http://<server>:3002`
+- Museum API: `http://<server>:8080`
+- MinIO object storage: `http://<server>:3200`
+
+On first launch, create an account through the web UI. The verification code (OTP) is printed in the `ente-museum` container logs:
+
+```bash
+docker logs ente-museum 2>&1 | grep -i "verification code"
+```
+
+## Multi-device access (required for use beyond the host)
+
+Ente stores object URLs and the API origin using `localhost`, which only resolves on the server itself. To use Ente from another device (phone, laptop), replace `localhost` with your server's LAN IP (e.g. `192.168.1.50`) in `docker-compose.yml`:
+
+- `museum` service: `ENTE_S3_B2_EU_CEN_ENDPOINT` → `<LAN-IP>:3200`
+- `museum` service: `ENTE_APPS_PUBLIC_ALBUMS` → `http://<LAN-IP>:3002`
+- `web` service: `ENTE_API_ORIGIN` → `http://<LAN-IP>:8080`
+
+Because the web UI and object storage sit on different ports, browsers treat cross-port requests as cross-origin. For production use, front all services with a reverse proxy on a single domain, or configure MinIO CORS for your IP. See the [Ente reverse-proxy guide](https://help.ente.io/self-hosting/).
+
+## Secrets
+
+This app ships with fixed placeholder secrets so it boots out of the box. **Rotate them before real use.** In `docker-compose.yml`, change every occurrence of:
+
+- `change-me-qE7Yb2sN4wR9tK1` (database password — appears in `museum` and `postgres`)
+- `change-me-minio-vH3pL8xC0zN5` (MinIO secret — appears in `museum`, `minio`, `minio-init`)
+- `ENTE_KEY_ENCRYPTION`, `ENTE_KEY_HASH`, `ENTE_JWT_SECRET` (museum crypto keys)
+
+Generate new museum keys with Ente's tool: `go run tools/gen-random-keys/main.go` from the [ente-io/ente](https://github.com/ente-io/ente) repo.
+
+## Architecture
+
+| Service      | Purpose                                             |
+|--------------|-----------------------------------------------------|
+| `museum`     | API server (port 8080).                             |
+| `web`        | Photos web UI (3000) + public albums (3002).        |
+| `postgres`   | Application database.                               |
+| `minio`      | S3-compatible object storage (port 3200).           |
+| `socat`      | Bridges museum's `localhost:3200` to `minio:3200`.  |
+| `minio-init` | One-shot job that creates the storage buckets.      |
+
+## Links
+
+- Documentation: https://help.ente.io/self-hosting/
+- Source: https://github.com/ente-io/ente
+- Support: https://community.bigbeartechworld.com/
+````
+
+- [ ] **Step 2: Verify the file is non-empty Markdown**
+
+Run: `test -s apps/ente/README.md && echo README_OK`
+Expected: `README_OK`
+
+- [ ] **Step 3: Run the full validator (all apps) to confirm no regressions**
+
+Run: `bash scripts/validate-apps.sh 2>&1 | tail -8`
+Expected: `Passed:` count = 238, `Failed:   0 apps`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ente/README.md
+git commit -m "docs: add ente photos README (#2416)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** museum-via-env (§1) → Task 1 env block; committed secrets (§2) → Task 1 fixed values + Task 3 rotation docs; LAN-IP caveat (§3) → Task 3 multi-device section + Task 2 env descriptions; minio-init bucket bootstrap (§4) → Task 1 `minio-init` service; web frontend (§5) → Task 1 `web` service; image pinning (§6) → Global Constraints + Task 1 images. app.json structure → Task 2. compose structure → Task 1. Success criteria 1-6 → Task verify steps.
+- **No placeholders:** all file bodies are complete literal content.
+- **Type/name consistency:** `main_service: web` matches the `web` service in compose; volume names `ente_postgres_data`/`ente_minio_data` identical across compose + app.json volume_mappings; secret placeholder strings identical across the services that share them.

--- a/docs/superpowers/specs/2026-07-07-ente-photos-design.md
+++ b/docs/superpowers/specs/2026-07-07-ente-photos-design.md
@@ -18,6 +18,7 @@ Ente self-hosting requires five cooperating containers:
 | `postgres`| `postgres:15`              | Application database.                                          |
 | `minio`   | `minio/minio`              | S3-compatible object storage (port 3200).                     |
 | `socat`   | `alpine/socat`             | TCP bridge so `museum` resolves `localhost:3200` → `minio:3200`. |
+| `minio-init` | `minio/mc`              | One-shot job: creates the three S3 buckets, then exits.       |
 
 The museum server accepts **all** configuration via environment variables using the `ENTE_` prefix with underscores replacing nesting and hyphens (e.g. `db.user` → `ENTE_DB_USER`, `s3.b2-eu-cen.key` → `ENTE_S3_B2_EU_CEN_KEY`). This lets us avoid the separate `museum.yaml` file that the official quickstart generates — the catalog format supports only `app.json` + `docker-compose.yml`, so a mounted config file is not an option.
 
@@ -44,7 +45,7 @@ MinIO presigned URLs and the web API origin embed `localhost`, which works on th
 
 ### 4. MinIO bucket bootstrap
 
-MinIO's three buckets (`b2-eu-cen`, `wasabi-eu-central-2-v3`, `scw-eu-fr-v3`) are created via a `MINIO_DEFAULT_BUCKETS` environment variable on the minio service. Only `b2-eu-cen` is functionally required (replication is off by default), but all three are created to match Ente's expectations and avoid startup warnings. If `MINIO_DEFAULT_BUCKETS` proves unreliable across the minio image version, fall back to a lightweight one-shot `minio/mc` init service that creates the buckets and exits (validated during implementation).
+MinIO's three buckets (`b2-eu-cen`, `wasabi-eu-central-2-v3`, `scw-eu-fr-v3`) are created by a dedicated one-shot `minio-init` service running `minio/mc`. It waits for minio to be reachable, sets a `mc` alias with the root credentials, runs `mc mb --ignore-existing` for each bucket, then exits `0`. This is chosen over minio's `post_start` lifecycle hook (requires compose spec ≥ 2.30 and is stripped by some platform converters) and over `MINIO_DEFAULT_BUCKETS` (unused by any existing catalog app, no confirmed support in the pinned image). The init service uses `depends_on: minio` and does not carry a `restart` policy (it must run once and stay exited). Only `b2-eu-cen` is functionally required (replication is off by default); all three are created to match Ente's expectations and avoid museum startup warnings.
 
 ### 5. Web frontend
 
@@ -81,7 +82,8 @@ services:
   socat:       # alpine/socat, network_mode: service:museum, forwards :3200 → minio:3200
   web:         # ghcr.io/ente/web, ports 3000 + 3002, ENTE_API_ORIGIN
   postgres:    # postgres:15, healthcheck, named volume
-  minio:       # minio/minio, port 3200, MINIO_DEFAULT_BUCKETS, named volume
+  minio:       # minio/minio, port 3200, named volume
+  minio-init:  # minio/mc, one-shot bucket creation, depends_on minio, no restart
 volumes:
   ente_postgres_data
   ente_minio_data
@@ -101,7 +103,7 @@ Restart policy `unless-stopped`, explicit `container_name`, named volumes with `
 ## Success Criteria
 
 1. `apps/ente/{app.json,docker-compose.yml,README.md}` created.
-2. `scripts/validate-apps.sh` reports `ente: PASSED` and total pass count = 238.
+2. `scripts/validate-apps.sh` reports `ente: PASSED` with zero failed apps (baseline was 237 passed / 0 failed; ente adds one more passing app).
 3. `bun .github/scripts/check-version-mismatches.js` reports no mismatch for `ente`.
 4. `docker-compose.yml` is valid YAML and parses via `docker compose config`.
 5. README documents the LAN-IP edit, secret rotation, and default login flow.

--- a/docs/superpowers/specs/2026-07-07-ente-photos-design.md
+++ b/docs/superpowers/specs/2026-07-07-ente-photos-design.md
@@ -1,0 +1,108 @@
+# Ente Photos — Universal App Design
+
+Issue: [#2416](https://github.com/bigbeartechworld/big-bear-universal-apps/issues/2416)
+Branch: `feat/add-ente-photos`
+
+## Goal
+
+Add Ente Photos, a self-hosted end-to-end-encrypted photo storage service, to the Big Bear Universal Apps catalog as a new app (`apps/ente/`) consisting of `app.json` + `docker-compose.yml` + `README.md`, passing `scripts/validate-apps.sh` and the CI version-mismatch check.
+
+## Background
+
+Ente self-hosting requires five cooperating containers:
+
+| Service   | Image                      | Purpose                                                        |
+|-----------|----------------------------|---------------------------------------------------------------|
+| `museum`  | `ghcr.io/ente/server`      | API server (port 8080). Reads config from env vars.           |
+| `web`     | `ghcr.io/ente/web`         | Photos web UI (port 3000) + public albums (3002).             |
+| `postgres`| `postgres:15`              | Application database.                                          |
+| `minio`   | `minio/minio`              | S3-compatible object storage (port 3200).                     |
+| `socat`   | `alpine/socat`             | TCP bridge so `museum` resolves `localhost:3200` → `minio:3200`. |
+
+The museum server accepts **all** configuration via environment variables using the `ENTE_` prefix with underscores replacing nesting and hyphens (e.g. `db.user` → `ENTE_DB_USER`, `s3.b2-eu-cen.key` → `ENTE_S3_B2_EU_CEN_KEY`). This lets us avoid the separate `museum.yaml` file that the official quickstart generates — the catalog format supports only `app.json` + `docker-compose.yml`, so a mounted config file is not an option.
+
+## Design Decisions
+
+### 1. Configuration via environment variables (no museum.yaml)
+
+All museum config is inlined as `ENTE_*` environment variables in the compose file. This keeps the app within the catalog's two-file format. Required config surface:
+
+- **DB:** `ENTE_DB_HOST=postgres`, `ENTE_DB_PORT=5432`, `ENTE_DB_NAME=ente_db`, `ENTE_DB_USER`, `ENTE_DB_PASSWORD`, `ENTE_DB_SSLMODE=disable`.
+- **S3/MinIO** (bucket key `b2-eu-cen`, the default hot storage): `ENTE_S3_B2_EU_CEN_KEY`, `ENTE_S3_B2_EU_CEN_SECRET`, `ENTE_S3_B2_EU_CEN_ENDPOINT=localhost:3200`, `ENTE_S3_B2_EU_CEN_REGION=eu-central-2`, `ENTE_S3_B2_EU_CEN_BUCKET=b2-eu-cen`, plus the local-minio workarounds `ENTE_S3_ARE_LOCAL_BUCKETS=true` and `ENTE_S3_USE_PATH_STYLE_URLS=true`.
+- **Secrets:** `ENTE_KEY_ENCRYPTION`, `ENTE_KEY_HASH`, `ENTE_JWT_SECRET`.
+- **App endpoints:** `ENTE_APPS_PUBLIC_ALBUMS=http://localhost:3002`.
+
+The `socat` bridge listens on port 3200 inside museum's network namespace and forwards to `minio:3200`, so museum's `localhost:3200` endpoint resolves. This mirrors Ente's official quickstart compose exactly.
+
+### 2. Committed secret defaults (not blank)
+
+`ENTE_KEY_ENCRYPTION`, `ENTE_KEY_HASH`, `ENTE_JWT_SECRET`, `ENTE_DB_PASSWORD`, and the MinIO root credentials ship with fixed committed random values (base64, generated once for this app), **not** blank and not `${VAR:-}`. Rationale: consistent with the repo's committed-password-defaults convention — CasaOS/Portainer render these as real editable fields, and the app boots working out of the box. The README instructs users to rotate them for real use.
+
+### 3. LAN-IP caveat documented, not automated
+
+MinIO presigned URLs and the web API origin embed `localhost`, which works on the host but **not** from other devices on the LAN. A static compose cannot know the server's LAN IP. Following the same convention as `immich` and other catalog apps, the app ships with working `localhost` defaults and the README documents the single edit needed for multi-device access: replace `localhost` with the server's LAN IP in `ENTE_S3_B2_EU_CEN_ENDPOINT`, `ENTE_APPS_PUBLIC_ALBUMS`, the web `ENTE_API_ORIGIN`, and MinIO CORS. No `${SERVER_IP}` env with a broken blank default; no bundled reverse proxy (out of scope, diverges from the single-purpose compose pattern).
+
+### 4. MinIO bucket bootstrap
+
+MinIO's three buckets (`b2-eu-cen`, `wasabi-eu-central-2-v3`, `scw-eu-fr-v3`) are created via a `MINIO_DEFAULT_BUCKETS` environment variable on the minio service. Only `b2-eu-cen` is functionally required (replication is off by default), but all three are created to match Ente's expectations and avoid startup warnings. If `MINIO_DEFAULT_BUCKETS` proves unreliable across the minio image version, fall back to a lightweight one-shot `minio/mc` init service that creates the buckets and exits (validated during implementation).
+
+### 5. Web frontend
+
+The `web` service exposes port 3000 (Photos) and 3002 (public albums), with `ENTE_API_ORIGIN=http://localhost:8080` pointing at museum. Additional web sub-apps (accounts 3001, cast 3004, etc.) are **out of scope** for v1 — Photos + public albums cover the issue's request. This keeps the compose focused; the README notes how to enable others.
+
+### 6. Image pinning
+
+`museum` and `web` pin to `latest@sha256:<digest>` (Ente publishes no semver tags — only `latest` + SHA digests):
+
+- `ghcr.io/ente/server:latest@sha256:c56831e83306988b2f5ee30eee20194d6b8f848a9cc4f4afa75931722ac1086b`
+- `ghcr.io/ente/web:latest@sha256:3bf4390356f57400c762dbd7ed26e5af7cc7bb2add4f627ba5481c94635f1614`
+
+The `latest` tag keeps the line human-readable; the digest pins reproducibility. The CI version-mismatch checker (`:([^:]+)$` regex) extracts the digest hex, which fails the `^(v)?\d+` semver test and is skipped as a non-semver tag — no false mismatch. `postgres:15`, `minio/minio`, and `alpine/socat` follow the catalog's existing infra-image conventions (postgres pinned to major tag, renovate-disabled for db images).
+
+`app.json` `metadata.version` = `2026.07.07` (date stamp, since upstream has no semver).
+
+## app.json Structure
+
+Follows the `immich` app.json as the template (closest analog — multi-service photo app):
+
+- `metadata`: id `ente`, name `Ente Photos`, category `BigBearCasaOS`, developer `ente-io`, homepage `https://ente.io`, description of E2E-encrypted photo storage.
+- `technical`: `main_service: web`, `default_port: 3000`, `main_image: ghcr.io/ente/web`, architectures `[amd64, arm64]`.
+- `deployment`: document the key env vars, volumes (postgres data, minio data), and ports (3000, 3002, 8080, 3200).
+- `visual`: icon/logo from `https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente.png` (verify existence during implementation; fall back to Ente's official logo URL if absent).
+- `compatibility`: all six platforms (casaos, portainer, runtipi, dockge, cosmos, umbrel) with volume_mappings + port overrides mirroring immich. Umbrel gets a 10xxx host port.
+- `resources`: documentation `https://help.ente.io/self-hosting/`, repository `https://github.com/ente-io/ente`, support community URL.
+
+## docker-compose.yml Structure
+
+```
+name: ente
+services:
+  museum:      # ghcr.io/ente/server, port 8080, ENTE_* env, depends_on postgres (healthy)
+  socat:       # alpine/socat, network_mode: service:museum, forwards :3200 → minio:3200
+  web:         # ghcr.io/ente/web, ports 3000 + 3002, ENTE_API_ORIGIN
+  postgres:    # postgres:15, healthcheck, named volume
+  minio:       # minio/minio, port 3200, MINIO_DEFAULT_BUCKETS, named volume
+volumes:
+  ente_postgres_data
+  ente_minio_data
+networks:
+  ente_network (bridge)
+```
+
+Restart policy `unless-stopped`, explicit `container_name`, named volumes with `ente_` prefix (matches immich convention for the platform converters' volume_mappings).
+
+## Out of Scope
+
+- Reverse proxy / single-origin setup.
+- Web sub-apps beyond Photos + public albums (accounts, cast, auth, locker).
+- Object-storage replication (off by default upstream).
+- SMTP/Stripe/passkey/Discord integrations (all optional upstream, blank by default).
+
+## Success Criteria
+
+1. `apps/ente/{app.json,docker-compose.yml,README.md}` created.
+2. `scripts/validate-apps.sh` reports `ente: PASSED` and total pass count = 238.
+3. `bun .github/scripts/check-version-mismatches.js` reports no mismatch for `ente`.
+4. `docker-compose.yml` is valid YAML and parses via `docker compose config`.
+5. README documents the LAN-IP edit, secret rotation, and default login flow.
+6. app.json validates against `schemas/app-schema-v1.json`.

--- a/docs/superpowers/specs/2026-07-07-ente-photos-design.md
+++ b/docs/superpowers/specs/2026-07-07-ente-photos-design.md
@@ -70,7 +70,7 @@ Follows the `immich` app.json as the template (closest analog — multi-service 
 - `technical`: `main_service: web`, `default_port: 3000`, `main_image: ghcr.io/ente/web`, architectures `[amd64, arm64]`.
 - `deployment`: document the key env vars, volumes (postgres data, minio data), and ports (3000, 3002, 8080, 3200).
 - `visual`: icon/logo from `https://cdn.jsdelivr.net/gh/selfhst/icons/png/ente.png` (verify existence during implementation; fall back to Ente's official logo URL if absent).
-- `compatibility`: all six platforms (casaos, portainer, runtipi, dockge, cosmos, umbrel) with volume_mappings + port overrides mirroring immich. Umbrel gets a 10xxx host port.
+- `compatibility`: `casaos`, `portainer`, `dockge` supported (they publish all ports to the host directly). `runtipi`, `cosmos`, `umbrel` set `supported: false` — Ente's browser client reaches the museum API (:8080) and MinIO (:3200) as separate origins, which single-port-proxy platforms cannot serve (UI loads but login/upload fails). Same precedent as host-network apps that only ship platforms where they actually work. Volume_mappings + port overrides mirror immich.
 - `resources`: documentation `https://help.ente.io/self-hosting/`, repository `https://github.com/ente-io/ente`, support community URL.
 
 ## docker-compose.yml Structure


### PR DESCRIPTION
Adds Ente Photos, a self-hosted end-to-end encrypted photo store (museum + web + postgres + minio + socat bridge + bucket bootstrap). All config inlined as ENTE_* env vars; ships working localhost defaults with README docs for the LAN-IP edit. Supported on CasaOS/Portainer/Dockge only — single-port-proxy platforms can't serve Ente's multi-origin browser requests. Also fixes the version-mismatch CI scripts to skip digest-pinned images.

Closes #2416

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Ente Photos — a self-hosted, E2E-encrypted photo storage service — to the app catalog as a 6-service Docker Compose stack (museum API, web UI, PostgreSQL, MinIO, socat bridge, and a one-shot bucket-init container). It also fixes the CI version-mismatch scripts to correctly skip digest-pinned images.

- **`apps/ente/`**: New app with `docker-compose.yml`, `app.json`, and `README.md`. The compose uses digest-pinned images for the two Ente services and a socat sidecar to bridge museum's `localhost:3200` to the MinIO container; platform compatibility is correctly restricted to CasaOS, Portainer, and Dockge.
- **`.github/scripts/`**: Both `check-version-mismatches.js` and `fix-version-mismatches.js` gain an early-exit guard for images containing `@` (digest-pinned), preventing false mismatch reports on the new app.
- **`docs/superpowers/`**: Internal spec and plan documents describing the design decisions and implementation checklist.

<h3>Confidence Score: 3/5</h3>

The CI scripts and documentation are safe. The compose file needs attention before merging for a service marketed as end-to-end encrypted.

The most significant concern is in docker-compose.yml: ENTE_KEY_ENCRYPTION, ENTE_KEY_HASH, and ENTE_JWT_SECRET are committed as fixed known values in a public repository. For a service whose primary selling point is end-to-end encryption, these keys are not equivalent to a typical database password — they protect the ciphertext itself. Any user who deploys without rotating them immediately has data encrypted with publicly known key material, and the git history makes those values permanent even after a local edit. There is also a startup race between museum and the socat sidecar, and infra images carry no version pin.

apps/ente/docker-compose.yml — the crypto key defaults and socat dependency ordering need review

<details open><summary><h3>Security Review</h3></summary>

- **Published cryptographic master keys** (`apps/ente/docker-compose.yml` lines 30–32): `ENTE_KEY_ENCRYPTION` and `ENTE_KEY_HASH` are committed as fixed known values in a public repository. These keys govern the E2E encryption of all stored photos and videos. Any deployment that launches without rotating them uses publicly known key material, completely undermining the advertised end-to-end encryption guarantee. The values are also permanently recorded in git history. `ENTE_JWT_SECRET` on the same lines is similarly a known value that allows JWT forgery.
- **Default credentials in public repo**: `ENTE_DB_PASSWORD` and `MINIO_ROOT_PASSWORD` are committed as recognizable placeholder strings. The repo convention explicitly allows this pattern and the README documents rotation — but the elevated risk here versus a typical selfhosted app is that the service is advertised as E2E-encrypted, creating a higher expectation of out-of-box security.
- **MinIO console port (3201) not exposed**: The admin console is not exposed in the port mappings, which is a positive security choice.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/ente/docker-compose.yml | New 6-service Ente Photos compose: museum, web, postgres, minio, socat sidecar, and minio-init bootstrap. Contains hardcoded published crypto keys (ENTE_KEY_ENCRYPTION / ENTE_KEY_HASH) and a socat startup race; infra images also lack version pins. |
| apps/ente/app.json | New catalog manifest: schema v1.0, correct platform compatibility flags (runtipi/cosmos/umbrel marked unsupported as documented), standard metadata and port mapping. ENTE_KEY_ENCRYPTION and ENTE_KEY_HASH are absent from the deployment env-var list, so CasaOS/Portainer UIs won't prompt users to rotate the most sensitive secrets. |
| apps/ente/README.md | New user-facing README: covers access URLs, OTP log retrieval, multi-device LAN-IP edit, secret rotation guide, and architecture table. Complete and accurate. |
| .github/scripts/check-version-mismatches.js | Adds early-exit for digest-pinned images (those containing '@'). Correctly pushes them to noVersion with 'digest-pinned' label so they appear in the informational report without triggering a mismatch failure. |
| .github/scripts/fix-version-mismatches.js | Adds matching early-continue for digest-pinned images, preventing the fix script from incorrectly patching a digest hex as a version string. Clean and correct. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant web as web 3000/3002
    participant museum as museum 8080
    participant socat as socat sidecar
    participant postgres as postgres 5432
    participant minio as minio 3200
    participant init as minio-init one-shot

    Note over postgres: starts and healthcheck passes
    Note over minio: starts service_started
    init->>minio: poll until mc alias set responds
    init->>minio: mc mb b2-eu-cen wasabi scw
    Note over init: exits 0 service_completed_successfully
    Note over museum: starts after postgres minio init
    Note over socat: starts after museum
    socat-->>museum: binds localhost:3200 in museum network namespace

    Browser->>web: GET server port 3000
    web-->>Browser: SPA assets with ENTE_API_ORIGIN embedded
    Browser->>museum: API calls to localhost 8080
    museum->>socat: S3 request to localhost 3200
    socat->>minio: TCP forward to minio 3200
    minio-->>socat: object data
    socat-->>museum: forwarded response
    museum-->>Browser: API response and presigned URLs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant web as web 3000/3002
    participant museum as museum 8080
    participant socat as socat sidecar
    participant postgres as postgres 5432
    participant minio as minio 3200
    participant init as minio-init one-shot

    Note over postgres: starts and healthcheck passes
    Note over minio: starts service_started
    init->>minio: poll until mc alias set responds
    init->>minio: mc mb b2-eu-cen wasabi scw
    Note over init: exits 0 service_completed_successfully
    Note over museum: starts after postgres minio init
    Note over socat: starts after museum
    socat-->>museum: binds localhost:3200 in museum network namespace

    Browser->>web: GET server port 3000
    web-->>Browser: SPA assets with ENTE_API_ORIGIN embedded
    Browser->>museum: API calls to localhost 8080
    museum->>socat: S3 request to localhost 3200
    socat->>minio: TCP forward to minio 3200
    minio-->>socat: object data
    socat-->>museum: forwarded response
    museum-->>Browser: API response and presigned URLs
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/ente/docker-compose.yml:30-32
**Known encryption keys published to a public repo**

`ENTE_KEY_ENCRYPTION` and `ENTE_KEY_HASH` are the museum server's master cryptographic keys — they protect the encryption of every user's photo library. Publishing fixed, known values for these in a public git repo means any deployment that goes live without rotating them has broken E2E encryption: anyone with access to this repo's history can derive the effective key material. Unlike a database password (which controls access), these keys protect the ciphertext itself. Once data is written with the published keys it cannot be re-encrypted just by updating the compose file later; the original keys remain in git history. A `.env.example` pattern, or generating keys at first boot via an entrypoint script, avoids permanently recording them. The `ENTE_JWT_SECRET` is also in the same position — a leaked JWT secret lets an attacker forge authentication tokens.

### Issue 2 of 3
apps/ente/docker-compose.yml:38-46
**Startup ordering: socat binds after museum is already running**

`socat` depends on `museum` (`service_started`), but museum's `ENTE_S3_B2_EU_CEN_ENDPOINT` points to `localhost:3200` — a port that socat won't bind until after museum is already up. In the gap between museum starting and socat binding port 3200 in museum's network namespace, any museum code that eagerly validates its S3 connection (e.g. health-check probes or startup migrations) will receive `ECONNREFUSED`. The inverse dependency isn't expressible with `network_mode: service:museum` (socat must start after museum to share its namespace), but museum could add a startup retry loop or socat's readiness could be confirmed by a wrapper script before museum serves traffic.

### Issue 3 of 3
apps/ente/docker-compose.yml:39
**Unversioned infra images**

`alpine/socat`, `minio/minio`, and `minio/mc` (line 97) carry no tag and no digest, so `docker compose pull` on a fresh host can silently pick up a different version than was tested. The museum and web images are correctly pinned with `latest@sha256:…`. Pinning the infra images (e.g. `minio/minio:RELEASE.2024-XX-XX`, `minio/mc:RELEASE.2024-XX-XX`, `alpine/socat:1.8.0.0`) or at minimum adding a digest provides the same reproducibility guarantees.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: populate ente jwt secret default so..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/6b7f6ece64180596e7c1f83f034ee2adb8f1c4f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42521355)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->