### PR TITLE
chore(apps): pin image digests across all apps

### DIFF
--- a/apps/2fauth/docker-compose.yml
+++ b/apps/2fauth/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-2fauth
     # Docker image to be used
-    image: 2fauth/2fauth:8.0.1
+    image: 2fauth/2fauth:8.0.1@sha256:4a1f329e42b9bdfb625db3094bd6f79a2f44640b6259d4cdb9f336c676bf120e
     # Restart policy for the service
     restart: unless-stopped
     # Port mappings for the service

--- a/apps/GemDigest/docker-compose.yml
+++ b/apps/GemDigest/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-gem-digest-bot
     # Docker image to use
-    image: piero24/gemdigest:1.0
+    image: piero24/gemdigest:1.0@sha256:6f49c511af7f2f7a1b9e652e517e6a222760632e7b69801a4997787e40065cc6
     # Mount local directory to the container's /home/dev directory
     volumes:
       - GemDigest_extra_configs:/gem_digest_bot/extra_configs

--- a/apps/Homepage/docker-compose.yml
+++ b/apps/Homepage/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # The `app` service definition
   app:
     # Image to be used for the container
-    image: ghcr.io/gethomepage/homepage:v1.13.1
+    image: ghcr.io/gethomepage/homepage:v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401
     # Name of the container instance
     container_name: homepage
     # Port mapping between host and container

--- a/apps/_example/docker-compose.yml
+++ b/apps/_example/docker-compose.yml
@@ -2,7 +2,7 @@ name: example-app
 
 services:
   app:
-    image: bigbeartechworld/big-bear-minio:RELEASE.2025-10-15T17-29-55Z
+    image: bigbeartechworld/big-bear-minio:RELEASE.2025-10-15T17-29-55Z@sha256:7a18393957baa73bb4e3181e2e53b8b7051a99d7ce9a020bf76a58961f68c10f
     container_name: example-app
     ports:
       - "8080:8080"

--- a/apps/actual-server/docker-compose.yml
+++ b/apps/actual-server/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-actual-server
 services:
   # Service name: app
   app:
-    image: actualbudget/actual-server:26.7.0 # The Docker image to use (latest version of actual-server)
+    image: actualbudget/actual-server:26.7.0@sha256:e18b7fbfec6157a368fad4146563f397502e9da70a120aeaeac63b4977405d1c # The Docker image to use (latest version of actual-server)
     container_name: actual-server # Name of the container instance
     volumes:
       - actual-server_data:/data # Mounting the data volume

--- a/apps/adguard-home-host/docker-compose.yml
+++ b/apps/adguard-home-host/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-adguard-home-host
     # Docker image to be used
-    image: adguard/adguardhome:v0.107.77
+    image: adguard/adguardhome:v0.107.77@sha256:e6f2b8bcda06064ab055b44933a4f0e983c35558b9cdb8d2e7ab1efcee36d890
     # Volume mappings for the service
     volumes:
       - "adguard-home-host_data_work:/opt/adguardhome/work" # Map data work directory

--- a/apps/adguard-home/docker-compose.yml
+++ b/apps/adguard-home/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: adguard-home
     # Docker image to be used
-    image: adguard/adguardhome:v0.107.77
+    image: adguard/adguardhome:v0.107.77@sha256:e6f2b8bcda06064ab055b44933a4f0e983c35558b9cdb8d2e7ab1efcee36d890
     # Resources for the service
     deploy:
       resources:

--- a/apps/anse/docker-compose.yml
+++ b/apps/anse/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-anse
     # Image to be used for the container
-    image: ddiu8081/anse:v1.1.11
+    image: ddiu8081/anse:v1.1.11@sha256:fd9afc84b9e1df02ca065170e72994b787e7d2ea881f22eda2fcd2c58e717164
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/appsmith/docker-compose.yml
+++ b/apps/appsmith/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: app
   # The `app` service definition
   app:
-    image: appsmith/appsmith-ce:v1.98.1 # Docker image to use
+    image: appsmith/appsmith-ce:v1.98.1@sha256:9a5119fdbf22c5ae25c2240a5d5f944b9c44c4fe4a6cfa65934dc3792d24c871 # Docker image to use
     container_name: appsmith # Name of the container
     ports:
       - "1080:80" # Port mapping host:container for HTTP

--- a/apps/audiobookshelf/docker-compose.yml
+++ b/apps/audiobookshelf/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-audiobookshelf
     # Image to be used for the container
-    image: ghcr.io/advplyr/audiobookshelf:2.34.0
+    image: ghcr.io/advplyr/audiobookshelf:2.34.0@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/authentik/docker-compose.yml
+++ b/apps/authentik/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-authentik
     # Image to be used for the container
-    image: ghcr.io/goauthentik/server:2026.2.2
+    image: ghcr.io/goauthentik/server:2026.2.2@sha256:40f0df709957c11324420fa387f1135c427f16086f12ca266b2d883d39c71fe3
     command: server
     environment:
       AUTHENTIK_REDIS__HOST: big-bear-authentik-redis
@@ -30,7 +30,7 @@ services:
     networks:
       - big_bear_authentik_network
   big-bear-authentik-worker:
-    image: ghcr.io/goauthentik/server:2026.2.2
+    image: ghcr.io/goauthentik/server:2026.2.2@sha256:40f0df709957c11324420fa387f1135c427f16086f12ca266b2d883d39c71fe3
     restart: unless-stopped
     command: worker
     container_name: big-bear-authentik-worker
@@ -63,7 +63,7 @@ services:
     # PostgreSQL 14+ required by Authentik (since version 2024.6)
     # BREAKING CHANGE: Existing users with PostgreSQL 12 data need to migrate
     # See: https://www.postgresql.org/docs/current/upgrading.html
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]

--- a/apps/ayon/docker-compose.yml
+++ b/apps/ayon/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ayon
     # Image to be used for the container
-    image: ynput/ayon:1.3.6-20240823
+    image: ynput/ayon:1.3.6-20240823@sha256:def63d3138061857115faf7de0950bb01d4f116272c03a0d3f0d28fcf7e6fc21
     # Container restart policy
     restart: unless-stopped
     # Healthcheck configuration to ensure the service is running properly
@@ -39,7 +39,7 @@ services:
         condition: service_started
   # Service definition for the PostgreSQL database
   postgres:
-    image: postgres:15-alpine
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
     container_name: postgres
     restart: unless-stopped
     environment:

--- a/apps/baserow/docker-compose.yml
+++ b/apps/baserow/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Set the name of the Docker container.
     container_name: baserow
     # Use the specified Docker image for Baserow and specify its version.
-    image: baserow/baserow:2.2.2
+    image: baserow/baserow:2.2.2@sha256:73886bcda89632664dc7aaa9ae15414ffb32b00e571d413ccee3c5b5d66b9883
     # Set environment variables for Baserow.
     environment:
       # Set the your CASA OS IP for Baserow to use.

--- a/apps/beaverhabits/docker-compose.yml
+++ b/apps/beaverhabits/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-beaverhabits
     # Image to be used for the container specifies the btop version and source
-    image: daya0576/beaverhabits:0.9.1
+    image: daya0576/beaverhabits:0.9.1@sha256:6cd7e464207369785c88cfd59f99c6cc44ec57f3a8d90c3439908da42271d69f
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     user: "1000:1000"

--- a/apps/beszel/docker-compose.yml
+++ b/apps/beszel/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-beszel
     # Image to be used for the container
-    image: henrygd/beszel:0.18.7
+    image: henrygd/beszel:0.18.7@sha256:a849ad80814b6a1a3be665304dcace5d4854b3bed7bde4dd1227e8ce1b82d477
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/big-bear-casaos-user-management/docker-compose.yml
+++ b/apps/big-bear-casaos-user-management/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-casaos-user-management
     # Image to be used for the container specifies the btop version and source
-    image: bigbeartechworld/big-bear-casaos-user-management:0.1.1
+    image: bigbeartechworld/big-bear-casaos-user-management:0.1.1@sha256:10bbfe4067e947649a27db62864efeb60ccb35f9b1578b4c95d4b276b3e40342
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Run the container in privileged mode to allow access to system metrics

--- a/apps/bookstack/docker-compose.yml
+++ b/apps/bookstack/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-bookstack
     # Image to be used for the container
-    image: linuxserver/bookstack:26.05.20260608
+    image: linuxserver/bookstack:26.05.20260608@sha256:e3c387ac44a20fa29abcae8426e3e0d8c88b4ccf95d3c091fd9d96c8d0edcd8e
     # Container restart policy
     restart: unless-stopped
     volumes:
@@ -33,7 +33,7 @@ services:
       - big_bear_bookstack_network
   # Service definition for the database (MariaDB)
   big-bear-bookstack-db:
-    image: linuxserver/mariadb:10.11.6 # The Docker image for MariaDB
+    image: linuxserver/mariadb:10.11.6@sha256:7e34d92147dd7e1b63f43b3e76af73c273d7c3677786c32164a485f2a04964d8 # The Docker image for MariaDB
     container_name: big-bear-bookstack-db # Name of the container
     environment: # Environment variables for the MariaDB service
       - MYSQL_ROOT_PASSWORD=793e92b7-58d2-47b9-aae5-b8c7d58bd699 # Root password for MariaDB

--- a/apps/brave/docker-compose.yml
+++ b/apps/brave/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-brave # Name of the CasaOS application
 services:
   brave:
     container_name: big-bear-brave # Name of the Docker container
-    image: kasmweb/brave:1.15.0-rolling # Docker image for the Brave browser
+    image: kasmweb/brave:1.15.0-rolling@sha256:679eefbde9b44b6de2a73a5b266790393cea11e5756a8ab884798944cfef6ea7 # Docker image for the Brave browser
     ports:
       - "6901:6901" # Expose port 6901 for VNC access
     environment:

--- a/apps/btop/docker-compose.yml
+++ b/apps/btop/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-btop
     # Image to be used for the container specifies the btop version and source
-    image: bigbeartechworld/big-bear-btop:0.1.10
+    image: bigbeartechworld/big-bear-btop:0.1.10@sha256:750bd69f934dc11458e88667ba311745535c57855a127f16ea2ed9c2ba8a3762
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Run the container in privileged mode to allow access to system metrics

--- a/apps/budibase/docker-compose.yml
+++ b/apps/budibase/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-budibase
     # Image to be used for the container
-    image: budibase/budibase:3.39.29
+    image: budibase/budibase:3.39.29@sha256:f84854cc4a955a68f77acd890989649799297c0ce28c5dd8248c86ecd758b6b3
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/cadvisor/docker-compose.yml
+++ b/apps/cadvisor/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Service for cAdvisor, a tool to monitor container performance
   app:
     # Docker image to be used for cAdvisor
-    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    image: gcr.io/cadvisor/cadvisor:v0.55.1@sha256:3de2bd5203120b866d74a9b283b2ffb8ec382fbf9dc321814700c6ea6f44ec57
     # Name of the container instance
     container_name: monitoring_cadvisor
     # Restart policy - Restart the container unless it's stopped manually

--- a/apps/calcom/docker-compose.yml
+++ b/apps/calcom/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-calcom
     # Image to be used for the container
-    image: calcom/cal.com:v6.2.0
+    image: calcom/cal.com:v6.2.0@sha256:ace3bb1219fb7306585ab9f4d94d41af7ee064c343db0498173436bbe857bd49
     # Container restart policy
     restart: unless-stopped
     # Environment variables
@@ -48,7 +48,7 @@ services:
       - big_bear_calcom_network
   big-bear-calcom-db:
     container_name: big-bear-calcom-db
-    image: postgres:16.1
+    image: postgres:16.1@sha256:09f23e02d76670d3b346a3c00aa33a27cf57aab8341eedfcdaed41459d14f5c4
     restart: on-failure
     volumes:
       - calcom_data_db:/var/lib/postgresql/data

--- a/apps/celestory/docker-compose.yml
+++ b/apps/celestory/docker-compose.yml
@@ -3,7 +3,7 @@ name: celestory-voltask
 services:
 
   gateway:
-    image: celestory/gateway:1.1.2
+    image: celestory/gateway:1.1.2@sha256:d37ccfefd431abde1cec62b1c93d00d5579f57f194e65b5d488057206201154e
     container_name: celestory-gateway
     ports:
       - "1500:80"
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: celestory/frontend:1.1.4
+    image: celestory/frontend:1.1.4@sha256:e17dc1682c172578923368ceee14f0cc5774e67eb75f99fe9e2c39644bf2dc7b
     container_name: celestory-frontend
     environment:
       CLOUD_API_URL: http://api
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
 
   hub:
-    image: celestory/hub:1.1.0
+    image: celestory/hub:1.1.0@sha256:0a297ce4d96474096b81488de6ad4a566eba9144db26d491a31dab24d8f90678
     container_name: celestory-hub
     environment:
       AUTH_ORIGIN: http://auth
@@ -81,7 +81,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: celestory/api:1.1.3
+    image: celestory/api:1.1.3@sha256:a2a63d3c86b8b1b4922a31b111783f79b661dea403978dfc5e99dabca45adb2b
     container_name: celestory-api
     volumes:
       - celestory-project-files:/app/projectFiles
@@ -112,7 +112,7 @@ services:
     restart: unless-stopped
 
   generator:
-    image: celestory/generator:1.1.2
+    image: celestory/generator:1.1.2@sha256:1c3f34312b73f0eec5ad6aabe8a7592e989137852d0e2b8b5e13fa02d95e290e
     container_name: celestory-generator
     volumes:
       - celestory-project-files:/usr/src/app/projectFiles
@@ -132,7 +132,7 @@ services:
     restart: unless-stopped
 
   auth:
-    image: celestory/auth:1.1.1
+    image: celestory/auth:1.1.1@sha256:24e59ca0f1ae080dc5a176b534d0d5d67200baeb2a9f2babdece6d05203a2b86
     container_name: celestory-auth
     environment:
       PORT: 80
@@ -158,7 +158,7 @@ services:
     restart: unless-stopped
 
   voltask:
-    image: celestory/voltask:1.0.8
+    image: celestory/voltask:1.0.8@sha256:0a015c6e24e0c933718629534bb9e18a7de3466698dcc954e924d92e88df540c
     container_name: celestory-voltask
     environment:
       PORT: 1401
@@ -197,7 +197,7 @@ services:
     restart: unless-stopped
 
   plugins-bun:
-    image: celestory/voltask-plugins-bun:1.0.8
+    image: celestory/voltask-plugins-bun:1.0.8@sha256:5ecedad2b68f2eccef55919bbce23e7ffad748f59089154fa74760e65b1a402a
     container_name: celestory-plugins-bun
     restart: unless-stopped
     environment:
@@ -216,7 +216,7 @@ services:
       start_interval: 10s
 
   plugins-deno:
-    image: celestory/voltask-plugins-deno:1.0.8
+    image: celestory/voltask-plugins-deno:1.0.8@sha256:d34a4bae31f15e1c3ac3d002527e35103840d343e1f5e02b0534e21a07a65ea5
     container_name: celestory-plugins-deno
     restart: unless-stopped
     environment:
@@ -235,7 +235,7 @@ services:
       start_interval: 10s
 
   orchestrator:
-    image: celestory/voltask-orchestrator:1.0.8
+    image: celestory/voltask-orchestrator:1.0.8@sha256:558365b5b657cb718ceb7aef62182086503a8581cb342f46e6e791cb0d5d4c69
     container_name: celestory-orchestrator
     environment:
       PORT: 3003
@@ -253,7 +253,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: celestory/postgres:1.0.0
+    image: celestory/postgres:1.0.0@sha256:5ceb259468b3a38a73f8cc2d038a78a02f244aa5d81338dd66e77ddd532c49a8
     container_name: celestory-db
     environment:
       POSTGRES_USER: celestory_admin

--- a/apps/changedetection/docker-compose.yml
+++ b/apps/changedetection/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-changedetection
     # Image to be used for the container
-    image: ghcr.io/dgtlmoon/changedetection.io:0.55.3
+    image: ghcr.io/dgtlmoon/changedetection.io:0.55.3@sha256:2d0030e12494be9ebf6a6ebbbad46afe5763f498bbfefe9ebb7f0bf6be3ca5dc
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/chatpad/docker-compose.yml
+++ b/apps/chatpad/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-chatpad
     # Image to be used for the container
-    image: ghcr.io/deiucanta/chatpad:f45cd53bc410412610c1ba1cbd84cd137d8e167d
+    image: ghcr.io/deiucanta/chatpad:f45cd53bc410412610c1ba1cbd84cd137d8e167d@sha256:b0b2364a3ad97812bd88c1f33541ba4281e0bbff1878b509cef354ae7ec3278d
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/chrome/docker-compose.yml
+++ b/apps/chrome/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-chrome # Name of the CasaOS application
 services:
   chrome:
     container_name: big-bear-chrome # Name of the Docker container
-    image: kasmweb/chrome:1.15.0-rolling # Docker image for the chrome browser
+    image: kasmweb/chrome:1.15.0-rolling@sha256:ae404814331aa0259bfc71cfb3a07e5aca4b147595b833c0552288305f273e1a # Docker image for the chrome browser
     ports:
       - "6902:6901" # Expose port 6901 for VNC access
     environment:

--- a/apps/chromium/docker-compose.yml
+++ b/apps/chromium/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-chromium # Name of the CasaOS application
 services:
   chromium:
     container_name: big-bear-chromium # Name of the Docker container
-    image: linuxserver/chromium:version-6ae43f81 # Docker image for the chromium browser
+    image: linuxserver/chromium:version-6ae43f81@sha256:da269d40b655eb25ca0cd17c87f2e8e34b5b21f3e3eb14143746e40c62cb6951 # Docker image for the chromium browser
     ports:
       - "3000:3000" # Expose port 3000 for HTTP VNC access
       - "3001:3001" # Expose port 3001 for HTTPS VNC access

--- a/apps/cloudflared-web/docker-compose.yml
+++ b/apps/cloudflared-web/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-cloudflared-web
     # Image to be used for the container
-    image: wisdomsky/cloudflared-web:2026.6.1
+    image: wisdomsky/cloudflared-web:2026.6.1@sha256:3552fa87c10f2ec6a854c0c09209753957e909eca6194499194cedbb8c817db9
     # Container restart policy
     restart: unless-stopped
     # Network mode

