### PR TITLE
fix: pin mutable-branch thumbnail/screenshot URLs to commit SHAs

### DIFF
--- a/apps/adguard-home-host/app.json
+++ b/apps/adguard-home-host/app.json
@@ -17,11 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/thumbnail.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/thumbnail.png",
     "screenshots": [
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-1.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-2.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-3.png"
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-1.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-2.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-3.png"
     ],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png"
   },

--- a/apps/adguard-home/app.json
+++ b/apps/adguard-home/app.json
@@ -17,11 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/thumbnail.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/thumbnail.png",
     "screenshots": [
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-1.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-2.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-3.png"
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-1.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-2.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/AdGuardHome/screenshot-3.png"
     ],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/adguard-home.png"
   },

--- a/apps/jellyseerr/app.json
+++ b/apps/jellyseerr/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/seerr-team/seerr@develop/public/preview.jpg",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/seerr-team/seerr@5ae70d05e1ee123b3cda43153ed415754fd8e816/public/preview.jpg",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyseerr.png"
   },

--- a/apps/nextcloud-ls/app.json
+++ b/apps/nextcloud-ls/app.json
@@ -17,11 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@328f3616f78906ecb405bdcc00481bfbbeb59278/nextcloud-hub-25-files.png",
     "screenshots": [
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-3.png"
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-1.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-2.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-3.png"
     ],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png"
   },

--- a/apps/nextcloud-with-smbclient/app.json
+++ b/apps/nextcloud-with-smbclient/app.json
@@ -17,11 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@328f3616f78906ecb405bdcc00481bfbbeb59278/nextcloud-hub-25-files.png",
     "screenshots": [
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-3.png"
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-1.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-2.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-3.png"
     ],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png"
   },

--- a/apps/nextcloud/app.json
+++ b/apps/nextcloud/app.json
@@ -17,11 +17,11 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@master/nextcloud-hub-25-files.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/nextcloud/screenshots@328f3616f78906ecb405bdcc00481bfbbeb59278/nextcloud-hub-25-files.png",
     "screenshots": [
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png",
-      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-3.png"
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-1.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-2.png",
+      "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@f2eaaebe9b6d487a2b594a716fc5bbcf8e80ac0d/Apps/Nextcloud/screenshot-3.png"
     ],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nextcloud.png"
   },

--- a/apps/psitransfer/app.json
+++ b/apps/psitransfer/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/psitransfer.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/psi-4ward/psitransfer@master/docs/psitransfer.gif",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/psi-4ward/psitransfer@e1040f23d985810e6965a54dcb77e4f86542216f/docs/psitransfer.gif",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/psitransfer.png"
   },


### PR DESCRIPTION
## Summary
- Follow-up to #2481 (Greptile flagged jellyseerr's `@develop` ref as mutable)
- Pins jellyseerr, adguard-home(-host), nextcloud(-ls/-with-smbclient), psitransfer thumbnail/screenshot URLs from `@main`/`@master`/`@develop` to current commit SHAs
- All new URLs verified 200 before commit; self-referencing repo URLs left untouched (pinning those would go stale on next edit)

## Test plan
- [x] All modified app.json validated as valid JSON
- [x] Every pinned URL curl-verified 200

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins thumbnail and screenshot URLs across 7 app definitions from mutable branch refs (`@main`, `@master`, `@develop`) to specific commit SHAs on jsdelivr.net CDN, following up on a prior review flag on jellyseerr's `@develop` reference.

- **adguard-home / adguard-home-host**: thumbnail + 3 screenshots pinned from `@main` → `f2eaaebe` in `IceWhaleTech/CasaOS-AppStore`
- **nextcloud / nextcloud-ls / nextcloud-with-smbclient**: thumbnail pinned from `@master` → `328f3616` in `nextcloud/screenshots`; 3 screenshots pinned from `@main` → `f2eaaebe` in `IceWhaleTech/CasaOS-AppStore`
- **jellyseerr**: thumbnail pinned from `@develop` → `5ae70d05` in `seerr-team/seerr`; **psitransfer**: thumbnail pinned from `@master` → `e1040f23` in `psi-4ward/psitransfer`

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are URL string replacements in JSON metadata with no runtime logic affected.

All seven files only swap mutable branch names for full 40-character commit SHAs on the same paths and repos. The three Nextcloud variants use identical SHAs, confirming consistency. The PR author curl-verified every URL before committing, and no application logic, Docker configuration, or schema is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/adguard-home/app.json | Pins thumbnail and 3 screenshots from @main → commit SHA f2eaaebe in IceWhaleTech/CasaOS-AppStore; change is consistent with adguard-home-host |
| apps/adguard-home-host/app.json | Pins thumbnail and 3 screenshots from @main → commit SHA f2eaaebe in IceWhaleTech/CasaOS-AppStore; identical SHA used as adguard-home, correct |
| apps/jellyseerr/app.json | Pins thumbnail from @develop → commit SHA 5ae70d05 in seerr-team/seerr; directly addresses the issue flagged in #2481 |
| apps/nextcloud/app.json | Pins thumbnail from nextcloud/screenshots @master → 328f3616 and 3 screenshots from CasaOS-AppStore @main → f2eaaebe; consistent with ls and smbclient variants |
| apps/nextcloud-ls/app.json | Same SHA pinning as apps/nextcloud/app.json for both source repos; no inconsistency |
| apps/nextcloud-with-smbclient/app.json | Same SHA pinning as apps/nextcloud/app.json for both source repos; no inconsistency |
| apps/psitransfer/app.json | Pins thumbnail GIF from psi-4ward/psitransfer @master → commit SHA e1040f23; SHA is valid 40-character hex |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[app.json visual URLs] --> B{Branch ref type?}
    B -->|Mutable at main or master or develop| C[Can change without notice]
    B -->|Pinned 40-char SHA| D[Immutable content served by CDN]
    C -->|This PR fixes| D

    subgraph Pinned["Sources pinned in this PR"]
        E["IceWhaleTech/CasaOS-AppStore: main to f2eaaebe"]
        F["nextcloud/screenshots: master to 328f3616"]
        G["seerr-team/seerr: develop to 5ae70d05"]
        H["psi-4ward/psitransfer: master to e1040f23"]
    end

    D --> Pinned
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[app.json visual URLs] --> B{Branch ref type?}
    B -->|Mutable at main or master or develop| C[Can change without notice]
    B -->|Pinned 40-char SHA| D[Immutable content served by CDN]
    C -->|This PR fixes| D

    subgraph Pinned["Sources pinned in this PR"]
        E["IceWhaleTech/CasaOS-AppStore: main to f2eaaebe"]
        F["nextcloud/screenshots: master to 328f3616"]
        G["seerr-team/seerr: develop to 5ae70d05"]
        H["psi-4ward/psitransfer: master to e1040f23"]
    end

    D --> Pinned
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: pin third-party thumbnail/screensho..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/f9e7d9cab966a532f0f7ab3b6c44ef72e0533b00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43704233)</sub>

<!-- /greptile_comment -->