### PR TITLE
feat: add wordpress-v7 app, pin legacy wordpress at v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to Big Bear Universal Apps are documented here.
 Format: [CalVer](https://calver.org/) — `YYYY.MM.N` (N = release number within the month)
 
+## [2026.07.1]
+
+### Added
+- `apps/wordpress-v7/` — new WordPress 7.0.1 app paired with MySQL 8.0. WordPress 7 raises the minimum database to MySQL 8.0, which the legacy app's bundled MySQL 5.7 cannot satisfy.
+
+### Changed
+- `apps/wordpress/` — renamed to "WordPress (Legacy)", reverted to `wordpress:6.9.4` (still paired with MySQL 5.7), and pinned in `renovate.json` so it no longer auto-updates.
+
 ## [2026.06.3]
 
 ### Updated

--- a/apps/wordpress-v7/app.json
+++ b/apps/wordpress-v7/app.json
@@ -1,18 +1,18 @@
 {
   "spec_version": "1.0",
   "metadata": {
-    "id": "wordpress",
-    "name": "WordPress (Legacy)",
-    "description": "Initially started as a blogging tool in 2003, it has evolved into a highly flexible CMS that powers over 40% of the web (as of my last training data in 2022).",
+    "id": "wordpress-v7",
+    "name": "WordPress v7",
+    "description": "Initially started as a blogging tool in 2003, it has evolved into a highly flexible CMS that powers over 40% of the web. WordPress 7 requires MySQL 8.0 and is packaged as a new app alongside the legacy WordPress 6 entry.",
     "tagline": "WordPress",
-    "version": "6.9.4",
+    "version": "7.0.1",
     "author": "BigBearTechWorld",
     "developer": "Automattic",
     "category": "BigBearCasaOS",
     "license": "",
     "homepage": "https://hub.docker.com/r/wordpress",
     "source": "big-bear-universal",
-    "created": "2025-10-27T02:42:26Z",
+    "created": "2026-07-12T00:00:00Z",
     "updated": "2026-07-12T00:00:00Z"
   },
   "visual": {
@@ -35,7 +35,7 @@
     ],
     "platform": "linux",
     "main_service": "app",
-    "default_port": "8080",
+    "default_port": "8084",
     "main_image": "wordpress",
     "compose_file": "docker-compose.yml"
   },
@@ -84,17 +84,21 @@
   "ui": {
     "scheme": "http",
     "path": "",
-    "tips": {}
+    "tips": {
+      "before_install": {
+        "en_us": "🆕 WORDPRESS V7 - SEPARATE APP\n\nThis is a NEW app, separate from 'wordpress' (v6). Both can run simultaneously.\n\nFOR NEW USERS:\n✅ Install this app for new WordPress deployments\n✅ Pairs WordPress 7.0.1 with MySQL 8.0 (WordPress 7 requires MySQL 8.0)\n\nFOR V6 USERS:\n⚠️  Do NOT uninstall your 'wordpress' v6 app\n⚠️  Deploy this as a NEW app alongside v6\n⚠️  WordPress 7 rejects MySQL 5.7, and a 5.7 data directory does not upgrade in-place to 8.0\n⚠️  Migration requires a manual MySQL dump/reload — back up your database first\n\nSupport: https://community.bigbeartechworld.com/"
+      }
+    }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "8080",
+      "port_map": "8084",
       "volume_mappings": {
-        "wordpress_html": "/DATA/AppData/$AppID/html",
-        "wordpress_mysql": "/DATA/AppData/$AppID/mysql"
+        "wordpress-v7_html": "/DATA/AppData/$AppID/html",
+        "wordpress-v7_mysql": "/DATA/AppData/$AppID/mysql"
       },
-      "port": "8080"
+      "port": "8084"
     },
     "portainer": {
       "supported": true,
@@ -104,7 +108,7 @@
         "selfhosted"
       ],
       "administrator_only": false,
-      "port": "8080"
+      "port": "8084"
     },
     "runtipi": {
       "supported": true,
@@ -115,30 +119,30 @@
         "arm"
       ],
       "volume_mappings": {
-        "wordpress_html": "html",
-        "wordpress_mysql": "mysql"
+        "wordpress-v7_html": "html",
+        "wordpress-v7_mysql": "mysql"
       },
-      "port": "8142"
+      "port": "8145"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "8080"
+      "port": "8084"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "8080"
+      "port": "8084"
     },
     "umbrel": {
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "wordpress_html": "html",
-        "wordpress_mysql": "mysql"
+        "wordpress-v7_html": "html",
+        "wordpress-v7_mysql": "mysql"
       },