--- a/apps/code-server/docker-compose.yml
+++ b/apps/code-server/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-code-server
 services:
   # Service name: app
   app:
-    image: linuxserver/code-server:4.126.0 # The Docker image to be used for the service
+    image: linuxserver/code-server:4.126.0@sha256:26dfecc1cd4c0e4c47dceb913b4eb8afd97af9f2311eb449d04b59126e6e5483 # The Docker image to be used for the service
     container_name: code-server # Name of the container instance
     environment:
       - PUID=1000 # User ID under which code-server will run

--- a/apps/codex-docs/docker-compose.yml
+++ b/apps/codex-docs/docker-compose.yml
@@ -3,7 +3,7 @@ name: big-bear-codex-docs
 # Service definitions for the big-bear-codex-docs application
 services:
   app:
-    image: ghcr.io/codex-team/codex.docs:v2.2
+    image: ghcr.io/codex-team/codex.docs:v2.2@sha256:c25f47c7f5af84206cef1fcedb2debcd25ba9ce1d4c6e5a33a0f273faff5a41f
     ports:
       - "3000:3000"
     volumes:

--- a/apps/composetoolbox/docker-compose.yml
+++ b/apps/composetoolbox/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # Node environment
       NODE_ENV: production
     # Image to be used for the container
-    image: ghcr.io/bluegoosemedia/composetoolbox:latest
+    image: ghcr.io/bluegoosemedia/composetoolbox:latest@sha256:61e8a6f0a00583f145e83018ce0954089f5bd89157dc39ef7459043643ca17f6
     pull_policy: always
     # Ports mapping between host and container
     ports:

--- a/apps/convertx/docker-compose.yml
+++ b/apps/convertx/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Name of the container
     container_name: big-bear-convertx
     # Image to be used for the container
-    image: ghcr.io/c4illin/convertx:v0.17.0
+    image: ghcr.io/c4illin/convertx:v0.17.0@sha256:e1f85be04bbaf8a55ead9261194c3ae0fa0957d303ea537127154860b2552afd
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Map port 3000 on the host to port 3000 on the container

--- a/apps/coolify/docker-compose.yml
+++ b/apps/coolify/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-coolify
     # Image to be used for the container specifies the fastfetch version and source
-    image: ghcr.io/coollabsio/coolify:4.0.0-beta.434
+    image: ghcr.io/coollabsio/coolify:4.0.0-beta.434@sha256:39db8373628c340747cf6199f5873322d5d0a9b6617bad0ce5cf6895369a3a83
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for the container
@@ -98,7 +98,7 @@ services:
       - big_bear_coolify_network
   big-bear-coolify-postgres:
     container_name: big-bear-coolify-postgres
-    image: postgres:15-alpine
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
     ports:
       - "5432:5432"
     volumes:
@@ -133,7 +133,7 @@ services:
       - big_bear_coolify_network
   big-bear-coolify-soketi:
     container_name: big-bear-coolify-soketi
-    image: quay.io/soketi/soketi:1.6-16-alpine
+    image: quay.io/soketi/soketi:1.6-16-alpine@sha256:5e45fe1adbf2d4ef8022d0126a3c7e4371b7b08f35784b76a2dc353954ee885c
     ports:
       - "6001:6001"
       - "6002:6002"

--- a/apps/crafty/docker-compose.yml
+++ b/apps/crafty/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-crafty
     # Image to be used for the container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.10.4
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.10.4@sha256:d2f61fcabb4756a63bc8538fb4f5e35ffddca3f1916a733c95a31c705c697742
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/cyberchef/docker-compose.yml
+++ b/apps/cyberchef/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-cyberchef
     # Image to be used for the container
-    image: ghcr.io/gchq/cyberchef:11.0.0
+    image: ghcr.io/gchq/cyberchef:11.0.0@sha256:45082a0ac41d6beeea2daeb192d8b20c66520362854542f4fe340aab37635f66
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/dashdot/docker-compose.yml
+++ b/apps/dashdot/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-dashdot
 services:
   app:
-    image: mauricenino/dashdot:6.3.4
+    image: mauricenino/dashdot:6.3.4@sha256:434a54d2937411a06b09c50e55709cc7d3b092c0fe173a9e5c986f9b5a33c7c6
     ports:
       - "3001:3001"
     volumes:

--- a/apps/dashy-v4/docker-compose.yml
+++ b/apps/dashy-v4/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # Service name: big-bear-dashy-v4
   big-bear-dashy-v4:
     # Image to be used for the app service
-    image: lissy93/dashy:4.0.8
+    image: lissy93/dashy:4.0.8@sha256:1b3de6159d93e1a75f0b808e74d8cb5100c06251b120abd2d68e557ec7544ab6
     # Name of the container
     container_name: big-bear-dashy-v4
     volumes:

--- a/apps/dashy/docker-compose.yml
+++ b/apps/dashy/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: big-bear-dashy
   big-bear-dashy:
     # Image to be used for the app service
-    image: lissy93/dashy:3.3.1
+    image: lissy93/dashy:3.3.1@sha256:8c04ab116bb52bd784137d3922acaa945b5559de49a14f163dbbcf0605adf3e6
     # Name of the container
     container_name: big-bear-dashy
     # Uncomment below if you want to mount volumes

--- a/apps/davis/docker-compose.yml
+++ b/apps/davis/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-davis
     # Image to be used for the container
-    image: ghcr.io/tchapi/davis-standalone:5.4.1
+    image: ghcr.io/tchapi/davis-standalone:5.4.1@sha256:9db11b957fdce6d56c04185793c149b62db1596035feb876878acef6b3421be4
     # Container restart policy
     restart: unless-stopped
     # Environment variables to be set in the container
@@ -42,7 +42,7 @@ services:
   # Service name: big-bear-davis-mailpit
   big-bear-davis-mailpit:
     container_name: big-bear-davis-mailpit # Container name for the app service
-    image: axllent/mailpit:v1.30 # Image for the app service
+    image: axllent/mailpit:v1.30@sha256:5a49a77c5bdbe7c5474450b4f46348d09949df3695257729c93a30369382d4f6 # Image for the app service
     restart: unless-stopped # Restart policy for the container
     volumes: # Volumes to mount for the app service
       - davis_mailpit_data:/data
@@ -56,7 +56,7 @@ services:
   # Service name: big-bear-mysql
   big-bear-davis-mysql:
     container_name: big-bear-davis-mysql
-    image: mariadb:10.6.10
+    image: mariadb:10.6.10@sha256:d1bd65504ffbea8dc7445223c9a9b1e6dc7d93f49f5ceff352bb9d43f52d0ffa
     environment:
       - MYSQL_ROOT_PASSWORD=0c9d2acc-d4f3-423c-8361-86f35cdd3eb2
       - MYSQL_DATABASE=davis

--- a/apps/dbgate/docker-compose.yml
+++ b/apps/dbgate/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-dbgate
     # Image to be used for the container
-    image: dbgate/dbgate:7.2.1-alpine
+    image: dbgate/dbgate:7.2.1-alpine@sha256:91ddb068053c8b8cc46f7b5b7e56e5864ac53bcf2a21339fbed6d83e2f97205b
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/discopanel/docker-compose.yml
+++ b/apps/discopanel/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-discopanel
 
     # Image to be used for the container
-    image: nickheyer/discopanel:v2.0.15
+    image: nickheyer/discopanel:v2.0.15@sha256:4b8bd7d13bceaa4fbb06846760814fcaecf29a4383dbb3b8563b5df23efde192
 
     # Container restart policy
     restart: unless-stopped

--- a/apps/diun/docker-compose.yml
+++ b/apps/diun/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-diun
     # Image to be used for the container
-    image: crazymax/diun:4.33.0
+    image: crazymax/diun:4.33.0@sha256:e324b793eb32dfb7f74d3a39421ebf090141caaadee69b8f78da63112408ee25
     # Command to run inside the container
     command: ["serve"]
     # Container restart policy

--- a/apps/docker-cron-restart-notifier/docker-compose.yml
+++ b/apps/docker-cron-restart-notifier/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-docker-cron-restart-notifier
     # Image to be used for the container
-    image: deduard/tools:restart-notifier-latest
+    image: deduard/tools:restart-notifier-latest@sha256:8299b18aaff643879f94193b23615cb794e3828b165f2da3847c24470f3ebb02
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/dockge/docker-compose.yml
+++ b/apps/dockge/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-dockge
     # Image to be used for the container
-    image: louislam/dockge:1.5.0
+    image: louislam/dockge:1.5.0@sha256:335c6368b880ecc203236ed89e6e5232e0d6578e8ef5920e4a502390451502bf
     # Environment variables
     environment:
       # Tell Dockge where is your stacks directory

--- a/apps/dockhand/docker-compose.yml
+++ b/apps/dockhand/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-dockhand
 
     # Image to be used for the container
-    image: fnsys/dockhand:latest
+    image: fnsys/dockhand:latest@sha256:1927b2b33966a83964a876d010818157b84af05fc3736f1c0c600d7291f2c2b1
 
     # Container restart policy
     restart: unless-stopped

--- a/apps/dockpeek/docker-compose.yml
+++ b/apps/dockpeek/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-dockpeek
     # Image to be used for the container
-    image: ghcr.io/dockpeek/dockpeek:v1.7.2
+    image: ghcr.io/dockpeek/dockpeek:v1.7.2@sha256:87654d0104eacff48a70c7c1eea6126f19f5803b21bfdace842ae765351593b4
     # Environment variables
     environment:
       # Secret key for the application (change this)

--- a/apps/docmost/docker-compose.yml
+++ b/apps/docmost/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-docmost
     # Image to be used for the container
-    image: docmost/docmost:0.90.1
+    image: docmost/docmost:0.90.1@sha256:665d9a522e10b6e919188ffa8d3baf6572f064569dbd5630fbe0605d5b91916f
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -32,7 +32,7 @@ services:
       - big-bear-docmost-redis
   big-bear-docmost-db:
     container_name: big-bear-docmost-db
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
     environment:
       - POSTGRES_DB=docmost
       - POSTGRES_USER=docmost

--- a/apps/dozzle/docker-compose.yml
+++ b/apps/dozzle/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-dozzle
     # Image to be used for the container
-    image: amir20/dozzle:v10.6.8
+    image: amir20/dozzle:v10.6.8@sha256:d282389858d23858cfe23882f9965d42145f370ac4abc021639efd95c3334336
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/ejbca-ce/docker-compose.yml
+++ b/apps/ejbca-ce/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ejbca-ce
     # Image to be used for the container
-    image: keyfactor/ejbca-ce:9.3.7
+    image: keyfactor/ejbca-ce:9.3.7@sha256:183b86af44b9b13e7cc8912c868f635aeb8dba6bf056ccbd4683b17626964d0a
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/ente/docker-compose.yml
+++ b/apps/ente/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ente_network
 
   socat:
-    image: alpine/socat
+    image: alpine/socat@sha256:d85531a29ef5ba99dfb4717485c239307e2902d522a1bc010992a2728c92cfad
     container_name: ente-socat
     network_mode: service:museum
     depends_on:
@@ -60,7 +60,7 @@ services:
       - ente_network
 
   postgres:
-    image: postgres:15
+    image: postgres:15@sha256:bcab099bfaab33333a73a2ebe8c1d615c9f4c2402dd43452f989a36c6da9a5ba
     container_name: ente-postgres
     environment:
       POSTGRES_USER: pguser
@@ -79,7 +79,7 @@ services:
       - ente_network
 
   minio:
-    image: minio/minio
+    image: minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: ente-minio
     ports:
       - "3200:3200"
@@ -94,7 +94,7 @@ services:
       - ente_network
 
   minio-init:
-    image: minio/mc
+    image: minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     container_name: ente-minio-init
     depends_on:
       - minio

--- a/apps/erugo/docker-compose.yml
+++ b/apps/erugo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-erugo
     # Image to be used for the container
-    image: wardy784/erugo:0.2.15
+    image: wardy784/erugo:0.2.15@sha256:0d9d31365e180408baee86172694a420418a7e05badd158fe84eb873a9f77753
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/eufy-security-ws/docker-compose.yml
+++ b/apps/eufy-security-ws/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-eufy-security-ws
     # Image to be used for the container
-    image: bropat/eufy-security-ws:3.1.0
+    image: bropat/eufy-security-ws:3.1.0@sha256:d41169205f4e20e1e7e173283aaf8bb2d68e2abecb42bc1500a5fac5bb7a8750
     # Environment variables for the container
     environment:
       USERNAME: "[EUFY_USERNAME]"

--- a/apps/excalidraw/docker-compose.yml
+++ b/apps/excalidraw/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-excalidraw
     # Docker image to be used
-    image: excalidraw/excalidraw:latest
+    image: excalidraw/excalidraw:latest@sha256:f7ee194addd607bf831d2af0f0a34463dd4225e426cf35199ef0b12a803398e9
     # Restart policy for the service
     restart: unless-stopped
     # Port mappings for the service

--- a/apps/farmos-v4/docker-compose.yml
+++ b/apps/farmos-v4/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Name of the container
     container_name: big-bear-farmos-v4
     # Image to be used for the container
-    image: farmos/farmos:4.0.3
+    image: farmos/farmos:4.0.3@sha256:e297af5d4c9f8313efa4de0450c2750d7f44e2c605c0fe14dda10eb7a86c69c6
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -49,7 +49,7 @@ services:
     # Specify the container name
     container_name: big-bear-farmos-v4-db
     # Use MariaDB 10.6 image (minimum required for farmOS v4)
-    image: mariadb:10.6
+    image: mariadb:10.6@sha256:114d40be36852d0a019afd8458f7e1cc63fd300403b115b1f32e31130d5f671b
     # Mount the database files to persist data
     volumes:
       - "farmos-v4_db:/var/lib/mysql"

--- a/apps/farmos/docker-compose.yml
+++ b/apps/farmos/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-farmos
     # Image to be used for the container
-    image: farmos/farmos:3.5.1
+    image: farmos/farmos:3.5.1@sha256:7eca19088bcfc290d9811cf013ded4b4c1552f5cc65d9fc8766c532351748626
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -28,7 +28,7 @@ services:
     # Specify the container name
     container_name: big-bear-farmos-db
     # Use MariaDB version 10 image
-    image: mariadb:10
+    image: mariadb:10@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350
     # Mount the database files to persist data
     volumes:
       - "farmos_db:/var/lib/mysql"

--- a/apps/faster-whisper/docker-compose.yml
+++ b/apps/faster-whisper/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-faster-whisper
     # Image to be used for the container
-    image: linuxserver/faster-whisper:3.3.1
+    image: linuxserver/faster-whisper:3.3.1@sha256:69462a9da4ed3da7fb5e19264b290d9420943d9264ca5fc81b52a51b0dc71fd5
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/fastfetch/docker-compose.yml
+++ b/apps/fastfetch/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-fastfetch
     # Image to be used for the container specifies the fastfetch version and source
-    image: bigbeartechworld/big-bear-fastfetch:0.0.5
+    image: bigbeartechworld/big-bear-fastfetch:0.0.5@sha256:fa84a845c95fdc1b9ee427786e7467c3909fbadfd98c4b32e0cf4a2f2a227751
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Run the container in privileged mode to allow access to system metrics

--- a/apps/filebrowser-quantum/docker-compose.yml
+++ b/apps/filebrowser-quantum/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: big-bear-filebrowser-quantum
 
     # Image to be used for the container
-    image: gtstef/filebrowser:1.4.0-stable
+    image: gtstef/filebrowser:1.4.0-stable@sha256:2cd949cd06c058576773c5b8400c854478a64c4f364b1e2bea275819847f099b
 
     # Container restart policy
     restart: unless-stopped

--- a/apps/filebrowser/docker-compose.yml
+++ b/apps/filebrowser/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-filebrowser
     # Image to be used for the container
-    image: filebrowser/filebrowser:v2.63.18-s6
+    image: filebrowser/filebrowser:v2.63.18-s6@sha256:6b41f1f8f12bc5359d825bf4096c17ef53d2c962a076361ea1b9b1923db7b422
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/financial-freedom/docker-compose.yml
+++ b/apps/financial-freedom/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-financial-freedom
     # Image to be used for the container
-    image: serversideup/financial-freedom:v0.2.0-alpha1
+    image: serversideup/financial-freedom:v0.2.0-alpha1@sha256:e36fc6e42b8fd41f9f715b2a26461f1c2365355ff139b8d5d2cfdc60593ccdf2
     # Container restart policy
     restart: unless-stopped
     # financial-freedom-network networks
@@ -71,7 +71,7 @@ services:
       - MYSQL_USER="bigbear"
       - MYSQL_PASSWORD="cd876479-f30b-43f2-8714-e52e040c657a"
   mariadb:
-    image: mariadb:10.11
+    image: mariadb:10.11@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350
     volumes:
       - financial-freedom_mariadb:/var/lib/mysql
     # financial-freedom-network is defined in networks section

--- a/apps/firefox/docker-compose.yml
+++ b/apps/firefox/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-firefox # Name of the CasaOS application
 services:
   firefox:
     container_name: big-bear-firefox # Name of the Docker container
-    image: linuxserver/firefox:1152.0.5 # Docker image for the Firefox browser
+    image: linuxserver/firefox:1152.0.5@sha256:d90c3bbaff5f4a0a1d0e24a65b2996e9bd940e137a6dbcfb1e78c4601313bba6 # Docker image for the Firefox browser
     ports:
       - "3000:3000" # Expose port 3000 for HTTP VNC access
       - "3001:3001" # Expose port 3001 for HTTPS VNC access

--- a/apps/flame/docker-compose.yml
+++ b/apps/flame/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main service for the Flame application
   app:
     # The Docker image to be used for the Flame application
-    image: pawelmalak/flame:multiarch2.3.1
+    image: pawelmalak/flame:multiarch2.3.1@sha256:9f88b17692a0e7393bfceec774dd556a8331032bfb737d7db282a2eedc6b74d1
     # Environment variables that configure the application
     environment:
       # Specifies the password to be used by the Flame application

