### PR TITLE
fix: replace dead IceWhale thumbnail URLs

### DIFF
--- a/apps/jellyseerr/app.json
+++ b/apps/jellyseerr/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyseerr/thumbnail.jpg",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/seerr-team/seerr@develop/public/preview.jpg",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png"
   },

--- a/apps/nextcloud-ls/app.json
+++ b/apps/nextcloud-ls/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
     "screenshots": [
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",

--- a/apps/nextcloud-with-smbclient/app.json
+++ b/apps/nextcloud-with-smbclient/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
     "screenshots": [
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",

--- a/apps/nextcloud/app.json
+++ b/apps/nextcloud/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/thumbnail.jpg",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
     "screenshots": [
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
       "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",


### PR DESCRIPTION
IceWhale removed the Jellyseerr and Nextcloud thumbnails from CasaOS-AppStore, so those URLs now 404 and fail the v2 app store build.

Repoints jellyseerr and the 3 nextcloud apps to live jsDelivr CDN thumbnails (all verified 200).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces four dead thumbnail URLs (Jellyseerr and three Nextcloud variants) that were previously pointing to assets removed from the IceWhale `CasaOS-AppStore` repository, causing 404s that break the v2 app store build.

- Nextcloud thumbnails for `nextcloud`, `nextcloud-ls`, and `nextcloud-with-smbclient` are repointed to `nextcloud/screenshots@master/nextcloud-hub-25-files.png` on jsDelivr, which resolves correctly.
- Jellyseerr's thumbnail is repointed to `seerr-team/seerr@develop/public/preview.jpg`; the `@develop` branch reference is mutable and could silently break again if that branch is rebased or the file is relocated.
- The `screenshots` arrays in all three Nextcloud apps still reference the same `IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/` path that was the source of the breakage, meaning those assets may also be 404 and would still fail build validation.

<h3>Confidence Score: 3/5</h3>

The thumbnail fixes are correct and should unblock the build, but the screenshot URLs in all three Nextcloud apps still point at the same removed IceWhale repository path — if those assets are also gone, the build will continue to fail after this PR merges.

The three Nextcloud apps each have a `screenshots` array still referencing `IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-*.png` — the same repository from which the thumbnails were removed. If the screenshot assets were cleaned up in the same sweep, this PR only partially resolves the build breakage. Additionally, the Jellyseerr thumbnail now resolves against a mutable `@develop` branch, which could silently break on any future rebase or file move in that repo.

All three Nextcloud `app.json` files need their `screenshots` arrays verified and potentially updated; `apps/jellyseerr/app.json` should ideally pin the thumbnail to a stable commit SHA rather than the `develop` branch tip.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/jellyseerr/app.json | Thumbnail URL updated from dead IceWhale path to seerr-team/seerr preview; new URL uses a mutable `@develop` branch reference that could break again in the future. |
| apps/nextcloud/app.json | Thumbnail URL fixed, but three screenshot URLs still point to the same removed IceWhale CasaOS-AppStore repository and may also be 404. |
| apps/nextcloud-ls/app.json | Thumbnail URL fixed; same residual issue as apps/nextcloud/app.json — screenshot URLs still reference the potentially removed IceWhale repository. |
| apps/nextcloud-with-smbclient/app.json | Thumbnail URL fixed; screenshot URLs still reference the potentially removed IceWhale repository, same as the other two Nextcloud variants. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Store Build] --> B{Fetch thumbnail URLs}
    B -->|jellyseerr| C["seerr-team/seerr@develop\n/public/preview.jpg\n✅ Fixed - but mutable ref"]
    B -->|nextcloud variants x3| D["nextcloud/screenshots@master\n/nextcloud-hub-25-files.png\n✅ Fixed"]
    A --> E{Fetch screenshot URLs}
    E -->|nextcloud variants x3| F["IceWhaleTech/CasaOS-AppStore@main\n/Apps/Nextcloud/screenshot-*.png\n⚠️ Still unchanged - may 404"]
    C --> G[Build passes?]
    D --> G
    F --> G
    G -->|All 200| H[✅ Build succeeds]
    G -->|Any 404| I[❌ Build fails]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[App Store Build] --> B{Fetch thumbnail URLs}
    B -->|jellyseerr| C["seerr-team/seerr@develop\n/public/preview.jpg\n✅ Fixed - but mutable ref"]
    B -->|nextcloud variants x3| D["nextcloud/screenshots@master\n/nextcloud-hub-25-files.png\n✅ Fixed"]
    A --> E{Fetch screenshot URLs}
    E -->|nextcloud variants x3| F["IceWhaleTech/CasaOS-AppStore@main\n/Apps/Nextcloud/screenshot-*.png\n⚠️ Still unchanged - may 404"]
    C --> G[Build passes?]
    D --> G
    F --> G
    G -->|All 200| H[✅ Build succeeds]
    G -->|Any 404| I[❌ Build fails]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/nextcloud/app.json`, line 22-24 ([link](https://github.com/bigbeartechworld/big-bear-universal-apps/blob/a95a8dd88eab010f4c2b28913dff2559f96a9210/apps/nextcloud/app.json#L22-L24)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Screenshot URLs may still be 404**

   The PR fixes the `thumbnail` URL but leaves the `screenshots` array pointing at the same `IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/` path that was the source of the breakage. If IceWhale removed the thumbnail they likely removed or reorganised the screenshot assets in the same cleanup, meaning `screenshot-1.png`, `screenshot-2.png`, and `screenshot-3.png` could also be returning 404 and will still fail the v2 build validation. The same stale screenshot URLs appear identically in `apps/nextcloud-ls/app.json` and `apps/nextcloud-with-smbclient/app.json`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/nextcloud/app.json
   Line: 22-24

   Comment:
   **Screenshot URLs may still be 404**

   The PR fixes the `thumbnail` URL but leaves the `screenshots` array pointing at the same `IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/` path that was the source of the breakage. If IceWhale removed the thumbnail they likely removed or reorganised the screenshot assets in the same cleanup, meaning `screenshot-1.png`, `screenshot-2.png`, and `screenshot-3.png` could also be returning 404 and will still fail the v2 build validation. The same stale screenshot URLs appear identically in `apps/nextcloud-ls/app.json` and `apps/nextcloud-with-smbclient/app.json`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/nextcloud/app.json:22-24
**Screenshot URLs may still be 404**

The PR fixes the `thumbnail` URL but leaves the `screenshots` array pointing at the same `IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/` path that was the source of the breakage. If IceWhale removed the thumbnail they likely removed or reorganised the screenshot assets in the same cleanup, meaning `screenshot-1.png`, `screenshot-2.png`, and `screenshot-3.png` could also be returning 404 and will still fail the v2 build validation. The same stale screenshot URLs appear identically in `apps/nextcloud-ls/app.json` and `apps/nextcloud-with-smbclient/app.json`.

### Issue 2 of 2
apps/jellyseerr/app.json:20
**Mutable branch reference may break again**

The new thumbnail URL resolves against the `develop` branch of `seerr-team/seerr`, which is a mutable reference. If that branch is force-pushed, rebased, or the file is moved as Seerr development continues, the URL will silently return 404 — reproducing the exact problem this PR is fixing. Pinning to a specific commit SHA or a stable release tag would make this durable.

```suggestion
    "thumbnail": "https://cdn.jsdelivr.net/gh/seerr-team/seerr@<COMMIT_SHA>/public/preview.jpg",
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace dead IceWhale thumbnail URL..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/a95a8dd88eab010f4c2b28913dff2559f96a9210) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43701499)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->