-      "port": "10187"
+      "port": "10194"
     }
   },
   "tags": [

--- a/apps/wordpress-v7/app.json
+++ b/apps/wordpress-v7/app.json
@@ -75,7 +75,7 @@
     "ports": [
       {
         "container": "80",
-        "host": "80",
+        "host": "8084",
         "protocol": "tcp",
         "description": "Container Port: 80"
       }

--- a/apps/wordpress-v7/docker-compose.yml
+++ b/apps/wordpress-v7/docker-compose.yml
@@ -1,0 +1,69 @@
+# Configuration for big-bear-wordpress-v7 setup
+
+# WORDPRESS V7.0.1 - NEW DEPLOYMENT
+# ================================
+# This is a SEPARATE app from 'wordpress' (v6.9.4). They can coexist.
+#
+# WHY A NEW APP:
+# - WordPress 7.0 raises the minimum database to MySQL 8.0 (up from 5.5.5)
+# - The legacy 'wordpress' app bundles mysql:5.7, which WordPress 7 rejects
+# - A MySQL 5.7 data directory does NOT upgrade in-place to 8.0 cleanly
+#
+# FOR NEW INSTALLATIONS:
+# - Deploy this app for new WordPress instances
+# - Pairs WordPress 7.0.1 with MySQL 8.0
+#
+# FOR MIGRATION FROM THE LEGACY APP:
+# - Do NOT uninstall your existing 'wordpress' (v6) app
+# - Deploy this as a NEW app alongside it
+# - Migration is manual (MySQL 5.7 -> 8.0 requires a dump/reload)
+#
+# Migration steps (after deploying this app):
+# 1. Dump legacy DB: docker compose -f apps/wordpress/docker-compose.yml exec db mysqldump -u root -pcasaos wordpress > wordpress.sql
+# 2. Copy legacy html volume contents into wordpress-v7_html
+# 3. Import into v7 DB: docker compose -f apps/wordpress-v7/docker-compose.yml exec -T db mysql -u root -pcasaos wordpress < wordpress.sql
+# 4. Verify the v7 site before removing the legacy app
+
+# Name of the big-bear-wordpress-v7 application
+name: big-bear-wordpress-v7
+# Service definitions for the wordpress-v7 application
+services:
+  # Service definition for the main application
+  app:
+    # Docker image to use for the application
+    image: wordpress:7.0.1
+    # Port mapping for the application
+    ports:
+      - 8084:80
+    # Environment variables for the application
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: casaos
+      WORDPRESS_DB_PASSWORD: casaos
+      WORDPRESS_DB_NAME: wordpress
+    # Volume mapping for the application
+    volumes:
+      - wordpress-v7_html:/var/www/html
+    # Service dependencies for the application
+    depends_on:
+      - db
+  # Service definition for the database
+  db:
+    # Docker image to use for the database
+    image: mysql:8.0
+    # Environment variables for the database
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: casaos
+      MYSQL_PASSWORD: casaos
+      MYSQL_ROOT_PASSWORD: casaos
+    # Volume mapping for the database
+    volumes:
+      - wordpress-v7_mysql:/var/lib/mysql
+volumes:
+  wordpress-v7_html:
+    name: wordpress-v7_html
+    driver: local
+  wordpress-v7_mysql:
+    name: wordpress-v7_mysql
+    driver: local

--- a/apps/wordpress/docker-compose.yml
+++ b/apps/wordpress/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service definition for the main application
   app:
     # Docker image to use for the application
-    image: wordpress:7.0.1
+    image: wordpress:6.9.4
     # Port mapping for the application
     ports:
       - 8080:80

--- a/renovate.json
+++ b/renovate.json
@@ -164,6 +164,11 @@
       "matchPackageNames": ["lissy93/dashy"],
       "matchFileNames": ["apps/dashy/docker-compose.yml"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["wordpress"],
+      "matchFileNames": ["apps/wordpress/docker-compose.yml"],
+      "enabled": false
     }
   ],
   "customManagers": []


### PR DESCRIPTION
WordPress 7 requires MySQL 8.0, but the existing app bundles mysql:5.7 and can't upgrade in-place — so split into a new `wordpress-v7` app (WP7 + mysql:8.0) and reverted/pinned the legacy `wordpress` app at 6.9.4.

Also triaged the open major-update PRs: merged 5 safe tag bumps (onedev v16, rackpeek v2, node-red v5, eufy-security-ws v3, nova-dso-tracker v6) after confirming no breaking changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the existing WordPress app into two separate deployments to handle WordPress 7's hard dependency on MySQL 8.0 (incompatible with the legacy stack's MySQL 5.7). The legacy `wordpress` app is reverted to `6.9.4` and pinned in Renovate so it will not auto-upgrade again, while a new `wordpress-v7` app is introduced pairing `wordpress:7.0.1` with `mysql:8.0`.