--- a/apps/flcontainers-guacamole/docker-compose.yml
+++ b/apps/flcontainers-guacamole/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # app service configuration
   app:
     # Docker image to use for this service
-    image: flcontainers/guacamole:1.6.0
+    image: flcontainers/guacamole:1.6.0@sha256:81a420f386ef8cbb4697208e13ea90f6a10a54619981241bed672e4a41b5f77f
     # Container name
     container_name: big-bear-flcontainers-guacamole
     # Restart policy for the container

--- a/apps/flowise/docker-compose.yml
+++ b/apps/flowise/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-flowise
     # Image to be used for the container specifies the flowise version and source
-    image: flowiseai/flowise:3.1.3
+    image: flowiseai/flowise:3.1.3@sha256:fa39f54c82ebecabb817cbd2d01fc9fa7bb26d58a7e818c36bb6c2bad44b366a
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Entrypoint to be used for the container

--- a/apps/focalboard/docker-compose.yml
+++ b/apps/focalboard/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-focalboard
     # Docker image to be used
-    image: mattermost/focalboard:7.11.4
+    image: mattermost/focalboard:7.11.4@sha256:c935a2879dc7bcb8243a562afea21a30edbb6dbe029b53a9c0ae7ab4b3255c54
     # Restart policy for the service
     restart: unless-stopped
     # Port mappings for the service

--- a/apps/genmon/docker-compose.yml
+++ b/apps/genmon/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-genmon
     # Image to be used for the container
-    image: bigbeartechworld/big-bear-genmon:2.0.01
+    image: bigbeartechworld/big-bear-genmon:2.0.01@sha256:0cc8f42c7859c64b428e0b5eca908c7e67f02880b34520b3b1985558998a897a
     # Environment variables to set inside the container
     environment:
       - TZ=America/Chicago # Set the timezone to 'America/Chicago'

--- a/apps/ghost/docker-compose.yml
+++ b/apps/ghost/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-ghost
     # Docker image to be used
-    image: ghost:6.49.0-alpine
+    image: ghost:6.49.0-alpine@sha256:8d9be08b52c8bacdf1b3d752beb53748e8d5674a733a6994be2b40c37791e8d6
     # Restart policy for the service
     restart: on-failure
     # Networks used by the service
@@ -40,7 +40,7 @@ services:
     # Container name
     container_name: big-bear-ghost-db
     # Docker image to be used
-    image: mysql:8.0
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     # Restart policy for the service
     restart: on-failure
     # Volume mappings for persistent storage

--- a/apps/ghostfolio/docker-compose.yml
+++ b/apps/ghostfolio/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service definition for the Ghostfolio application
   big-bear-ghostfolio:
     container_name: big-bear-ghostfolio # Unique name for the container instance
-    image: ghostfolio/ghostfolio:3.18.0 # Docker image to use
+    image: ghostfolio/ghostfolio:3.18.0@sha256:f661cdba75921ce1b8d97b8b7b311f23edb8bdb16e1d0589498dc09afa7b7558 # Docker image to use
     restart: unless-stopped # Policy to restart the container unless manually stopped
     environment: # Environment variables for configuration
       NODE_ENV: production # Node environment setting (production, development, etc.)
@@ -35,7 +35,7 @@ services:
   # PostgreSQL database service for Ghostfolio
   big-bear-ghostfolio-db:
     container_name: big-bear-ghostfolio-db
-    image: postgres:15.4-alpine # Using PostgreSQL 15.4 on Alpine Linux
+    image: postgres:15.4-alpine@sha256:35ce2187f2f7fb75e8e79493e13743596c21eb3789ff41ece145ae04d06e93a5 # Using PostgreSQL 15.4 on Alpine Linux
     restart: unless-stopped
     environment: # Database configuration settings
       POSTGRES_DB: ghostfolio

--- a/apps/gitea-mirror/docker-compose.yml
+++ b/apps/gitea-mirror/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # Name of the container
     container_name: big-bear-gitea-mirror
     # Image to be used for the container
-    image: ghcr.io/raylabshq/gitea-mirror:v3.15.10
+    image: ghcr.io/raylabshq/gitea-mirror:v3.15.10@sha256:2d97c98fd6f32915bbcc247373b9b39606d337cb3fb576980673d842dcaea291
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-gitea
 services:
   big-bear-gitea:
     container_name: big-bear-gitea
-    image: gitea/gitea:1.26.4
+    image: gitea/gitea:1.26.4@sha256:8e25c717b8f748445e15ec46e0390f577cb628101184cb0a150d1dae126c1f39
     restart: unless-stopped
     ports:
       - "3000:3000"

--- a/apps/gladys/docker-compose.yml
+++ b/apps/gladys/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: app
   # The `app` service definition
   app:
-    image: gladysassistant/gladys:v4.81.0 # Docker image to use for the 'app' service
+    image: gladysassistant/gladys:v4.81.0@sha256:3a5fe199cc0c316866ccb93722c3bb673c6f1ab75db2002f6dd5d19c3e089d28 # Docker image to use for the 'app' service
     restart: always # Container should always restart
     privileged: true # Grants additional privileges to this container
     network_mode: host

--- a/apps/glances/docker-compose.yml
+++ b/apps/glances/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Name of the container
     container_name: big-bear-glances
     # Docker image to use
-    image: nicolargo/glances:4.5.3.2-full
+    image: nicolargo/glances:4.5.3.2-full@sha256:2d16ab0fdba4b9f61b327f78dbb8a7e7931f4967be8e1db4d37326e4680e8433
     # Port mapping between host and container
     ports:
       - 61208:61208

--- a/apps/gluetun/docker-compose.yml
+++ b/apps/gluetun/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Portainer Agent Server service configuration
   gluetun:
     # This configuration is for the 'qmcgaw/gluetun' Docker image, a versatile VPN client in a Docker container.
-    image: qmcgaw/gluetun:v3.41.1
+    image: qmcgaw/gluetun:v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab
     # Assign a name to this container instance.
     container_name: gluetun
     # Uncomment the following line if you want to allow external containers to connect to this one.

--- a/apps/goaway/docker-compose.yml
+++ b/apps/goaway/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-goaway
     # Docker image to be used
-    image: pommee/goaway:0.63.17
+    image: pommee/goaway:0.63.17@sha256:971efe3aca286accf2d2da24b28bac57354df29949f800d5c48134363c9533ac
     # Restart policy for the service
     restart: unless-stopped
     # Port mappings for the service

--- a/apps/gotify/docker-compose.yml
+++ b/apps/gotify/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-gotify
 services:
   # Service name: app
   app:
-    image: gotify/server:2.9.1 # Docker image for the service
+    image: gotify/server:2.9.1@sha256:a3af47067ce6aad76aadf5ba32d6ddfecd1ae576a961359f039fd1831e8b7652 # Docker image for the service
     ports:
       - 8091:80 # Port mapping (host:container)
     environment: # Environment variables for the service

--- a/apps/guacamole/docker-compose.yml
+++ b/apps/guacamole/docker-compose.yml
@@ -5,12 +5,12 @@ services:
   # guacd service configuration
   guacd:
     # Docker image to use for this service
-    image: guacamole/guacd:1.6.0
+    image: guacamole/guacd:1.6.0@sha256:8974eaa9ba32f713daf311e7cc8cd7e4cdfba1edea39eed75524e78ef4b08f4f
     # Restart policy for the container
     restart: always
   # app service configuration
   app:
-    image: guacamole/guacamole:1.6.0
+    image: guacamole/guacamole:1.6.0@sha256:f344085e618bb05e22b964b0208dbd06d3468275bac70206f93805245e067b40
     restart: always
     # Link this service to the guacd service
     links:
@@ -27,7 +27,7 @@ services:
       - 8090:8080
   # mysql service configuration
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
     restart: always
     # Environment variables for the MySQL service
     environment:

--- a/apps/healthchecks/docker-compose.yml
+++ b/apps/healthchecks/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-healthchecks
     # Image to be used for the container
-    image: linuxserver/healthchecks:4.2.20260708
+    image: linuxserver/healthchecks:4.2.20260708@sha256:4cb0891d82d4a085eaeedd09f06ad9063e078587afdcfef0ad7ea61d53a97664
     # Container restart policy
     restart: unless-stopped
     environment:

--- a/apps/homarr-v1/docker-compose.yml
+++ b/apps/homarr-v1/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-homarr-v1
     # Image to be used for the container
-    image: ghcr.io/homarr-labs/homarr:v1.63.0
+    image: ghcr.io/homarr-labs/homarr:v1.63.0@sha256:6daf640531c1c114ccce15775185b3fb8958365a62c2fabc559d9cc5ae064326
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: homarr
     # Image to be used for the container
-    image: ghcr.io/ajnart/homarr:0.16.1
+    image: ghcr.io/ajnart/homarr:0.16.1@sha256:e103abadfb527186af5b4bd43df4eff7c67afa5cd4df8e65fa97910c8840b2a9
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/home-assistant/docker-compose.yml
+++ b/apps/home-assistant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-home-assistant
     # Image to be used for the container
-    image: ghcr.io/home-assistant/home-assistant:2026.5.1
+    image: ghcr.io/home-assistant/home-assistant:2026.5.1@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867
     # Container restart policy
     restart: unless-stopped
     # Required capabilities for Bluetooth management in Home Assistant Docker containers

--- a/apps/homebridge/docker-compose.yml
+++ b/apps/homebridge/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-homebridge
     # Image to be used for the container
-    image: homebridge/homebridge:2024-05-02
+    image: homebridge/homebridge:2024-05-02@sha256:ecdcb11b69a3c73e5c8e638a5f06ecd16d5212d8bdb52b58f1759f1fdcac6c9e
     # Container restart policy
     restart: unless-stopped
     # Environment Variables

--- a/apps/homer/docker-compose.yml
+++ b/apps/homer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # The `app` service definition
   app:
     # Specifies the Docker image to be used for the service
-    image: b4bz/homer:v26.4.2
+    image: b4bz/homer:v26.4.2@sha256:ace7c6a2cfb66e13f0e94d5534cb569562f190aa5cac9446b2453ef7822cd195
     # Assigns a name to the container created from this service definition
     container_name: homer
     # Binds the container's volumes to host directories or named volumes

--- a/apps/ihatemoney/docker-compose.yml
+++ b/apps/ihatemoney/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ihatemoney
     # Image to be used for the container
-    image: ihatemoney/ihatemoney:7.1.1
+    image: ihatemoney/ihatemoney:7.1.1@sha256:cfd8a44362458559f0b9a216e4f878eb2542ae383cceb1e074bcf8f59d91bb71
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -27,7 +27,7 @@ services:
       - big_bear_ihatemoney_network # Connects the service to a network.
   # Define a service named 'big-bear-ihatemoney-db' for the database.
   big-bear-ihatemoney-db:
-    image: mariadb:10 # Use MariaDB version 10 Docker image.
+    image: mariadb:10@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350 # Use MariaDB version 10 Docker image.
     container_name: big-bear-ihatemoney-db # Custom container name.
     environment:
       MYSQL_ROOT_PASSWORD: password # Root password for MariaDB.

--- a/apps/immich-aio-alpine/docker-compose.yml
+++ b/apps/immich-aio-alpine/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   # Configuration for Database service
   big-bear-immich-db:
     container_name: big-bear-immich-db # Name of the running container
-    image: tensorchord/pgvecto-rs:pg14-v0.2.0 # Image to be used
+    image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:739cdd626151ff1f796dc95a6591b55a714f341c737e27f045019ceabf8e8c52 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos
       POSTGRES_USER: casaos

--- a/apps/immich-kiosk/docker-compose.yml
+++ b/apps/immich-kiosk/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-immich-kiosk
     # Image to be used for the container specifies the Immich Kiosk version and source
-    image: ghcr.io/damongolding/immich-kiosk:0.38.1
+    image: ghcr.io/damongolding/immich-kiosk:0.38.1@sha256:28cf751b556e5c9fefc18f0c2b0ed2d6fe672df734ca3c860d6adc9b2b7fdffb
     # Enable TTY for interactive terminal access
     tty: true
     # Container restart policy - restarts the container unless manually stopped

--- a/apps/immich-without-machine-learning/docker-compose.yml
+++ b/apps/immich-without-machine-learning/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v2.7.5 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5 # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -32,7 +32,7 @@ services:
   # Configuration for Database service
   database:
     container_name: immich-postgres # Name of the running container
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0@sha256:c570d9e1c2494f65d2a0a379a7f6df66e8441964254a30aa62cc58e8ebf1dee0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos
       POSTGRES_USER: casaos

--- a/apps/immich/docker-compose.yml
+++ b/apps/immich/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Immich Server service configuration
   immich-server:
     container_name: immich-server # Name of the running container
-    image: ghcr.io/immich-app/immich-server:v3.0.0 # Image to be used
+    image: ghcr.io/immich-app/immich-server:v3.0.0@sha256:685ba5c93337058ff8a189d3ed89f0ba470ef966b1c94d2eace1a3d991f9816e # Image to be used
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -31,7 +31,7 @@ services:
   # Configuration for Immich Machine Learning service
   immich-machine-learning:
     container_name: immich-machine-learning # Name of the running container
-    image: ghcr.io/immich-app/immich-machine-learning:v3.0.0 # Image to be used
+    image: ghcr.io/immich-app/immich-machine-learning:v3.0.0@sha256:5b480e92a2b77618d9ccae8c8110b0eae144ec9daf86715d246ec6d39cb7a553 # Image to be used
     volumes: # Mounting directories for persistent data storage
       - immich_model-cache:/cache
     environment: # Setting environment variables
@@ -55,7 +55,7 @@ services:
   # Configuration for Database service
   database:
     container_name: immich-postgres # Name of the running container
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0 # Image to be used
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0@sha256:c570d9e1c2494f65d2a0a379a7f6df66e8441964254a30aa62cc58e8ebf1dee0 # Image to be used
     environment: # Setting environment variables
       POSTGRES_PASSWORD: casaos
       POSTGRES_USER: casaos

--- a/apps/invoice-ninja/docker-compose.yml
+++ b/apps/invoice-ninja/docker-compose.yml
@@ -5,7 +5,7 @@ name: big-bear-invoice-ninja
 # Service definitions for the big-bear-invoice-ninja application
 services:
   big-bear-invoice-ninja:
-    image: invoiceninja/invoiceninja:5.13.26
+    image: invoiceninja/invoiceninja:5.13.26@sha256:d1eec88a8134481b19a0d78107abc6a72bf29987e310cc82f3b81dfcb02decf1
     container_name: big-bear-invoice-ninja
     restart: unless-stopped
     user: 1500:1500
@@ -36,7 +36,7 @@ services:
     # Name of the container
     container_name: big-bear-invoice-ninja-web
     # Image to be used for the container
-    image: nginx:1.29
+    image: nginx:1.29@sha256:1881968aff6f7cdcc4b888c00a11f4ce241ad7ec957e0cb4a9e19e93a3ff87ea
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -50,7 +50,7 @@ services:
     networks:
       - big-bear-invoice-ninja-network
   big-bear-invoice-ninja-db:
-    image: mariadb:10.4
+    image: mariadb:10.4@sha256:22edfe1c78349f8cae88bbb5c2873b7e6c515be767c91c691308ce57445806f3
     container_name: big-bear-invoice-ninja-db
     restart: unless-stopped
     environment:
@@ -67,7 +67,7 @@ services:
     # This command is required to set important mariadb defaults
     command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
   big-bear-invoice-ninja-init:
-    image: bash:5.3.15
+    image: bash:5.3.15@sha256:a19c811ee9e97fa8a080001d82b8e0ded303f0795cffdb1cbd162731bc8ce208
     container_name: big-bear-invoice-ninja-init
     volumes:
       - invoice-ninja_data:/tmp/data

--- a/apps/it-tools/docker-compose.yml
+++ b/apps/it-tools/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-it-tools
     # Image to be used for the container
-    image: corentinth/it-tools:2023.11.2-7d94e11
+    image: corentinth/it-tools:2023.11.2-7d94e11@sha256:30b032f2175e9c4dc5c795cfa44354ce7fe76d9768caee0f24a9a7371948ac0d
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/jellyseerr/docker-compose.yml
+++ b/apps/jellyseerr/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-jellyseerr # Name of the compose project
 services:
   app:
-    image: fallenbagel/jellyseerr:2.7.3 # Image to use for the jellyseerr service
+    image: fallenbagel/jellyseerr:2.7.3@sha256:4538137bc5af902dece165f2bf73776d9cf4eafb6dd714670724af8f3eb77764 # Image to use for the jellyseerr service
     ports:
       - "5055:5055" # Maps port 5055 on the host to port 5055 on the container
     volumes:

--- a/apps/jellystat/docker-compose.yml
+++ b/apps/jellystat/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-jellystat
     # Image to be used for the container
-    image: cyfershepard/jellystat:1.1.11
+    image: cyfershepard/jellystat:1.1.11@sha256:c4e2dfa8bddf8d5ac3a675d7202f71a54dcfe3540cc186899d9201e0fe701fa5
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -30,7 +30,7 @@ services:
       - big-bear-jellystat-network
   big-bear-jellystat-db:
     container_name: big-bear-jellystat-db
-    image: postgres:15.2
+    image: postgres:15.2@sha256:78a275d4c891f7b3a33d3f1a78eda9f1d744954d9e20122bfdc97cdda25cddaf
     environment:
       POSTGRES_DB: "jfstat"
       POSTGRES_USER: postgres

--- a/apps/jfa-go/docker-compose.yml
+++ b/apps/jfa-go/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-jfa-go
     # Image to be used for the container specifies the hrfee/jfa-go version and source
-    image: hrfee/jfa-go:latest
+    image: hrfee/jfa-go:latest@sha256:701cfca823f9278b65f4cf7706b0c7f89b3be33e17ca077f11d89dc119e9f307
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Volume mappings required for system integration

--- a/apps/jlesage-firefox/docker-compose.yml
+++ b/apps/jlesage-firefox/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-jlesage-firefox # Name of the CasaOS application
 services:
   big-bear-jlesage-firefox:
     container_name: big-bear-jlesage-firefox # Name of the Docker container
