### PR TITLE
fix(wg-easy-v15): map /dev/net/tun for userspace fallback on ZimaOS

### DIFF
--- a/apps/wg-easy-v15/docker-compose.yml
+++ b/apps/wg-easy-v15/docker-compose.yml
@@ -35,6 +35,10 @@ services:
       - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv6.conf.all.forwarding=1
       - net.ipv6.conf.default.forwarding=1
+    # Devices mapped from host to container
+    devices:
+      # Map the TUN device so wg-easy can use its userspace wireguard-go fallback on hosts without the WireGuard kernel module (e.g. ZimaOS 1.6.2+)
+      - /dev/net/tun:/dev/net/tun
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local wg-easy-v15_data directory to /etc/wireguard inside the container

--- a/apps/wg-easy/docker-compose.yml
+++ b/apps/wg-easy/docker-compose.yml
@@ -27,6 +27,10 @@ services:
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv4.ip_forward=1
+    # Devices mapped from host to container
+    devices:
+      # Map the TUN device so wg-easy can use its userspace wireguard-go fallback on hosts without the WireGuard kernel module (e.g. ZimaOS 1.6.2+)
+      - /dev/net/tun:/dev/net/tun
     # Volumes to be mounted to the container
     volumes:
       # Mounting the local wg-easy_data directory to /etc/wireguard inside the container


### PR DESCRIPTION
Fixes bigbeartechworld/big-bear-casaos#6299

ZimaOS 1.6.2 dropped the WireGuard kernel module, so wg-easy failed with `wg show wg0 dump: No such device`. Mapping `/dev/net/tun` lets wg-easy's bundled wireguard-go userspace fallback create the interface; kernel-capable hosts are unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR maps `/dev/net/tun` from host into both `wg-easy` and `wg-easy-v15` containers so that wg-easy's bundled `wireguard-go` userspace implementation can create a TUN interface on ZimaOS 1.6.2+, which dropped the WireGuard kernel module. Hosts that retain the kernel module are unaffected — the kernel path continues to take precedence.

- **`apps/wg-easy-v15/docker-compose.yml`**: adds the `devices` block with `/dev/net/tun:/dev/net/tun` alongside the existing `NET_ADMIN`/`SYS_MODULE` capabilities and network sysctls.
- **`apps/wg-easy/docker-compose.yml`**: same device mapping applied to the companion non-versioned app (which also targets `wg-easy:15`), keeping both configs in sync for ZimaOS users.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, targeted, and consistent across both app configs.

Both files receive the same one-block addition of `/dev/net/tun` device passthrough. The mapping is additive and does not alter any existing capability, sysctl, volume, or port configuration. On hosts with the WireGuard kernel module the container behaviour is unchanged; on ZimaOS 1.6.2+ hosts it enables the wireguard-go fallback that was previously unavailable. No credentials, secrets, or data paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/wg-easy-v15/docker-compose.yml | Adds `/dev/net/tun` device mapping to enable wireguard-go userspace fallback on ZimaOS 1.6.2+ hosts that lack the WireGuard kernel module. |
| apps/wg-easy/docker-compose.yml | Same `/dev/net/tun` device mapping applied to the non-versioned wg-easy app (also using image `wg-easy:15`), ensuring both apps receive the ZimaOS fix consistently. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Container starts] --> B{WireGuard kernel\nmodule present?}
    B -- Yes --> C[wg-easy uses\nkernel WireGuard]
    B -- No --> D{/dev/net/tun\ndevice present?}
    D -- Yes --> E[wg-easy falls back to\nwireguard-go userspace]
    D -- No --> F[Container fails to start\ndevice-not-found error]
    C --> G[VPN tunnel up ✓]
    E --> G
    style F fill:#f88,stroke:#d00
    style G fill:#8f8,stroke:#0a0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Container starts] --> B{WireGuard kernel\nmodule present?}
    B -- Yes --> C[wg-easy uses\nkernel WireGuard]
    B -- No --> D{/dev/net/tun\ndevice present?}
    D -- Yes --> E[wg-easy falls back to\nwireguard-go userspace]
    D -- No --> F[Container fails to start\ndevice-not-found error]
    C --> G[VPN tunnel up ✓]
    E --> G
    style F fill:#f88,stroke:#d00
    style G fill:#8f8,stroke:#0a0
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(wg-easy): map /dev/net/tun for users..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/25f764f4f0d25a5e03de616ebc8205686c470946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43384705)</sub>

<!-- /greptile_comment -->