- **New `apps/wordpress-v7`**: Full compose stack (WordPress 7.0.1 + MySQL 8.0) with a new `app.json` manifest, thorough in-compose migration documentation, and a before-install tip warning users not to delete their v6 instance.
- **Legacy `apps/wordpress` pinned**: Image reverted to `6.9.4`, name changed to "WordPress (Legacy)", and a Renovate disable rule added scoped to that compose file to prevent future auto-upgrades.
- **CHANGELOG**: New `2026.07.1` entry correctly documents both the addition and the pin.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the split is clean, both stacks are isolated with distinct named volumes and host ports, and the legacy pin is properly scoped in Renovate.

All changes are additive or straightforward reverts. The new wordpress-v7 compose file is well-structured, volumes are properly namespaced to avoid collision with the legacy app, and the Renovate rule correctly targets only the legacy compose file. The two minor notes (floating mysql:8.0 tag, repo-relative migration commands in comments) do not affect runtime correctness.

No files require special attention; apps/wordpress-v7/docker-compose.yml has the minor items noted above but nothing blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/wordpress-v7/docker-compose.yml | New WordPress 7.0.1 + MySQL 8.0 compose stack; mysql:8.0 uses a floating tag (unlike the pinned wordpress:7.0.1), and migration CLI examples reference repo-relative paths that won't resolve for typical self-hosted users. |
| apps/wordpress-v7/app.json | New app manifest for WordPress v7; deployment.ports correctly declares host:8084 matching docker-compose; runtipi/umbrel ports (8145/10194) follow the same platform-specific offset pattern as the legacy app. |
| apps/wordpress/docker-compose.yml | Image reverted from wordpress:7.0.1 to wordpress:6.9.4 to pin the legacy app; no other changes. |
| apps/wordpress/app.json | Renamed to "WordPress (Legacy)", version bumped down to 6.9.4, updated timestamp; straightforward metadata update. |
| renovate.json | Adds a packageRule to disable Renovate auto-updates for the legacy wordpress app, preventing future major-version bumps from re-upgrading the pinned 6.9.4 image. |
| CHANGELOG.md | New 2026.07.1 entry correctly documents the wordpress-v7 addition and legacy wordpress pin. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Legacy["apps/wordpress (Legacy)"]
        WP6["wordpress:6.9.4"]
        MY57["mysql:5.7"]
        WP6 -->|"WORDPRESS_DB_HOST: db"| MY57
        WP6 -->|"8080:80"| U1(["User :8080"])
    end

    subgraph New["apps/wordpress-v7 (New)"]
        WP7["wordpress:7.0.1"]
        MY80["mysql:8.0"]
        WP7 -->|"WORDPRESS_DB_HOST: db"| MY80
        WP7 -->|"8084:80"| U2(["User :8084"])
    end

    RJ["renovate.json\n(wordpress pinned, auto-update disabled)"] --> Legacy
    RJ -. "wordpress-v7 NOT pinned\n(auto-updates enabled)" .-> New
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Legacy["apps/wordpress (Legacy)"]
        WP6["wordpress:6.9.4"]
        MY57["mysql:5.7"]
        WP6 -->|"WORDPRESS_DB_HOST: db"| MY57
        WP6 -->|"8080:80"| U1(["User :8080"])
    end

    subgraph New["apps/wordpress-v7 (New)"]
        WP7["wordpress:7.0.1"]
        MY80["mysql:8.0"]
        WP7 -->|"WORDPRESS_DB_HOST: db"| MY80
        WP7 -->|"8084:80"| U2(["User :8084"])
    end

    RJ["renovate.json\n(wordpress pinned, auto-update disabled)"] --> Legacy
    RJ -. "wordpress-v7 NOT pinned\n(auto-updates enabled)" .-> New
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix: set wordpress-v7 deployment.ports h..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/4b112bb23e81776daf5968497945226c2ef07838) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43647529)</sub>

<!-- /greptile_comment -->