-    image: jlesage/firefox:v26.03.1 # Docker image for the Firefox browser
+    image: jlesage/firefox:v26.03.1@sha256:a68749c6696c857d992c5b750c234ab86f184bcac92d6c080bab7679c759f845 # Docker image for the Firefox browser
     ports:
       - "5800:5800" # Expose port 5800 for VNC access
     environment:

--- a/apps/jlesage-handbrake/docker-compose.yml
+++ b/apps/jlesage-handbrake/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-jlesage-handbrake # Name of the CasaOS application
 services:
   big-bear-jlesage-handbrake:
     container_name: big-bear-jlesage-handbrake # Name of the Docker container
-    image: jlesage/handbrake:v26.03.3 # Docker image for the Handbrake
+    image: jlesage/handbrake:v26.03.3@sha256:2b1eb1e34cf2edba2590c3ab768206a11cf8916fbe8a8a3391fe74d9eabcdce0 # Docker image for the Handbrake
     ports:
       - "5800:5800" # Expose port 5800 for VNC access
     environment:

--- a/apps/joplin/docker-compose.yml
+++ b/apps/joplin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Configuration for the Joplin server service
   big-bear-joplin:
     container_name: big-bear-joplin # The name of the Docker container for easy reference.
-    image: joplin/server:3.7.1 # Docker image to use, specifying version.
+    image: joplin/server:3.7.1@sha256:0877bfba41a943017c42c58e90db9d8d548bfe699b5e410248b5b879371734f9 # Docker image to use, specifying version.
     restart: unless-stopped # Policy to automatically restart the container unless manually stopped.
     # Environment variables for the Joplin server, configuring database connection and application settings.
     environment:
@@ -30,7 +30,7 @@ services:
   # Configuration for the PostgreSQL database service used by Joplin
   big-bear-joplin-db:
     container_name: big-bear-joplin-db # Name of the database container.
-    image: postgres:14.2 # Docker image for PostgreSQL, specifying version.
+    image: postgres:14.2@sha256:2c954f8c5d03da58f8b82645b783b56c1135df17e650b186b296fa1bb71f9cfd # Docker image for PostgreSQL, specifying version.
     volumes:
       - joplin_postgresql_data:/var/lib/postgresql/data # Maps data directory to host for persistence.
     restart: unless-stopped # Restart policy similar to the Joplin server container.

--- a/apps/kasm/docker-compose.yml
+++ b/apps/kasm/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-kasm
     # Image to be used for the container
-    image: linuxserver/kasm:1.120.20221218
+    image: linuxserver/kasm:1.120.20221218@sha256:6f40f6c999fa626b8e68371298d0a7870b8bbd1696df4cbcb87352e681f7f7cd
     # Container restart policy
     restart: unless-stopped
     # Privilege of the container

--- a/apps/kavita/docker-compose.yml
+++ b/apps/kavita/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-kavita
     # Image to be used for the container
-    image: jvmilazz0/kavita:0.9.0
+    image: jvmilazz0/kavita:0.9.0@sha256:36aab0c578d488f8b10bd33910953b50965aff9ac6adc476ef4692c38c60427e
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/kiwix-serve/docker-compose.yml
+++ b/apps/kiwix-serve/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-kiwix-serve
     # Image to be used for the container
-    image: ghcr.io/kiwix/kiwix-serve:3.7.0-2
+    image: ghcr.io/kiwix/kiwix-serve:3.7.0-2@sha256:9a19c082d0cf4a2bebc190e62d9f76980f18ea35ca3c9347197c5ed0ebaa08ce
     # Command to run inside the container
     command: "*.zim"
     # Container restart policy

--- a/apps/komf/docker-compose.yml
+++ b/apps/komf/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-komf
     # Image to be used for the container
-    image: sndxr/komf:1.7.1
+    image: sndxr/komf:1.7.1@sha256:4a6971a76abc30869f6d0555a7328ff8cd879f3016a7378395df331c1245cbb2
     # Container restart policy
     restart: unless-stopped
     environment:

--- a/apps/komga/docker-compose.yml
+++ b/apps/komga/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-komga
     # Image to be used for the container
-    image: ghcr.io/gotson/komga:1.24.4
+    image: ghcr.io/gotson/komga:1.24.4@sha256:dae630271561b642d47c9723803ec77900d1f0a803fbe6a42da69db5b21ebaeb
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/kopia/docker-compose.yml
+++ b/apps/kopia/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-kopia
     # Image to be used for the container
-    image: ghcr.io/thespad/kopia-server:v0.17.0-spad3
+    image: ghcr.io/thespad/kopia-server:v0.17.0-spad3@sha256:e9e9256e0037030932b78a16bdef09894b6f9c6f89e8367e05d9777813e67f62
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/lancache/docker-compose.yml
+++ b/apps/lancache/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-lancache
 services:
   # Service name: app
   app:
-    image: lancachenet/monolithic:latest # Docker image for the caching service
+    image: lancachenet/monolithic:latest@sha256:a5f93cef3a4c48c63e9f09883ac7a3961621db56974427110d9aeb4f36af9360 # Docker image for the caching service
     environment:
       # Toggle for load balancer usage or separate IPs for each service
       - USE_GENERIC_CACHE=true
@@ -36,7 +36,7 @@ services:
       - lancache_logs:/data/logs
   # DNS service configuration
   dns:
-    image: lancachenet/lancache-dns:latest # Docker image for DNS service
+    image: lancachenet/lancache-dns:latest@sha256:3f37998a643435c2a9d1226a64ff13ea073f588031f6e3a92648b80d8281f20f # Docker image for DNS service
     environment:
       # Toggle for load balancer usage or separate IPs for each service
       - USE_GENERIC_CACHE=true

--- a/apps/libredesk/docker-compose.yml
+++ b/apps/libredesk/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-libredesk
     # Image to be used for the container
-    image: libredesk/libredesk:v0.7.4-alpha
+    image: libredesk/libredesk:v0.7.4-alpha@sha256:61dc7cea8d46d40d75b90a9ea0e4276d7d3092388e36ab7578049784fb96b57e
     # Container restart policy
     restart: unless-stopped
     # Environment variables
@@ -36,7 +36,7 @@ services:
       - big-bear-libredesk-network
   # PostgreSQL database
   big-bear-libredesk-db:
-    image: postgres:17-alpine
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
     container_name: big-bear-libredesk-db
     restart: unless-stopped
     networks:

--- a/apps/libretranslate/docker-compose.yml
+++ b/apps/libretranslate/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-libretranslate
     # Image to be used for the container
-    image: libretranslate/libretranslate:v1.9.6
+    image: libretranslate/libretranslate:v1.9.6@sha256:1de2d7056bb8ad607a412f4563d9abe324ff632b43b5be9428bcc8e213aebb32
     # Container restart policy
     restart: unless-stopped
     environment:

--- a/apps/linkstack/docker-compose.yml
+++ b/apps/linkstack/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # The `big-bear-linkstack` service definition
   big-bear-linkstack:
     # Image to be used for the container
-    image: linkstackorg/linkstack:V4
+    image: linkstackorg/linkstack:V4@sha256:5cc5b4806f57c153e924fbd0c49d4255dee4c66cd6621f0e457fd43e43e5c000
     # Name of the container
     container_name: big-bear-linkstack
     # Hostname for the container

--- a/apps/linkwarden/docker-compose.yml
+++ b/apps/linkwarden/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-linkwarden
     # Image to be used for the container
-    image: ghcr.io/linkwarden/linkwarden:v2.14.1
+    image: ghcr.io/linkwarden/linkwarden:v2.14.1@sha256:31cf4bd2a2e111991fa5c9de03174c8698869c83722105c6ce529e4c911e6861
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -34,7 +34,7 @@ services:
     # Name of the container
     container_name: big-bear-linkwarden-db
     # Image to be used
-    image: postgres:16
+    image: postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/lobe-chat/docker-compose.yml
+++ b/apps/lobe-chat/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-lobe-chat
     # Image to be used for the container
-    image: lobehub/lobe-chat:1.143.3
+    image: lobehub/lobe-chat:1.143.3@sha256:b2d2454525523d9f0a19c79661f83ec45f13363dbadd5c1180887e77af35d872
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/ls-adguardhome-sync/docker-compose.yml
+++ b/apps/ls-adguardhome-sync/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ls-adguard-home-sync
     # Image to be used for the container
-    image: linuxserver/adguardhome-sync:0.9.2
+    image: linuxserver/adguardhome-sync:0.9.2@sha256:1cb17c47915b27f2eb1757c6bbc0170ef5d95585ad2eda66d3a517ac7c0dd958
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/lyrionmusicserver/docker-compose.yml
+++ b/apps/lyrionmusicserver/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-lyrionmusicserver
     # Image to be used for the container
-    image: lmscommunity/lyrionmusicserver:9.2.0
+    image: lmscommunity/lyrionmusicserver:9.2.0@sha256:a6322f5596fa08967112be88536b72e4b93b63742c7885ba5d6a221b4c451819
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/mailpit/docker-compose.yml
+++ b/apps/mailpit/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-mailpit
 services:
   # Service name: app
   app:
-    image: axllent/mailpit:v1.30 # Image for the app service
+    image: axllent/mailpit:v1.30@sha256:5a49a77c5bdbe7c5474450b4f46348d09949df3695257729c93a30369382d4f6 # Image for the app service
     container_name: mailpit # Container name for the app service
     restart: unless-stopped # Restart policy for the container
     volumes: # Volumes to mount for the app service

--- a/apps/matterbridge/docker-compose.yml
+++ b/apps/matterbridge/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-matterbridge
     # Docker image to be used
-    image: luligu/matterbridge:3.9.3
+    image: luligu/matterbridge:3.9.3@sha256:32d33714771e2b0396cf239de7318e52666267418c39ae7aaf6fbfb96f56d3e4
     # Restart policy for the service
     restart: unless-stopped
     # Network mode set to host for Matter mdns support

--- a/apps/maybe-finance/docker-compose.yml
+++ b/apps/maybe-finance/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-maybe-finance
     # Image to be used for the container
-    image: ghcr.io/maybe-finance/maybe:sha-347c0a790693031fdd3b32792b5b6792693d1805
+    image: ghcr.io/maybe-finance/maybe:sha-347c0a790693031fdd3b32792b5b6792693d1805@sha256:92e13ea9d1639747da2e7ce603d28123f22ead2fa8c2b9fb8ac8e86ff4e21a7b
     # Container restart policy
     restart: unless-stopped
     # Privilege of the container
@@ -63,7 +63,7 @@ services:
     # Name of the container
     container_name: big-bear-maybe-finance-postgres
     # Image to be used for the container
-    image: postgres:16
+    image: postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/mealie/docker-compose.yml
+++ b/apps/mealie/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-mealie
     # Image to be used for the container
-    image: hkotel/mealie:v3.20.1
+    image: hkotel/mealie:v3.20.1@sha256:9b680f5dad8618e69317a005e083a00a699845fb2a72c392a558a4e2898aed20
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/microbin/docker-compose.yml
+++ b/apps/microbin/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       # List server publicly (default: false)
       MICROBIN_LIST_SERVER: "false"
     # Image to be used for the container
-    image: danielszabo99/microbin:2.1.4
+    image: danielszabo99/microbin:2.1.4@sha256:6660e5ccad0d764fa3c0032464ffb8f4b4f28c92a2eb9e39202b94cdc5b68909
     # Ports mapping between host and container
     ports:
       - "8888:8080"

--- a/apps/mind/docker-compose.yml
+++ b/apps/mind/docker-compose.yml
@@ -3,7 +3,7 @@ name: big-bear-mind
 # Service definitions for the big-bear-mind application
 services:
   app:
-    image: "mrcas/mind:v1.4.1"
+    image: "mrcas/mind:v1.4.1@sha256:152f824d093f2e8772af0d209afc710b9e79edf3e6286d7c3eccb0509dafffd4"
     container_name: mind
     environment:
       - TZ=UTC

--- a/apps/minio/docker-compose.yml
+++ b/apps/minio/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-minio
 services:
   app:
-    image: bigbeartechworld/big-bear-minio:RELEASE.2025-10-15T17-29-55Z
+    image: bigbeartechworld/big-bear-minio:RELEASE.2025-10-15T17-29-55Z@sha256:7a18393957baa73bb4e3181e2e53b8b7051a99d7ce9a020bf76a58961f68c10f
     container_name: big-bear-minio
     volumes:
       - minio_data:/data

--- a/apps/monica/docker-compose.yml
+++ b/apps/monica/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-monica
     # Image to be used for the container
-    image: monica:4.1.2
+    image: monica:4.1.2@sha256:f4e948060cf2ba9f304ed62de5c1e47035df91f0cb92f8cdbec924760f6735ae
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -29,7 +29,7 @@ services:
       - big_bear_monica_network
   # Database service for monica
   big-bear-monica-db:
-    image: mariadb:10.6.11
+    image: mariadb:10.6.11@sha256:efa2cc5bf16a2112ccb7e832f76d9e3913d017777b91293cd3e7c0d5e8286b23
     container_name: big-bear-monica-db
     environment:
       - TZ=UTC

--- a/apps/morphos/docker-compose.yml
+++ b/apps/morphos/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     # Name of the container
     container_name: big-bear-morphos
     # Image to be used for the container specifies the btop version and source
-    image: ghcr.io/danvergara/morphos-server:0.6.0
+    image: ghcr.io/danvergara/morphos-server:0.6.0@sha256:3d6f64ef386cbb6a7c5d55526e1a69da2d3661a1996d757897e92bf4369088f5
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Volume mappings required for system integration

--- a/apps/mumble-server/docker-compose.yml
+++ b/apps/mumble-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main application service
   app:
     # Docker image to use
-    image: mumblevoip/mumble-server:v1.4.230-6
+    image: mumblevoip/mumble-server:v1.4.230-6@sha256:42ea734f0a8962cde8c3cd5f0dc5536c9caf6131064093b9ba76ed133b104fc4
     # Name of the container
     container_name: mumble-server
     # Hostname for the container

--- a/apps/music-assistant/docker-compose.yml
+++ b/apps/music-assistant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-music-assistant-server
     # Image to be used for the container
-    image: ghcr.io/music-assistant/server:2.8.7
+    image: ghcr.io/music-assistant/server:2.8.7@sha256:eef3ee7810d0e4702afa4a0ff55b10bbbfcaa16c98a277fe1b7f4cb6d5d426b4
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/myspeed/docker-compose.yml
+++ b/apps/myspeed/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: app
   # The `app` service definition
   app:
-    image: germannewsmaker/myspeed:1.0.9 # Docker image to be used for the service
+    image: germannewsmaker/myspeed:1.0.9@sha256:3a3e774b3f78d930a5a962d625b99bcb3d71730bfeb4a6b93e04fd38cfe7d9a9 # Docker image to be used for the service
     ports:
       - "5216:5216" # Port mapping from host to container
     volumes:

--- a/apps/n8n/docker-compose.yml
+++ b/apps/n8n/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Service configuration for the n8n application
   app:
     container_name: n8n # Name of the n8n container
-    image: n8nio/n8n:2.29.2 # Docker image and version to use for n8n
+    image: n8nio/n8n:2.29.2@sha256:1357982c594730263f0dedf9e1770075b78cac9417775d30531a3c00a72b2a58 # Docker image and version to use for n8n
     restart: unless-stopped # Restart policy: Restart unless manually stopped
     ports:
       - 5678:5678 # Port mapping between host and container
@@ -27,7 +27,7 @@ services:
   # Database service configuration
   db-n8n:
     container_name: db-n8n # Name of the database container
-    image: postgres:14.2 # Docker image and version for PostgreSQL
+    image: postgres:14.2@sha256:2c954f8c5d03da58f8b82645b783b56c1135df17e650b186b296fa1bb71f9cfd # Docker image and version for PostgreSQL
     restart: on-failure # Restart policy: Restart on failure
     volumes:
       - n8n_pgdata:/var/lib/postgresql/data # Persistent DB data

--- a/apps/ncdu/docker-compose.yml
+++ b/apps/ncdu/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ncdu
     # Image to be used for the container specifies the ncdu version and source
-    image: bigbeartechworld/big-bear-ncdu:0.0.9
+    image: bigbeartechworld/big-bear-ncdu:0.0.9@sha256:d48a75e108f9387393265eefc2e99564e4b717a78f5207d000ebe619e8ff05b3
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Run the container in privileged mode to allow access to system metrics

--- a/apps/neko-firefox/docker-compose.yml
+++ b/apps/neko-firefox/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: neko-firefox
     # Image to be used for the container
-    image: m1k1o/neko:firefox
+    image: m1k1o/neko:firefox@sha256:66a6b71166cb1a9340485ab5486c2d8a66c13f5b933702d392d6daeabf482d97
     # Container restart policy
     restart: unless-stopped
     # Shared memory size

--- a/apps/netalertx-v26/docker-compose.yml
+++ b/apps/netalertx-v26/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-netalertx-v26
     # Image to be used for the container
-    image: jokobsk/netalertx:26.7.1
+    image: jokobsk/netalertx:26.7.1@sha256:ffab3346b7a924b47bf6b992f369241801b736e54087011047e227937969532f
     # Container restart policy
     restart: unless-stopped
     # Drop all capabilities and add only what's needed

--- a/apps/netalertx/docker-compose.yml
+++ b/apps/netalertx/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-netalertx
     # Image to be used for the container
-    image: jokobsk/netalertx:25.11.29
+    image: jokobsk/netalertx:25.11.29@sha256:fd1a4ca4bd4c0f38797b36b4ec5b0928d7add7b9add788d9cedb11fd25a42a65
     # Container restart policy
     restart: unless-stopped
     # Make the container privileged

--- a/apps/netpulse/docker-compose.yml
+++ b/apps/netpulse/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-netpulse
     # Image to be used for the container
-    image: ghcr.io/bentfender/netpulse:sha-8922b29
+    image: ghcr.io/bentfender/netpulse:sha-8922b29@sha256:14a442573fe53e0e812d2d3e5d84f0ecc11646578372f55ff98ffc07d5288624
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/nextcloud-ls/docker-compose.yml
+++ b/apps/nextcloud-ls/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Define the container name
     container_name: big-bear-nextcloud-ls
     # Use the nextcloud:28.0.1-apache image
-    image: linuxserver/nextcloud:34.0.1
+    image: linuxserver/nextcloud:34.0.1@sha256:a5f914b3284eba90d9fe059fffaba9718dc194432a8b6cabe856b88d17436ec2
     # Restart the container unless stopped
     restart: unless-stopped
     # Map port 7580 on the host to port 80 on the container

--- a/apps/nextcloud-with-smbclient/docker-compose.yml
+++ b/apps/nextcloud-with-smbclient/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Define the container name
     container_name: big-bear-nextcloud-smb
     # Use the nextcloud image from the official Docker Hub
-    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5@sha256:c74370fa69284a8f2243cc3ee07d429ef81d089c746f71771d2b9ade4b5625b2
     # Restart the container unless stopped
     restart: unless-stopped
     # Map port 7580 on the host to port 80 on the container
@@ -44,7 +44,7 @@ services:
   # Define the database container for Nextcloud
   big-bear-nextcloud-smb-db:
     container_name: big-bear-nextcloud-smb-db
-    image: postgres:14.2
+    image: postgres:14.2@sha256:2c954f8c5d03da58f8b82645b783b56c1135df17e650b186b296fa1bb71f9cfd
     restart: unless-stopped
     volumes:
       - nextcloud-with-smbclient_pgdata:/var/lib/postgresql/data # Mount the PostgreSQL data directory
@@ -78,7 +78,7 @@ services:
       retries: 5
   big-bear-nextcloud-smb-cron:
     container_name: big-bear-nextcloud-smb-cron
-    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5@sha256:c74370fa69284a8f2243cc3ee07d429ef81d089c746f71771d2b9ade4b5625b2
     restart: on-failure
     volumes:
       - nextcloud-with-smbclient_html:/var/www/html

--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Define the container name
     container_name: nextcloud
     # Use the nextcloud image from the official Docker Hub
-    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5@sha256:c74370fa69284a8f2243cc3ee07d429ef81d089c746f71771d2b9ade4b5625b2
     # Restart the container unless stopped
     restart: unless-stopped
     # Map port 7580 on the host to port 80 on the container
@@ -44,7 +44,7 @@ services:
   # Define the database container for Nextcloud
   db-nextcloud:
     container_name: db-nextcloud
-    image: postgres:14.2
+    image: postgres:14.2@sha256:2c954f8c5d03da58f8b82645b783b56c1135df17e650b186b296fa1bb71f9cfd
     restart: unless-stopped
     volumes:
       - nextcloud_pgdata:/var/lib/postgresql/data # Mount the PostgreSQL data directory
@@ -77,7 +77,7 @@ services:
       timeout: 5s
       retries: 5
   cron:
-    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5
+    image: bigbeartechworld/big-bear-nextcloud-with-smbclient:33.0.5@sha256:c74370fa69284a8f2243cc3ee07d429ef81d089c746f71771d2b9ade4b5625b2
     restart: unless-stopped
     volumes:
       - nextcloud_html:/var/www/html

--- a/apps/nexterm/docker-compose.yml
+++ b/apps/nexterm/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-nexterm
     # Image to be used for the container
-    image: nexterm/aio:1.2.1-BETA
+    image: nexterm/aio:1.2.1-BETA@sha256:9760eaa844e679e595e1ca53ef667fa5e478e1bb2cc9a7b862aa446dc692385e
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the big-bear-nexterm container

--- a/apps/nightscout/docker-compose.yml
+++ b/apps/nightscout/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     # Name of the container
     container_name: big-bear-nightscout
     # Image to be used for the container
-    image: nightscout/cgm-remote-monitor:15.0.7
+    image: nightscout/cgm-remote-monitor:15.0.7@sha256:4399411fad4014352832865266207eb1ba4e3ec4129e4776ae3142a4e9abe913
     # Container restart policy
     restart: unless-stopped
     # Port mappings for the container
@@ -54,7 +54,7 @@ services:
     # Name of the MongoDB container
     container_name: big-bear-nightscout-mongo
     # Image to be used for the MongoDB container
-    image: mongo:4.4
+    image: mongo:4.4@sha256:4be76f674fc4b27859816811b8baa3c51830eb1dbf4ca81a51e26b79edd662ef
     # Networks for the MongoDB container
     networks:
       - big-bear-nightscout-network

--- a/apps/nocodb/docker-compose.yml
+++ b/apps/nocodb/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: big-bear-nocodb
   # This section configures the NocoDB application itself
   big-bear-nocodb:
-    image: nocodb/nocodb:0.301.5 # Specifies the Docker image to use for NocoDB
+    image: nocodb/nocodb:0.301.5@sha256:d9516f0bf546fd6c78a382ab0657626c683fca7aaafdbbe53c66baf15df7fc0d # Specifies the Docker image to use for NocoDB
     container_name: big-bear-nocodb # Sets a custom name for the container
     restart: unless-stopped # Container restart policy to ensure availability
     environment: # Environment variables for configuring NocoDB
@@ -23,7 +23,7 @@ services:
   # Database service configuration
   big-bear-nocodb-db:
     container_name: big-bear-nocodb-db
-    image: postgres:13 # Specifies the PostgreSQL Docker image to use
+    image: postgres:13@sha256:4689940c683801b4ab839ab3b0a0a3555a5fe425371422310944e89eca7d8068 # Specifies the PostgreSQL Docker image to use
     restart: always # Ensures the database container is always running
     environment: # Database credentials and configurations
       POSTGRES_DB: nocodb # Database name

--- a/apps/node-red/docker-compose.yml
+++ b/apps/node-red/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: node-red
     # Docker image to be used
-    image: nodered/node-red:5.0.1
+    image: nodered/node-red:5.0.1@sha256:6cb1b27fa5a83deec6a662db62eec8bb32e55ac5412d6b7a653e874ce62055d5
     # Restart policy for the service
     restart: unless-stopped
     # Port mappings for the service

--- a/apps/note-mark-aio/docker-compose.yml
+++ b/apps/note-mark-aio/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-note-mark-aio
     # Image to be used for the container
-    image: ghcr.io/enchant97/note-mark-aio:0.19.4
+    image: ghcr.io/enchant97/note-mark-aio:0.19.4@sha256:b8d6ff400af1e3a27ef8f2968308310b9816ad35d066dc83aab9bbdf73a51069
     # Container restart policy
     restart: unless-stopped
     environment:

--- a/apps/nova-dso-tracker/docker-compose.yml
+++ b/apps/nova-dso-tracker/docker-compose.yml
@@ -1,7 +1,7 @@
 name: nova-dso-tracker
 services:
   nova:
-    image: mrantonsg/nova-dso-tracker:6.2.0
+    image: mrantonsg/nova-dso-tracker:6.2.0@sha256:eb5cd12f4c7627ec6e70051f4bccc5852db1efcd349402929b0c2cc0da2f1938
     container_name: big-bear-nova-dso-tracker
     ports:
       - "5001:5001"

--- a/apps/npmplus/docker-compose.yml
+++ b/apps/npmplus/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-npmplus
     # Image to be used for the container
-    image: zoeyvid/npmplus:449
+    image: zoeyvid/npmplus:449@sha256:2d950075a98c3aece33e3f771abc0ecabfba4e428fad6f55db7f75c7c637ed81
     # Container restart policy
     restart: unless-stopped
     # Network mode for the container

--- a/apps/ntfysh/docker-compose.yml
+++ b/apps/ntfysh/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main application service configuration
   app:
     # Docker image to be used for the service
-    image: binwiederhier/ntfy:v2.25.0
+    image: binwiederhier/ntfy:v2.25.0@sha256:cfbbb1bac9196cb711e29ef0ac4adaeb033be6235f1df857705dc39c14384a1d
     # Command to run inside the container
     command:
       - serve

--- a/apps/obsidian-livesync/docker-compose.yml
+++ b/apps/obsidian-livesync/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: obsidian-livesync
     # Image to be used for the container
-    image: couchdb:3.5.0
+    image: couchdb:3.5.0@sha256:1c0a30a54535377bc9ae23f42efb1ca4e92abe796f78ec98b768ac1d5874cc1b
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/obsidian/docker-compose.yml
+++ b/apps/obsidian/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-obsidian
     # Image to be used for the container
-    image: linuxserver/obsidian:1.12.7
+    image: linuxserver/obsidian:1.12.7@sha256:6d7d462c8cd3e4b3b5aabee2c5a69d026c9fe41913adec115ae3ecbc8096dec0
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/octoprint/docker-compose.yml
+++ b/apps/octoprint/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: octoprint
     # Image to be used for the container
-    image: octoprint/octoprint:1.11.8
+    image: octoprint/octoprint:1.11.8@sha256:5ea0181e476597faa2800c991af4ce16903005f46b4c16666a4080ad606310bb
     # Container restart policy
     restart: unless-stopped
     # devices:

--- a/apps/odoo/docker-compose.yml
+++ b/apps/odoo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-odoo # Specifies the container instance name for identification
     # Image to be used for the container
-    image: odoo:19 # Docker image for Odoo version 17
+    image: odoo:19@sha256:f54272f31d5f77e4146b887efb3761c98480317daf687e4b4b5e76ed8bcc08c5 # Docker image for Odoo version 17
     # Container restart policy
     restart: unless-stopped # Restart policy to ensure service recovery
     # User to run the container as
@@ -33,7 +33,7 @@ services:
   # Database service for Odoo
   big-bear-odoo-db:
     container_name: big-bear-odoo-db # Database container name
-    image: postgres:15 # PostgreSQL version 15 Docker image
+    image: postgres:15@sha256:bcab099bfaab33333a73a2ebe8c1d615c9f4c2402dd43452f989a36c6da9a5ba # PostgreSQL version 15 Docker image
     user: root # Runs as root user
     environment:
       - POSTGRES_USER=odoo # Database user

--- a/apps/odysseus/docker-compose.yml
+++ b/apps/odysseus/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-odysseus
     # Image to be used for the container
-    image: bigbeartechworld/big-bear-odysseus:2026.06.29
+    image: bigbeartechworld/big-bear-odysseus:2026.06.29@sha256:64ec6fadda7de876097878d4ec32b1dce8c7f6c00d9ae4de8620037d009bac2d
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container
@@ -59,7 +59,7 @@ services:
     # Name of the container
     container_name: big-bear-odysseus-chromadb
     # Image to be used for the container
-    image: chromadb/chroma:1.5.9
+    image: chromadb/chroma:1.5.9@sha256:1e0b73a187a28757c572acba508c46f48c9e8b0acaf5c20e6d95cdedce1acdf6
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -77,7 +77,7 @@ services:
     # Name of the container
     container_name: big-bear-odysseus-searxng
     # Image to be used for the container
-    image: searxng/searxng:2026.6.2-e964708c0
+    image: searxng/searxng:2026.6.2-e964708c0@sha256:0872beb1d495d41f2dda73d7aea83746657afdd2be3010eb1b11f5a541555c9e
     # Container restart policy
     restart: unless-stopped
     # Inline entrypoint seeds settings.yml (secret + html/json formats) into the volume
@@ -133,7 +133,7 @@ services:
     # Name of the container
     container_name: big-bear-odysseus-ntfy
     # Image to be used for the container
-    image: binwiederhier/ntfy:v2.25.0
+    image: binwiederhier/ntfy:v2.25.0@sha256:cfbbb1bac9196cb711e29ef0ac4adaeb033be6235f1df857705dc39c14384a1d
     # Container restart policy
     restart: unless-stopped
     # Run the ntfy server

--- a/apps/ollama-amd/docker-compose.yml
+++ b/apps/ollama-amd/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ollama-amd
     # Image to be used for the container
-    image: ollama/ollama:0.31.2-rocm
+    image: ollama/ollama:0.31.2-rocm@sha256:b718f6b4f86fe27ac36791af72edce3cc2b5b5ada5089b78efd715bd2d8851f8
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/ollama-cpu/docker-compose.yml
+++ b/apps/ollama-cpu/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ollama-cpu
     # Image to be used for the container
-    image: ollama/ollama:0.31.2
+    image: ollama/ollama:0.31.2@sha256:509fdf54e23bd50d87af646cb51c0a7a203d6a83cc4d6695b3b08c5be1c62c0a
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/ollama-nvidia/docker-compose.yml
+++ b/apps/ollama-nvidia/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-ollama-nvidia
     # Image to be used for the container
-    image: ollama/ollama:0.31.2
+    image: ollama/ollama:0.31.2@sha256:509fdf54e23bd50d87af646cb51c0a7a203d6a83cc4d6695b3b08c5be1c62c0a
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/onedev/docker-compose.yml
+++ b/apps/onedev/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-onedev
     # Image to be used for the container
-    image: 1dev/server:16.0.5
+    image: 1dev/server:16.0.5@sha256:327030763933d36d0aa39a94b76128fb95d6dd1ca5c7595d57d9ba2ae0963169
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -42,7 +42,7 @@ services:
   # Define the service for the PostgreSQL database
   big-bear-onedev-db:
     container_name: big-bear-onedev-db # Container name for easy reference
-    image: postgres:14 # Use the specified PostgreSQL image
+    image: postgres:14@sha256:9e279cc7fc6e908da071befe389c576bd6752dbd295a9c078f96a75bab03e54c # Use the specified PostgreSQL image
     restart: unless-stopped # Policy to restart the container unless stopped manually
     environment: # Environment variables for PostgreSQL configuration
       - POSTGRES_USER=bigbear # Default username for PostgreSQL

--- a/apps/onlyoffice/docker-compose.yml
+++ b/apps/onlyoffice/docker-compose.yml
@@ -3,7 +3,7 @@ name: big-bear-onlyoffice
 # Service definitions for the big-bear-onlyoffice application
 services:
   app:
-    image: onlyoffice/documentserver:9.1.0
+    image: onlyoffice/documentserver:9.1.0@sha256:34b92f4a67bfd939bd6b75893e8217556e3b977f81e49472f7e28737b741ba1d
     container_name: documentserver
     ports:
       - "7400:80"

--- a/apps/open-webui/docker-compose.yml
+++ b/apps/open-webui/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-open-webui
     # Image to be used for the container
-    image: ghcr.io/open-webui/open-webui:git-33e54a9
+    image: ghcr.io/open-webui/open-webui:git-33e54a9@sha256:b1f3fdcbe97af8b282cecbc550339e55e032d37f6c5aeb1635457a209ec5d42f
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/openclaw/docker-compose.yml
+++ b/apps/openclaw/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-openclaw
 
 services:
   big-bear-openclaw:
-    image: ghcr.io/openclaw/openclaw:2026.5.3-1
+    image: ghcr.io/openclaw/openclaw:2026.5.3-1@sha256:142f70fa2751bdedf03648ae427372fff3f92ac0e96ab91abb3824b088c38b7b
     container_name: big-bear-openclaw
     environment:
       - HOME=/home/node
@@ -32,7 +32,7 @@ services:
       ]
 
   big-bear-openclaw-cli:
-    image: ghcr.io/openclaw/openclaw:2026.5.3-1
+    image: ghcr.io/openclaw/openclaw:2026.5.3-1@sha256:142f70fa2751bdedf03648ae427372fff3f92ac0e96ab91abb3824b088c38b7b
     container_name: big-bear-openclaw-cli
     environment:
       - HOME=/home/node

--- a/apps/openvpn-as/docker-compose.yml
+++ b/apps/openvpn-as/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-openvpn-as
     # Image to be used for the container
-    image: openvpn/openvpn-as:2.13.1-d8cdeb9c-Ubuntu22
+    image: openvpn/openvpn-as:2.13.1-d8cdeb9c-Ubuntu22@sha256:609aa2238acef1cb3b277c1e7f293e21da1033fb2eb1b52f51e8b22d6ee7227c
     # Container restart policy
     restart: unless-stopped
     # Privileged mode for the container

--- a/apps/otel-lgtm/docker-compose.yml
+++ b/apps/otel-lgtm/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-otel-lgtm
     # Image to be used for the container
-    image: grafana/otel-lgtm:0.28.0
+    image: grafana/otel-lgtm:0.28.0@sha256:10f48eb2f8670134df542177bb19536c55421b089e43f9dfc2a27d4c078204d8
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/owncloud/docker-compose.yml
+++ b/apps/owncloud/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-owncloud
     # Image to be used for the container
-    image: owncloud/server:10.16.3
+    image: owncloud/server:10.16.3@sha256:611a46000dbcf7e945aa243f3f6ff3a0f8b7c1c62ba81625a70029126a49e108
     # Container restart policy
     restart: unless-stopped
     # Environment variables
@@ -49,7 +49,7 @@ services:
       - big-bear-owncloud-redis
   big-bear-owncloud-db:
     container_name: big-bear-owncloud-db
-    image: mariadb:10.6
+    image: mariadb:10.6@sha256:114d40be36852d0a019afd8458f7e1cc63fd300403b115b1f32e31130d5f671b
     restart: unless-stopped
     environment:
       - MYSQL_ROOT_PASSWORD=f01914eb-2be3-4164-a57c-08e6518f313a

--- a/apps/paperless-ngx/docker-compose.yml
+++ b/apps/paperless-ngx/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-paperless-ngx
     # Image to be used for the container
-    image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
+    image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15@sha256:6c86cad803970ea782683a8e80e7403444c5bf3cf70de63b4d3c8e87500db92f
     # Container restart policy
     restart: unless-stopped
     # environment variables
@@ -45,7 +45,7 @@ services:
       - big-bear-paperless-ngx-network
   big-bear-paperless-ngx-broker:
     container_name: big-bear-paperless-ngx-broker
-    image: docker.io/library/redis:8.8.0
+    image: docker.io/library/redis:8.8.0@sha256:2838d5524559494f6f1cd66e97e76b200d64a633a8614200620755ed395daf32
     restart: unless-stopped
     volumes:
       - paperless-ngx_redis:/data
@@ -56,7 +56,7 @@ services:
     # Container name
     container_name: big-bear-paperless-ngx-db
     # Image to be used for the container
-    image: library/postgres:16
+    image: library/postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -78,7 +78,7 @@ services:
   # /tmp directory to prevent potential security issues.
   big-bear-paperless-ngx-gotenberg:
     container_name: big-bear-paperless-ngx-gotenberg
-    image: gotenberg/gotenberg:8.34
+    image: gotenberg/gotenberg:8.34@sha256:67097317623a503ba2a6a7e9ae8db6929a1f7e1bbd88077bacf2d325fbdab923
     restart: unless-stopped
     # The gotenberg chromium route is used to convert .eml files. We do not
     # want to allow external content like tracking pixels or even javascript.
@@ -94,7 +94,7 @@ services:
   # Apache Tika project and is configured to use the minimal image.
   big-bear-paperless-ngx-tika:
     container_name: big-bear-paperless-ngx-tika
-    image: apache/tika:3.3.1.0
+    image: apache/tika:3.3.1.0@sha256:90b7fa1dc018434075fce9e1d9b88b1e3d0ea6979d0cf86e116c79a8073ae973
     restart: unless-stopped
     # Volumes to be mounted to the container
     volumes:

--- a/apps/passwordpusher-v2/docker-compose.yml
+++ b/apps/passwordpusher-v2/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Name of the container
     container_name: big-bear-pwpush-v2
     # Image to be used for the container
-    image: pglombardo/pwpush:2.8.1
+    image: pglombardo/pwpush:2.8.1@sha256:2d92b5b62bcbc0e5cf6092e3828354a66dc784eda6de2171792a62cbfc7c4ea7
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container
@@ -60,7 +60,7 @@ services:
   big-bear-pwpush-v2-db:
     container_name: big-bear-pwpush-v2-db
     # PostgreSQL required for v2 (MySQL/MariaDB no longer supported)
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
     environment:
       POSTGRES_USER: "pwpusher"
       POSTGRES_PASSWORD: "6280144a-56af-486f-9088-ac7301399328"

--- a/apps/passwordpusher/docker-compose.yml
+++ b/apps/passwordpusher/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container (Docker does not have to generate a random name)
     container_name: big-bear-pwpush
     # Image to be used for the container
-    image: pglombardo/pwpush:1.69.3
+    image: pglombardo/pwpush:1.69.3@sha256:7bf7f919b87d818a9cafa2a5c53e2565a577a7b90983b3cd55de90d6de71cf07
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container
@@ -33,7 +33,7 @@ services:
       - big_bear_pwpush_network
   big-bear-pwpush-db:
     container_name: big-bear-pwpush-db
-    image: mariadb:10.6.5
+    image: mariadb:10.6.5@sha256:ca31f38b6e325ece985d857db7eba1fe59928b4fd83ff8a55cb912c9684b9e43
     ports:
       - "3306:3306"
     environment:

--- a/apps/pd3f/docker-compose.yml
+++ b/apps/pd3f/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-pd3f
     # Image to be used for the container
-    image: pd3f/pd3f:latest
+    image: pd3f/pd3f:latest@sha256:30a5c6c4c108c05799718d296630fb2d52d7053b2fba75cb0d89ff43b0eaa823
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -32,7 +32,7 @@ services:
       - big-bear-pd3f-network
   # Service name: parsr
   parsr:
-    image: axarev/parsr:v1.2.2
+    image: axarev/parsr:v1.2.2@sha256:9b2b844474cd750aa026cc4bcbba55fb807f93cead9f0bec47f8ac1dc9e33280
     networks:
       - big-bear-pd3f-network
     expose:
@@ -46,7 +46,7 @@ services:
       - 6379
   # Service name: worker
   worker:
-    image: pd3f/pd3f:latest
+    image: pd3f/pd3f:latest@sha256:30a5c6c4c108c05799718d296630fb2d52d7053b2fba75cb0d89ff43b0eaa823
     depends_on:
       - parsr
       - redis
@@ -62,7 +62,7 @@ services:
     command: ["rq", "worker", "-u", "redis://redis:6379", "--results-ttl", "86400"]
   # Service name: ocr_worker
   ocr_worker:
-    image: pd3f/pd3f-ocr:latest
+    image: pd3f/pd3f-ocr:latest@sha256:7bd3d4c8ba1816932e1f631d207056eb1f421f53f205b305372af8340db16a1b
     networks:
       - big-bear-pd3f-network
     volumes:

--- a/apps/penpot/docker-compose.yml
+++ b/apps/penpot/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-penpot-frontend
     # Image to be used for the container
-    image: penpotapp/frontend:2.16.2
+    image: penpotapp/frontend:2.16.2@sha256:4725b4698d8d1bd25ee1666e0d900d20da8937fea845c6a088f76cd69293560b
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -31,7 +31,7 @@ services:
   # Definition for penpot-backend service
   penpot-backend:
     # Docker image for the service
-    image: penpotapp/backend:2.16.2
+    image: penpotapp/backend:2.16.2@sha256:6c8e3851f3734e98e48d5a4a68e2c64485f6bd67a1ffec809aa9f1847d90a646
     # Name of the container
     container_name: big-bear-penpot-backend
     # Restart policy for the container
@@ -61,7 +61,7 @@ services:
   # Define the penpot-exporter service
   penpot-exporter:
     # Use the penpotapp/exporter:1.19.3 Docker image
-    image: penpotapp/exporter:2.16.2
+    image: penpotapp/exporter:2.16.2@sha256:b370f14927050fb05ac646441b5993d9337dda7eec60d944aa112819c88207bc
     # Set the container name to big-bear-penpot-exporter
     container_name: big-bear-penpot-exporter
     # Automatically restart the container unless stopped
@@ -77,7 +77,7 @@ services:
       - PENPOT_REDIS_URI=redis://big-bear-penpot-redis/0
   # Define the PostgreSQL service for Penpot
   penpot-postgres:
-    image: postgres:14
+    image: postgres:14@sha256:9e279cc7fc6e908da071befe389c576bd6752dbd295a9c078f96a75bab03e54c
     restart: unless-stopped
     container_name: big-bear-penpot-postgres
     stop_signal: SIGINT
@@ -100,7 +100,7 @@ services:
       - big-bear-penpot-network
   # Define the penpot-mailcatch service
   penpot-mailcatch:
-    image: sj26/mailcatcher:latest
+    image: sj26/mailcatcher:latest@sha256:5d153a4daadf0c266f29c3856085741f06ca1e3768671f4267622d3e3ffe5564
     restart: always
     expose:
       - "1025" # Expose port 1025 for SMTP

--- a/apps/peppermint/docker-compose.yml
+++ b/apps/peppermint/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-peppermint
     # Image to be used for the container
-    image: pepperlabs/peppermint:latest
+    image: pepperlabs/peppermint:latest@sha256:d13932713561c8d69baea49820ba2d42ea145b28193b6a7e33950a05812406fd
     # Container restart policy
     restart: always
     # Privilege of the container
@@ -51,7 +51,7 @@ services:
     # Name of the container
     container_name: db
     # Image to be used for the container
-    image: postgres:15.5
+    image: postgres:15.5@sha256:15b7f8dd3b75bc8f86ba8e875e92e560c03fd6314fe0a4d1315e169421aace01
     # Container restart policy
     restart: always
     # Environment variables for a PostgreSQL service or container

--- a/apps/photoprism/docker-compose.yml
+++ b/apps/photoprism/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-photoprism
     # Image to be used for the container
-    image: photoprism/photoprism:240915
+    image: photoprism/photoprism:240915@sha256:1f14335e2cd9dfaadc555ac8d40aa8a3966a5b5e5ef88fa78973ef7e8673fa2b
     environment:
       PHOTOPRISM_ADMIN_PASSWORD: casaos
       PHOTOPRISM_SITE_URL: "http://locahost/"
@@ -56,7 +56,7 @@ services:
   # Database service for Photoprism
   photoprism-db:
     # Docker image for the database
-    image: mariadb:10.8
+    image: mariadb:10.8@sha256:456709ab146585d6189da05669b84384518baecd83670c9e5221f8c20a47cf1e
     # Restart policy for the database container
     restart: unless-stopped
     # Container name for the database

--- a/apps/phpmyadmin/docker-compose.yml
+++ b/apps/phpmyadmin/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: phpmyadmin
   phpmyadmin:
     # Docker image to be used for this service
-    image: phpmyadmin/phpmyadmin:5.2.3
+    image: phpmyadmin/phpmyadmin:5.2.3@sha256:42a200db07b4e70fbf32c594ad4521cf16399b8e54bbb5adceae98e7566dfbeb
     # Name of the container once it's up and running
     container_name: big-bear-phpmyadmin
     # Environment variables passed to the service

--- a/apps/pihole-unbound/docker-compose.yml
+++ b/apps/pihole-unbound/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-pihole-unbound
     # Image to be used for the container
-    image: bigbeartechworld/big-bear-pihole-unbound:2026.06.0
+    image: bigbeartechworld/big-bear-pihole-unbound:2026.06.0@sha256:462ed84e3f4d8c2fb4749114ff37fcd7817221b3be867da75848d2b1736573eb
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/pihole-updatelists/docker-compose.yml
+++ b/apps/pihole-updatelists/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-pihole-updatelists
     # Image to be used for the container
-    image: jacklul/pihole:2026.06.0
+    image: jacklul/pihole:2026.06.0@sha256:374143d289e13aeef3a2d622f5f4565d2f10d1564a79a4217488cc2559bd766f
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/pihole/docker-compose.yml
+++ b/apps/pihole/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-pihole
     # Image to be used for the container
-    image: pihole/pihole:2026.06.0
+    image: pihole/pihole:2026.06.0@sha256:8ea95136e7c8c15b42d88eadf1a3875421aa1be30ad39e50f661188cc986fb27
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/pingvin-share/docker-compose.yml
+++ b/apps/pingvin-share/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Defines a set of services to be run together
   app:
     # Name of the service
-    image: stonith404/pingvin-share:v1.13.0
+    image: stonith404/pingvin-share:v1.13.0@sha256:6bf2bcd3043ee68cb61264f0857511ccf7f212fdb984382b7f2d491635184ad6
     # Image to be used for this service
 
     restart: unless-stopped

--- a/apps/piwigo/docker-compose.yml
+++ b/apps/piwigo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-piwigo
     # Image to be used for the container
-    image: linuxserver/piwigo:16.4.0
+    image: linuxserver/piwigo:16.4.0@sha256:97a159850563dd7c5e4cedb7a30801f467963c3e910e7ecc07f04cb53b11e5f0
     # Container restart policy
     restart: unless-stopped
     # Environment variables
@@ -28,7 +28,7 @@ services:
     networks:
       - big_bear_piwigo_network
   big-bear-piwigo-db:
-    image: mariadb:10.6
+    image: mariadb:10.6@sha256:114d40be36852d0a019afd8458f7e1cc63fd300403b115b1f32e31130d5f671b
     container_name: big-bear-piwigo-db
     environment:
       - MYSQL_ROOT_PASSWORD=3cf3f2c4-3415-4efe-b478-db7b6f0b9934 # Root password for MySQL

--- a/apps/planka-v2/docker-compose.yml
+++ b/apps/planka-v2/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     # Name of the container
     container_name: big-bear-planka-v2
     # Image to be used for the container specifies the Planka version and source
-    image: ghcr.io/plankanban/planka:2.1.1
+    image: ghcr.io/plankanban/planka:2.1.1@sha256:19b507ae3ab5cb1855c3f6984249e4a4881ed0b912febdfd492139c29bf10f39
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Volumes to be mounted to the container for persistent storage
@@ -111,7 +111,7 @@ services:
   big-bear-planka-v2-postgres:
     # Specifies the Docker image to use for the PostgreSQL database
     # Using version 14 of PostgreSQL, based on the lightweight Alpine Linux distribution
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
     # Specifies the container restart policy
     # The container will restart if it fails during runtime
     restart: on-failure

--- a/apps/planka/docker-compose.yml
+++ b/apps/planka/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     # Name of the container
     container_name: big-bear-planka
     # Image to be used for the container specifies the Planka version and source
-    image: ghcr.io/plankanban/planka:1.26.3
+    image: ghcr.io/plankanban/planka:1.26.3@sha256:e469d724985db3f560ef0aa2218d54536212459bf8ecbdbc9fd995fc3cbe29db
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Volumes to be mounted to the container for persistent storage
@@ -75,7 +75,7 @@ services:
   big-bear-planka-postgres:
     # Specifies the Docker image to use for the PostgreSQL database
     # Using version 14 of PostgreSQL, based on the lightweight Alpine Linux distribution
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
     # Specifies the container restart policy
     # The container will restart if it fails during runtime
     restart: on-failure

--- a/apps/plant-it/docker-compose.yml
+++ b/apps/plant-it/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-plant-it
     # Image to be used for the container
-    image: msdeluise/plant-it-server:0.10.0
+    image: msdeluise/plant-it-server:0.10.0@sha256:23ddf8660087d6b9f5dbdca2ca09817b84db45cb2d9d6e2e0176e70f514629e7
     # Container restart policy
     restart: unless-stopped
     environment:
@@ -72,7 +72,7 @@ services:
     # Name of the database container
     container_name: big-bear-plant-it-db
     # Image for the database
-    image: mysql:8.0
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     # Restart policy for the database container
     restart: always
     environment:

--- a/apps/playit-docker-web/docker-compose.yml
+++ b/apps/playit-docker-web/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-playit-docker-web
     # Image to be used for the container
-    image: wisdomsky/playit-docker-web:1.0.10
+    image: wisdomsky/playit-docker-web:1.0.10@sha256:1198f2246a1d91b4a24b6b3d7874030a354292f402d51435a7d71ea65a2b9984
     # Container restart policy
     restart: unless-stopped
     # Network mode

--- a/apps/playitgg/docker-compose.yml
+++ b/apps/playitgg/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: playitgg
     # Image to be used for the container
-    image: dysta/playitgg:1.2.0
+    image: dysta/playitgg:1.2.0@sha256:d26d21c5fca76253dbc45715f1556cdc29945648a11e0f63b01fb6a1c9b4a96a
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/plex-nvidia/docker-compose.yml
+++ b/apps/plex-nvidia/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-plex-nvidia
     # Image to be used for the container
-    image: linuxserver/plex:1.43.2
+    image: linuxserver/plex:1.43.2@sha256:2785a6ad64d3a91529e31df678cf0f9fe8ddfe2718415222f270b8d1a6d765f0
     # Environment variables for the container
     environment:
       - PUID=1000 # specify the user id

--- a/apps/plex/docker-compose.yml
+++ b/apps/plex/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-plex
     # Image to be used for the container
-    image: linuxserver/plex:1.43.2
+    image: linuxserver/plex:1.43.2@sha256:2785a6ad64d3a91529e31df678cf0f9fe8ddfe2718415222f270b8d1a6d765f0
     environment:
       - PUID=1000 # specify the user id
       - PGID=1000 # specify the group id

--- a/apps/pocketid/docker-compose.yml
+++ b/apps/pocketid/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Service configuration for the pocket-id application
   big-bear-pocketid:
     container_name: big-bear-pocketid # Name of the pocket-id container
-    image: ghcr.io/pocket-id/pocket-id:v2.7 # Docker image to use for pocket-id
+    image: ghcr.io/pocket-id/pocket-id:v2.7@sha256:45bdeaf3fcd6d07cf8721e98785d93324bb8e65b586498874c05a3d489c8094e # Docker image to use for pocket-id
     restart: unless-stopped # Restart policy: Restart unless manually stopped
     cpu_shares: 90
     command: []

--- a/apps/portainer-agent/docker-compose.yml
+++ b/apps/portainer-agent/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Portainer Agent Server service configuration
   app:
     container_name: portainer-agent # Name of the running container
-    image: portainer/agent:2.43.0 # Image to be used
+    image: portainer/agent:2.43.0@sha256:3e8cb049fc5fe8f7328dec3d5312d7da3f007127eb6f78f98f3e883d7c15e4b4 # Image to be used
     network_mode: bridge # Network mode to be used
     ports: # Port mapping between host and container
       - 9001:9001

--- a/apps/portainer/docker-compose.yml
+++ b/apps/portainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Portainer service configuration
   app:
     container_name: big-bear-portainer # Name of the running container
-    image: portainer/portainer-ce:2.43.0-alpine # Image to be used
+    image: portainer/portainer-ce:2.43.0-alpine@sha256:b39d73976b94d945f6e62ac727ca65d1cf9b46dc9d2c3c0e833ef0422469f09e # Image to be used
     network_mode: bridge # Network mode to be used
     ports: # Port mapping between host and container
       - 8000:8000

--- a/apps/portracker/docker-compose.yml
+++ b/apps/portracker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-portracker
     # Image to be used for the container
-    image: mostafawahied/portracker:1.3
+    image: mostafawahied/portracker:1.3@sha256:c7b4143ae32da4642a339d49ef5559c8408862eb1d1aacd9052df46e8ae225cb
     # Container restart policy
     restart: unless-stopped
     # Environment variables for service configuration

--- a/apps/poste-io/docker-compose.yml
+++ b/apps/poste-io/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-poste-io
     # Image to be used for the container specifies the analogic/poste.io version and source
-    image: analogic/poste.io:2.5.14
+    image: analogic/poste.io:2.5.14@sha256:4722c66d70034bb6b0f20be027cdea8659f1ae164ed5ee9aa52b2b703450cabd
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Network mode

--- a/apps/project-management/docker-compose.yml
+++ b/apps/project-management/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # Name of the container
     container_name: big-bear-project-management
     # Image to be used for the container
-    image: eloufirhatim/helper:1.2.3
+    image: eloufirhatim/helper:1.2.3@sha256:200b25415273529ca5c6513b5ce99931e46bee17e2c730c4d3c2cbc53992fd2e
     # Container restart policy
     restart: unless-stopped
     # Environment variables
@@ -38,7 +38,7 @@ services:
     depends_on:
       - big-bear-project-management-db
   big-bear-project-management-db:
-    image: mysql:5.7
+    image: mysql:5.7@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
     container_name: big-bear-project-management-db
     environment:
       - MYSQL_DATABASE=project_management

--- a/apps/psitransfer/docker-compose.yml
+++ b/apps/psitransfer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # The `app` service definition
   app:
     # Image to be used for the container
-    image: psitrax/psitransfer:v2.4.4
+    image: psitrax/psitransfer:v2.4.4@sha256:312d060e0e2934ff618b3e361d766872b89892dc33c5456858b4aa04dc17a18d
     # Name of the container
     container_name: big-bear-psitransfer
     # Run as UID 1000 (node user) to match the image's default user

--- a/apps/pterodactyl-panel/docker-compose.yml
+++ b/apps/pterodactyl-panel/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Container configuration for the Pterodactyl Panel
     container_name: pterodactyl-panel
     # Image to use for the panel
-    image: ghcr.io/pterodactyl/panel:v1.12.2
+    image: ghcr.io/pterodactyl/panel:v1.12.2@sha256:dd2687b00a532117fe25a88a8acbb34a6fb23a9ca59a76a405735e3cb729efca
     # Restart the container automatically if it stops
     restart: always
     # Ports mapping: [HOST:CONTAINER]
@@ -50,7 +50,7 @@ services:
       DB_CONNECTION: "mariadb" # Use MariaDB connector to avoid mysql binary requirement (v1.12.0+)
   database:
     # Image to use for the database
-    image: mariadb:10.5
+    image: mariadb:10.5@sha256:a530aeeefd82f4fa5150f391b6c75462140904780338766f6b03acecb1cca3ce
     # Restart the container automatically if it stops
     restart: always
     # Command to run on container start

--- a/apps/pterodactyl-wings/docker-compose.yml
+++ b/apps/pterodactyl-wings/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # Name of the container
     container_name: pterodactyl-wings
     # Docker image to use for the container
-    image: ghcr.io/pterodactyl/wings:v1.12.1
+    image: ghcr.io/pterodactyl/wings:v1.12.1@sha256:85d92f778d47cbc255f559a476d82915c4c5cb2973c3e6d44c82046513d53365
     # Determines the restart policy. In this case, the container will always restart if it stops.
     restart: always
     # Maps the host's port 2022 to the container's port 2022

--- a/apps/python-matter-server/docker-compose.yml
+++ b/apps/python-matter-server/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-python-matter-server
 services:
   app:
     # Docker image used for the service
-    image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+    image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
     # Container name for the service
     container_name: matter-server
     # Restart policy for the container

--- a/apps/rackpeek/docker-compose.yml
+++ b/apps/rackpeek/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-rackpeek
     # Image to be used for the container
-    image: aptacode/rackpeek:v2.0.0
+    image: aptacode/rackpeek:v2.0.0@sha256:ebe9b5a7585b07ecdff5978b9464815138d340f720cc88f53a262fb230b6e717
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/rallly/docker-compose.yml
+++ b/apps/rallly/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Main application service definition
   big-bear-rallly:
     container_name: big-bear-rallly # The name for the container instance of this service
-    image: lukevella/rallly:4.11.1 # Docker image to be used for creating the container
+    image: lukevella/rallly:4.11.1@sha256:b2acb78afb1e2e88445e78cec4393cd8b8cc63f9268cf1defe19f96d0db945b0 # Docker image to be used for creating the container
     restart: unless-stopped # Policy to restart the container unless manually stopped
     environment: # Environment variables passed to the container for configuration
       # Database connection URL (DATABASE_URL=postgres://username:password@host/database)
@@ -35,7 +35,7 @@ services:
   # Database service for the application
   big-bear-rallly-db:
     container_name: big-bear-rallly-db # Container name for the database service
-    image: postgres:14 # PostgreSQL version 14 as the database
+    image: postgres:14@sha256:9e279cc7fc6e908da071befe389c576bd6752dbd295a9c078f96a75bab03e54c # PostgreSQL version 14 as the database
     restart: unless-stopped # Restart policy similar to the application service
     volumes:
       - rallly_postgresql:/var/lib/postgresql/data # Persistent data storage

--- a/apps/reactive-resume/docker-compose.yml
+++ b/apps/reactive-resume/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Main application
   app:
     container_name: big-bear-reactive-resume
-    image: amruthpillai/reactive-resume:v5.2.3
+    image: amruthpillai/reactive-resume:v5.2.3@sha256:bfacee69faad04a8b785854d02cb078fb223824e8b07a07ff21fa39ebfa9fe8c
     restart: unless-stopped
     ports:
       - 3000:3000
@@ -70,7 +70,7 @@ services:
   # Database (Postgres)
   postgres:
     container_name: big-bear-reactive-resume-db
-    image: postgres:15-alpine
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
     restart: unless-stopped
     volumes:
       - reactive-resume_pg_data:/var/lib/postgresql/data
@@ -88,7 +88,7 @@ services:
   # Storage (for image uploads)
   minio:
     container_name: big-bear-reactive-resume-minio
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z-cpuv1
+    image: minio/minio:RELEASE.2024-09-13T20-26-02Z-cpuv1@sha256:a34ac7cbc53154bef4804b1f9d83a555f944d8c26e6466cef7e782fdb5ec40c4
     command: ["server", "/data"]
     restart: unless-stopped
     ports:
@@ -103,7 +103,7 @@ services:
   # Chrome Browser (for printing and previews)
   chrome:
     container_name: big-bear-reactive-resume-chrome
-    image: browserless/chrome:1.61.1-puppeteer-21.4.1
+    image: browserless/chrome:1.61.1-puppeteer-21.4.1@sha256:b6acad3ef2e1e0e3c2eb018add533570db2b34f5304682bad58c803b23ef7bd2
     restart: unless-stopped
     environment:
       TOKEN: "chrome_token"

--- a/apps/readeck/docker-compose.yml
+++ b/apps/readeck/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # Name of the container
     container_name: big-bear-readeck
     # Image to be used for the container
-    image: codeberg.org/readeck/readeck:0.22.3
+    image: codeberg.org/readeck/readeck:0.22.3@sha256:ed1c513f8e1d59b1d38fda324ac279eeb65afd0327907e498061ec9fd2f31c15
     # Container restart policy
     restart: unless-stopped
     # Environment variables for Readeck configuration

--- a/apps/retroarch-web/docker-compose.yml
+++ b/apps/retroarch-web/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-retroarch-web
     # Image to be used for the container
-    image: inglebard/retroarch-web:latest
+    image: inglebard/retroarch-web:latest@sha256:bf03014db81776a715b6289f017be2fc988688f9302590413cd6dcb615f07393
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/rocket-chat-v8/docker-compose.yml
+++ b/apps/rocket-chat-v8/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     container_name: big-bear-rocket-chat-v8
     # Docker Image
     # Specifies the Docker image to use for Rocket.Chat v8.
-    image: rocket.chat:8.5.1
+    image: rocket.chat:8.5.1@sha256:60a48d89164eb690c55f5581c324d4642f2431e010ac0bd7dfc97e7c5432139f
     # Restart Policy
     # Determines how the container should be handled if it stops.
     restart: unless-stopped

--- a/apps/rocket-chat/docker-compose.yml
+++ b/apps/rocket-chat/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     container_name: big-bear-rocket-chat
     # Docker Image
     # Specifies the Docker image to use for Rocket.Chat.
-    image: rocket.chat:6.13.1
+    image: rocket.chat:6.13.1@sha256:b6cfd507cf913290045d380be2c14511c735acb840509d471fb2d7359a820031
     # Restart Policy
     # Determines how the container should be handled if it stops.
     restart: unless-stopped
@@ -39,7 +39,7 @@ services:
   # Service: db
   # This service runs the MongoDB database used by Rocket.Chat.
   db:
-    image: mongo:4.4.28
+    image: mongo:4.4.28@sha256:7a272834036ddc9c7379c2d646b6a6c23c985e28c280f1340b3f611c762f9d83
     container_name: big-bear-rocketchat-db
     volumes:
       # Persistent storage for MongoDB

--- a/apps/romm/docker-compose.yml
+++ b/apps/romm/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service name: big-bear-romm
   # The `big-bear-romm` service definition
   big-bear-romm:
-    image: rommapp/romm:4.9.2 # Docker image for the application
+    image: rommapp/romm:4.9.2@sha256:c81778afcafe7c865bdf156d1c62349aec3dfca3aca5ec0d6c2c2e8bfa9fb071 # Docker image for the application
     container_name: big-bear-romm
     environment:
       - DB_HOST=big-bear-rommdb # Hostname of the MariaDB container
@@ -45,7 +45,7 @@ services:
       - big-bear-romm-network # Use the big-bear-romm-network network
   # MariaDB service for rommdb
   big-bear-rommdb:
-    image: mariadb:latest
+    image: mariadb:latest@sha256:628f228f0fd5913a220438693576b29b6fe4dc1fa0a1298c0e98579fae28635f
     container_name: big-bear-rommdb
     environment:
       - MYSQL_ROOT_PASSWORD=casaos # MariaDB root password

--- a/apps/rustfs/docker-compose.yml
+++ b/apps/rustfs/docker-compose.yml
@@ -2,7 +2,7 @@ name: rustfs
 
 services:
   app:
-    image: rustfs/rustfs:1.0.0-alpha.71
+    image: rustfs/rustfs:1.0.0-alpha.71@sha256:5ed6b4845ff98d44d42f733324761dc1379a8c36b7ee66c25e2dc3e8cbe0280d
     container_name: rustfs
     ports:
       - "9000:9000"

--- a/apps/scrutiny/docker-compose.yml
+++ b/apps/scrutiny/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-scrutiny
     # Image to be used for the container
-    image: ghcr.io/analogj/scrutiny:master-omnibus
+    image: ghcr.io/analogj/scrutiny:master-omnibus@sha256:18689773150d6b8b53c94a435f40f7b6e946fd4a6d40b44c64fa2154a5b38941
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/scrypted/docker-compose.yml
+++ b/apps/scrypted/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # This is the main app service for Scrypted
   scrypted:
     container_name: scrypted
-    image: koush/scrypted:v0.144.1-noble-full # Docker image for Scrypted
+    image: koush/scrypted:v0.144.1-noble-full@sha256:25440767192b0d4a0709f50388d14cdf365ba6bff59d04e40a41ca2b7b9a6b70 # Docker image for Scrypted
     network_mode: host # Use host networking mode
     environment:
       # These environment variables are for Scrypted webhook configuration
@@ -33,7 +33,7 @@ services:
       - WATCHTOWER_SCOPE=scrypted
       # Allows periodic auto-updates, can be removed if not desired
       - WATCHTOWER_HTTP_API_PERIODIC_POLLS=true
-    image: containrrr/watchtower # Docker image for Watchtower
+    image: containrrr/watchtower@sha256:6dd50763bbd632a83cb154d5451700530d1e44200b268a4e9488fefdfcf2b038 # Docker image for Watchtower
     container_name: watchtower
     restart: unless-stopped
     volumes:

--- a/apps/seafile/docker-compose.yml
+++ b/apps/seafile/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-seafile
     # Image to be used for the container
-    image: seafileltd/seafile-mc:11.0.13
+    image: seafileltd/seafile-mc:11.0.13@sha256:1239b087aa4bdf1b60a3802e80855f230736ac5d5fa3325a40b15d4c598f422c
     # Container restart policy
     restart: unless-stopped
     # Service dependencies
@@ -39,7 +39,7 @@ services:
       - big_bear_seafile_network
   # Database service for seafile
   big-bear-seafile-db:
-    image: mariadb:10.11
+    image: mariadb:10.11@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350
     container_name: big-bear-seafile-db
     environment:
       - MYSQL_ROOT_PASSWORD=seafilepassword # Requested, set the root's password of MySQL service.
@@ -60,7 +60,7 @@ services:
   # Memcached service for seafile
   big-bear-seafile-memcached:
     container_name: big-bear-seafile-memcached
-    image: memcached:1.6.39
+    image: memcached:1.6.39@sha256:462fa779babc9b64a235a69dd843cb79fb3591f229ee1f3ff6cb2ca058d8a759
     entrypoint: memcached -m 256
     networks:
       - big_bear_seafile_network

--- a/apps/seerr/docker-compose.yml
+++ b/apps/seerr/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-seerr # Name of the compose project
 services:
   app:
-    image: seerr/seerr:v3.3.0 # Image to use for the seerr service
+    image: seerr/seerr:v3.3.0@sha256:c92d2dc117f62185e7bcb88cd56efd374ea79210eaf433275449e8d5988eb5a8 # Image to use for the seerr service
     init: true # Enable init process
     container_name: big-bear-seerr
     ports:

--- a/apps/semaphore/docker-compose.yml
+++ b/apps/semaphore/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-semaphore
     # Image to be used for the container
-    image: semaphoreui/semaphore:v2.18.25
+    image: semaphoreui/semaphore:v2.18.25@sha256:9d2ca34eb47675397fb1939365a66b7c24899a57ee7654c8adc0fd1c0d9c5d57
     # Container restart policy
     restart: unless-stopped
     # Environment variables for configuration
@@ -38,7 +38,7 @@ services:
   # MySQL database service for semaphore
   big-bear-semaphore-db:
     container_name: big-bear-semaphore-db
-    image: mysql:8.0
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     restart: unless-stopped
     volumes:
       - semaphore_mysql:/var/lib/mysql # Data directory for MySQL

--- a/apps/send-visee/docker-compose.yml
+++ b/apps/send-visee/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # Name of the container (Docker does not have to generate a random name)
     container_name: big-bear-send-visee
     # Image to be used for the container
-    image: registry.gitlab.com/timvisee/send:v3.4.27
+    image: registry.gitlab.com/timvisee/send:v3.4.27@sha256:b950a557f0f4eb7d2114a9126aea5df984ffe868385a3fb6b327d9f770bec0ae
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/sftpgo/docker-compose.yml
+++ b/apps/sftpgo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-sftpgo
     # Image to be used for the container
-    image: drakkan/sftpgo:v2.7
+    image: drakkan/sftpgo:v2.7@sha256:6cb60f08fede46c5dc49a0c1d2994287ca440a63a3bd75b7f37ab2c0b24bbd06
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/snapotter/docker-compose.yml
+++ b/apps/snapotter/docker-compose.yml
@@ -5,7 +5,7 @@ name: snapotter
 services:
   snapotter:
     container_name: snapotter
-    image: snapotter/snapotter:2.0.0
+    image: snapotter/snapotter:2.0.0@sha256:de55c9279b067ea0bb5bfc7755dde6f72e727c8e1326629d1fa927cfbe6e3712
     restart: unless-stopped
     ports:
       - "1349:1349"

--- a/apps/spacedrive/docker-compose.yml
+++ b/apps/spacedrive/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-spacedrive
     # Image to be used for the container specifies the spacedrive version and source
-    image: ghcr.io/spacedriveapp/spacedrive/server:0.4.2
+    image: ghcr.io/spacedriveapp/spacedrive/server:0.4.2@sha256:fd3bc896f3a5b8e429e008cedde361d6b9468c48d8c81996fdb1d99e90e0837b
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for service configuration

--- a/apps/speedtest-tracker/docker-compose.yml
+++ b/apps/speedtest-tracker/docker-compose.yml
@@ -24,14 +24,14 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "speedtest-tracker_config:/config"
       - "speedtest-tracker_web:/etc/ssl/web"
-    image: "linuxserver/speedtest-tracker:1.14.5"
+    image: "linuxserver/speedtest-tracker:1.14.5@sha256:e4732e8e9073bdd5b419959c1151b761afa591166328d2ab751adc1e3d070563"
     restart: unless-stopped
     depends_on:
       - big-bear-speedtest-tracker-db
     networks:
       - big_bear_speedtest_tracker_network
   big-bear-speedtest-tracker-db:
-    image: mariadb:10
+    image: mariadb:10@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350
     container_name: big-bear-speedtest-tracker-db
     restart: always
     environment:

--- a/apps/spoolman/docker-compose.yml
+++ b/apps/spoolman/docker-compose.yml
@@ -1,7 +1,7 @@
 name: big-bear-spoolman # Name of the compose project
 services:
   app:
-    image: ghcr.io/donkie/spoolman:0.23.1 # Image to use for the spoolman service
+    image: ghcr.io/donkie/spoolman:0.23.1@sha256:c798bcc19194949962044459e4b43c09d667d084ae9c2c2e0187a42c36d43d9e # Image to use for the spoolman service
     ports:
       - "7912:8000" # Maps port 7912 on the host to port 8000 on the container
     volumes:

--- a/apps/stalwart-mail/docker-compose.yml
+++ b/apps/stalwart-mail/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-stalwart-mail
     # Image to be used for the container specifies the stalwartlabs/mail-server version and source
-    image: stalwartlabs/stalwart:v0.16.12
+    image: stalwartlabs/stalwart:v0.16.12@sha256:b30c99ed8240ea42612f784babe0388318d5c3668a77873efe7e3b1147e2226e
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Volume mappings required for system integration

--- a/apps/stirling-pdf/docker-compose.yml
+++ b/apps/stirling-pdf/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # Name of the container
     container_name: big-bear-stirling-pdf
     # Image to be used for the container specifies the stirling-pdf version and source
-    image: stirlingtools/stirling-pdf:2.14.2
+    image: stirlingtools/stirling-pdf:2.14.2@sha256:7ed4d9681d18e4fbc3aa6a63647c4b5c2bcc4b75841df7c05d7e3d2320f5c9a1
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for service configuration

--- a/apps/storyteller/docker-compose.yml
+++ b/apps/storyteller/docker-compose.yml
@@ -2,7 +2,7 @@ name: big-bear-storyteller
 
 services:
   app:
-    image: registry.gitlab.com/storyteller-platform/storyteller:web-v2.6.0-experimental.14
+    image: registry.gitlab.com/storyteller-platform/storyteller:web-v2.6.0-experimental.14@sha256:876ca77416c1e262faf871ad9f4558339fc3d8858a3fac49610ec5cb69b14957
     container_name: big-bear-storyteller
     ports:
       - "8015:8001"

--- a/apps/syncthing/docker-compose.yml
+++ b/apps/syncthing/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-syncthing
     # Image to be used for the container
-    image: syncthing/syncthing:2.1
+    image: syncthing/syncthing:2.1@sha256:4464f4161dd0251e20d46bb3aec83363db75d80cef1abdd5d5fd4054b04a004d
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/tailscale/docker-compose.yml
+++ b/apps/tailscale/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-tailscale
     # Image to be used for the container
-    image: tailscale/tailscale:v1.98.8
+    image: tailscale/tailscale:v1.98.8@sha256:d54b2e6a9c09f0e5ec52e82b9ad4af3d446b54a7c08075e92f11c39dd410105f
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/tandoor/docker-compose.yml
+++ b/apps/tandoor/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-tandoor
     # Image to be used for the container
-    image: ghcr.io/tandoorrecipes/recipes:2.6.9
+    image: ghcr.io/tandoorrecipes/recipes:2.6.9@sha256:969c5b3552ffbf18a6f82b3ad5babbae89bfbd30ab6e3195fd3c158bcf3062ed
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -38,7 +38,7 @@ services:
       big-bear-tandoor-db:
         condition: service_healthy
   big-bear-tandoor-db:
-    image: postgres:15-alpine
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
     container_name: big-bear-tandoor-db
     volumes:
       - tandoor_postgresql:/var/lib/postgresql/data

--- a/apps/tianji/docker-compose.yml
+++ b/apps/tianji/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-tianji
     # Image to be used for the container
-    image: moonrailgun/tianji:1.32.16
+    image: moonrailgun/tianji:1.32.16@sha256:5722eba3ae9baf18100f8ae7c3b71b2cbd553fb3c4845eb84d340a8e06d4027a
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container
@@ -30,7 +30,7 @@ services:
   # Postgres database
   big-bear-tianji-db:
     container_name: big-bear-tianji-db
-    image: postgres:15.4-alpine
+    image: postgres:15.4-alpine@sha256:35ce2187f2f7fb75e8e79493e13743596c21eb3789ff41ece145ae04d06e93a5
     environment:
       POSTGRES_DB: tianji
       POSTGRES_USER: tianji-user

--- a/apps/tp-link-omada-controller/docker-compose.yml
+++ b/apps/tp-link-omada-controller/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   app:
     container_name: big-bear-omada-controller # The name of the container.
     # The Docker image used for the service.
-    image: mbentley/omada-controller:6.2
+    image: mbentley/omada-controller:6.2@sha256:5313703d10e58aa8cf15a5fae6cc781b89b6157ac02d6873ee83c0df51c5f1d3
     # Restart policy for the container. "unless-stopped" means the container will always restart unless manually stopped.
     restart: unless-stopped
     # Set limits on system-level resources for the container.

--- a/apps/traccar/docker-compose.yml
+++ b/apps/traccar/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-traccar
 services:
   # Service name: app
   app:
-    image: traccar/traccar:6.14-ubuntu # Specifies the docker image to use for this service. Using the latest version of the traccar image.
+    image: traccar/traccar:6.14-ubuntu@sha256:629cf4b4e90a432c5c02726c9e393f6badae84f7c561f05dbe7c8a8be7e03f6b # Specifies the docker image to use for this service. Using the latest version of the traccar image.
     container_name: traccar # Name of the container that will be created
     hostname: traccar # Hostname of the container
     restart: unless-stopped # Restart policy. The container will restart unless it's explicitly stopped.

--- a/apps/trilium/docker-compose.yml
+++ b/apps/trilium/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-trilium
     # Image to be used for the container
-    image: triliumnext/trilium:v0.103.0
+    image: triliumnext/trilium:v0.103.0@sha256:8e6bc939a6d5dbeed42d1b5b155bc790b1c28ca3ac414382d04d626903c62081
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/tududi/docker-compose.yml
+++ b/apps/tududi/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-tududi
     # Image to be used for the container
-    image: chrisvel/tududi:0.87
+    image: chrisvel/tududi:0.87@sha256:733bceb71e60ba73d75e33d66569edaf8be55b5cd113830ecaee11b48e8e392a
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/tugtainer/docker-compose.yml
+++ b/apps/tugtainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-tugtainer
     # Image to be used for the container
-    image: quenary/tugtainer:v1.30.8
+    image: quenary/tugtainer:v1.30.8@sha256:4e9abfd0565fa0695fc770c107e8913650ce58ac9298831843d11f932810eac0
     # Container restart policy
     restart: unless-stopped
     # Ports to expose from the container

--- a/apps/uisp/docker-compose.yml
+++ b/apps/uisp/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-uisp
     # Image to be used for the container
-    image: nico640/docker-unms:2.4.155.1
+    image: nico640/docker-unms:2.4.155.1@sha256:f7f3f7820cb3e86bfbe0691585410482b5079f9708b400c810fbdc4cc9fd6590
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/umami/docker-compose.yml
+++ b/apps/umami/docker-compose.yml
@@ -4,7 +4,7 @@ name: big-bear-umami
 services:
   # Main service for the Umami application
   app:
-    image: ghcr.io/umami-software/umami:postgresql-latest # Docker image for the Umami app
+    image: ghcr.io/umami-software/umami:postgresql-latest@sha256:8edfe4beaef13f9d1300619fa264ef250a3688df9cc54d24ca830ca31cb475ec # Docker image for the Umami app
     ports:
       - "3000:3000" # Port mapping: host:container
     environment: # Environment variables for the service
@@ -17,7 +17,7 @@ services:
     restart: always # Restart policy
   # Database service for the Umami application
   db:
-    image: postgres:15-alpine # Docker image for the PostgreSQL database
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f # Docker image for the PostgreSQL database
     environment: # Environment variables for the service
       POSTGRES_DB: umami
       POSTGRES_USER: umami

--- a/apps/umbrel-os/docker-compose.yml
+++ b/apps/umbrel-os/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-umbrel
     # Image to be used for the container
-    image: dockurr/umbrel:1.7.3
+    image: dockurr/umbrel:1.7.3@sha256:cd461d81df2b3393ddb780eb975738ed2f7d2f5755a2673e488b1a2ce9f0d22d
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/unifi-network-application-mongo-4/docker-compose.yml
+++ b/apps/unifi-network-application-mongo-4/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-unifi-network-application-mongo-4
 services:
   # Main application service
   app: # Name of the service
-    image: linuxserver/unifi-network-application:10.4.57 # Docker image to use
+    image: linuxserver/unifi-network-application:10.4.57@sha256:7d25457f8d0600388f663cd2316d7f86c8104de8e6fa9b6e2e44c7f6526476d6 # Docker image to use
     container_name: big-bear-unifi-network-application # Name for the created container
     environment: # Environmental variables for the container
       - PUID=1000 # User ID
@@ -40,7 +40,7 @@ services:
       - unifi-db
   # MongoDB database for the application
   unifi-db:
-    image: mongo:4.4.28
+    image: mongo:4.4.28@sha256:7a272834036ddc9c7379c2d646b6a6c23c985e28c280f1340b3f611c762f9d83
     container_name: big-bear-unifi-db
     volumes:
       - unifi-network-application-mongo-4_db_data:/data/db # MongoDB data persistence

--- a/apps/unifi-network-application/docker-compose.yml
+++ b/apps/unifi-network-application/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-unifi-network-application
 services:
   # Main application service
   app: # Name of the service
-    image: linuxserver/unifi-network-application:10.4.57 # Docker image to use
+    image: linuxserver/unifi-network-application:10.4.57@sha256:7d25457f8d0600388f663cd2316d7f86c8104de8e6fa9b6e2e44c7f6526476d6 # Docker image to use
     container_name: big-bear-unifi-network-application # Name for the created container
     environment: # Environmental variables for the container
       - PUID=1000 # User ID
@@ -40,7 +40,7 @@ services:
       - unifi-db
   # MongoDB database for the application
   unifi-db:
-    image: mongo:6.0.11
+    image: mongo:6.0.11@sha256:52a007213974cab7753e9cd3fbd5750cc9a9f996f85ccdae73b164239b8f6951
     container_name: big-bear-unifi-db
     volumes:
       - unifi-network-application_db_data:/data/db # MongoDB data persistence

--- a/apps/upsnap/docker-compose.yml
+++ b/apps/upsnap/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-upsnap
     # Image to be used for the container
-    image: ghcr.io/seriousm4x/upsnap:5.3.4
+    image: ghcr.io/seriousm4x/upsnap:5.3.4@sha256:f7edc52fe03f5d424182b06faa72962c625f5e78ff3c9e8457e9617f20d0e611
     # Container restart policy
     restart: unless-stopped
     # Network mode

--- a/apps/uptime-kuma/docker-compose.yml
+++ b/apps/uptime-kuma/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # The `app` service definition includes the docker image, container name, volume mappings, port configurations, restart policy, and CasaOS specific settings.
   app:
     # Docker image to use for the app service
-    image: louislam/uptime-kuma:2
+    image: louislam/uptime-kuma:2@sha256:91e963bfda569ba115206e843febb446f473ab525add4e08b2b9e3beffa16985
     # Custom container name for identification
     container_name: uptime-kuma
     # Volume mappings: Maps host directory to container directory for persistent storage

--- a/apps/vert/docker-compose.yml
+++ b/apps/vert/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-vert
     # Image to be used for the container
-    image: ghcr.io/vert-sh/vert:sha-a1b0b15
+    image: ghcr.io/vert-sh/vert:sha-a1b0b15@sha256:9f69e1f0a61be4882f8b1e9ba35647e8df4a91669fb4c3cdf30aeb88c247c600
     # Container restart policy
     restart: unless-stopped
     # Ports mapping between host and container

--- a/apps/vikunja-v2/docker-compose.yml
+++ b/apps/vikunja-v2/docker-compose.yml
@@ -24,7 +24,7 @@ name: big-bear-vikunja-v2
 # Service definitions for the big-bear-vikunja-v2 application
 services:
   vikunja-v2:
-    image: vikunja/vikunja:2.3.0
+    image: vikunja/vikunja:2.3.0@sha256:f6b80393c1998cd5cd0dc38d24762c59ab4c10000a6f1032ef5b554e262cab93
     container_name: big-bear-vikunja-v2
     ports:
       - 8082:3456
@@ -46,7 +46,7 @@ services:
     networks:
       - vikunja-v2-network
   vikunja-v2-db:
-    image: mariadb:11
+    image: mariadb:11@sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4
     container_name: vikunja-v2-db
     command:
       - --character-set-server=utf8mb4

--- a/apps/vikunja/docker-compose.yml
+++ b/apps/vikunja/docker-compose.yml
@@ -5,7 +5,7 @@ name: big-bear-vikunja
 # Service definitions for the big-bear-vikunja application
 services:
   vikunja:
-    image: vikunja/vikunja:1.1.0
+    image: vikunja/vikunja:1.1.0@sha256:84b56920e2860c67cb889bce0e0950aa529e42838b45bdf81eb2422178e90cc7
     container_name: big-bear-vikunja
     ports:
       - 8081:3456
@@ -28,7 +28,7 @@ services:
     networks:
       - vikunja-network
   vikunja-db:
-    image: mariadb:10
+    image: mariadb:10@sha256:be981e4113326ada8d6004174dd09eeaefc03094037f811182a52d4f2e737350
     container_name: vikunja-db
     command:
       - --character-set-server=utf8mb4

--- a/apps/viseron/docker-compose.yml
+++ b/apps/viseron/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-viseron
     # Image to be used for the container
-    image: roflcoopter/viseron:3.5.3
+    image: roflcoopter/viseron:3.5.3@sha256:2ed603e5a3ae02eefbb8a17736b1fb40ed071fc65e8e16918ab4cfeebce834b4
     # Container restart policy
     restart: unless-stopped
     # Shared memory size

--- a/apps/wallabag/docker-compose.yml
+++ b/apps/wallabag/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-wallabag
     # Image to be used for the container
-    image: wallabag/wallabag:2.6.14
+    image: wallabag/wallabag:2.6.14@sha256:4a527e027e0d59e87c14225ef11e005af3d4890374202ad319ce5e63dfc66709
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for Wallabag configuration
@@ -51,7 +51,7 @@ services:
     # Name of the container
     container_name: big-bear-wallabag-db
     # Image to be used for the database container
-    image: mariadb:10.11.10
+    image: mariadb:10.11.10@sha256:41d89394db8e777d96058d4cf5cf4daf1ed87f76192154f3d89572676f1e2327
     # Container restart policy
     restart: unless-stopped
     # Environment variables for MariaDB configuration

--- a/apps/wallos/docker-compose.yml
+++ b/apps/wallos/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-wallos
     # Image to be used for the container
-    image: bellamy/wallos:4.9.6
+    image: bellamy/wallos:4.9.6@sha256:3b2cdc843b4b1920220ce26a5804208eab8c236c60d4c777c6223c181f837be1
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/warracker/docker-compose.yml
+++ b/apps/warracker/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     # Container name
     container_name: big-bear-warrackerdb
     # Container image
-    image: postgres:15-alpine
+    image: postgres:15-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
     # Container volumes
     volumes:
       - warracker_warrackerdb:/var/lib/postgresql/data

--- a/apps/watchyourlan/docker-compose.yml
+++ b/apps/watchyourlan/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-watchyourlan
     # Image to be used for the container
-    image: aceberg/watchyourlan:2.1.4
+    image: aceberg/watchyourlan:2.1.4@sha256:f77532ca7c3c9a4398cb094df7674013a3d7fcf4699386f1e456c24df6fef00e
     # Environment variables to be used for the container
     environment:
       - IFACES="eth0"

--- a/apps/wg-easy-v15/docker-compose.yml
+++ b/apps/wg-easy-v15/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-wg-easy-v15
     # Image to be used for the container
-    image: ghcr.io/wg-easy/wg-easy:15
+    image: ghcr.io/wg-easy/wg-easy:15@sha256:93bbd593e07bab98d02807a28770ac87ab6c48818e319e68c1f66561feb99876
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/wg-easy/docker-compose.yml
+++ b/apps/wg-easy/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-wg-easy
     # Image to be used for the container
-    image: ghcr.io/wg-easy/wg-easy:15
+    image: ghcr.io/wg-easy/wg-easy:15@sha256:93bbd593e07bab98d02807a28770ac87ab6c48818e319e68c1f66561feb99876
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container

--- a/apps/whats-up-docker/docker-compose.yml
+++ b/apps/whats-up-docker/docker-compose.yml
@@ -6,7 +6,7 @@ name: big-bear-wud
 services:
   # Service definition for the main application
   app:
-    image: fmartinou/whats-up-docker:6.6.1
+    image: fmartinou/whats-up-docker:6.6.1@sha256:7cbdfa9bb56de7ad820e3efea16205c3cf09e5f06192436530c5c798964607f0
     container_name: wud
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/apps/wishlist/docker-compose.yml
+++ b/apps/wishlist/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-wishlist
     # Image to be used for the container specifies the wishlist version and source
-    image: ghcr.io/cmintey/wishlist:v0.64.0
+    image: ghcr.io/cmintey/wishlist:v0.64.0@sha256:d2d189ec76f0f2d11864dca34183572900bedd72dd0594f18d639720409027d1
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for service configuration

--- a/apps/wordpress-v7/docker-compose.yml
+++ b/apps/wordpress-v7/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   # Service definition for the main application
   app:
     # Docker image to use for the application
-    image: wordpress:7.0.1
+    image: wordpress:7.0.1@sha256:e36cd332ae0de78f3c3691e468c54c5540c0a74286b51eb9b5964fa1e9c916cd
     # Port mapping for the application
     ports:
       - 8084:80
@@ -50,7 +50,7 @@ services:
   # Service definition for the database
   db:
     # Docker image to use for the database
-    image: mysql:8.0
+    image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
     # Environment variables for the database
     environment:
       MYSQL_DATABASE: wordpress

--- a/apps/wordpress/docker-compose.yml
+++ b/apps/wordpress/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Service definition for the main application
   app:
     # Docker image to use for the application
-    image: wordpress:6.9.4
+    image: wordpress:6.9.4@sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905
     # Port mapping for the application
     ports:
       - 8080:80
@@ -26,7 +26,7 @@ services:
   # Service definition for the database
   db:
     # Docker image to use for the database
-    image: mysql:5.7
+    image: mysql:5.7@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
     # Environment variables for the database
     environment:
       MYSQL_DATABASE: wordpress

--- a/apps/write-freely/docker-compose.yml
+++ b/apps/write-freely/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-write-freely
     # Image to be used for the container specifies the write-freely version and source
-    image: nephatrine/write-freely:0.16
+    image: nephatrine/write-freely:0.16@sha256:cfac7d4ec0c367905ed4189a3b3930bcbb69e2c7f1cdafa4c02d69a8a5abf61c
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Environment variables for service configuration

--- a/apps/zigbee2mqtt/docker-compose.yml
+++ b/apps/zigbee2mqtt/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-zigbee2mqtt
     # Image to be used for the container
-    image: koenkk/zigbee2mqtt:2.12.1
+    image: koenkk/zigbee2mqtt:2.12.1@sha256:80f7f04f72a99e4c4ef51ef7e98ee736edba6db0ecbb7abc626d0c4b0f1871f1
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container

--- a/apps/zipline/docker-compose.yml
+++ b/apps/zipline/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-zipline
     # Image to be used for the container
-    image: ghcr.io/diced/zipline:3.7.13
+    image: ghcr.io/diced/zipline:3.7.13@sha256:f0209223b159be9460bf1454b1908417877fef6a1f3a31d5e682885fb9431f30
     # Container restart policy
     restart: unless-stopped
     # Volumes to be mounted to the container
@@ -37,7 +37,7 @@ services:
     # Name of the container
     container_name: big-bear-zipline-db
     # Image to be used
-    image: postgres:15
+    image: postgres:15@sha256:bcab099bfaab33333a73a2ebe8c1d615c9f4c2402dd43452f989a36c6da9a5ba
     # Container restart policy
     restart: unless-stopped
     # Environment variables

--- a/apps/zotero/docker-compose.yml
+++ b/apps/zotero/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Name of the container
     container_name: big-bear-zotero
     # Image to be used for the container
-    image: linuxserver/zotero:9.0.20260417
+    image: linuxserver/zotero:9.0.20260417@sha256:1b37bde9b1974ac9be736f822212f63b515d3db21f3772373fb65fd2f21d5136
     # Container restart policy
     restart: unless-stopped
     # Environment variables for the container


### PR DESCRIPTION
## Summary

- Verified every app's image:tag resolves and pinned the sha256 digest (`docker buildx imagetools inspect`)
- 3 apps reference nonexistent tags, left unpinned, tracked in #2493
- Renovate's docker-compose manager keeps pinned digests in sync on future tag bumps automatically

Closes #2491