### PR TITLE
fix(apps): repair broken thumbnail URLs

### DIFF
--- a/apps/lobe-chat/app.json
+++ b/apps/lobe-chat/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/lobe-chat.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-casaos@main/Apps/lobe-chat/thumbnail.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps@main/apps/lobe-chat/thumbnail.png",
     "screenshots": [
       "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps@main/apps/lobe-chat/screenshots/screenshot-1.png"
     ],

--- a/apps/mailpit/app.json
+++ b/apps/mailpit/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/mailpit/logo.png",
-    "thumbnail": "https://github.com/axllent/mailpit/blob/develop/docs/screenshot.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/mailpit/logo.png",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps/apps/mailpit/logo.png"
   },

--- a/apps/spoolman/app.json
+++ b/apps/spoolman/app.json
@@ -17,7 +17,7 @@
   },
   "visual": {
     "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/spoolman.png",
-    "thumbnail": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps@main/apps/spoolman/screenshots-1.png",
+    "thumbnail": "https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-universal-apps@main/apps/spoolman/screenshot-1.png",
     "screenshots": [],
     "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/spoolman.png"
   },

--- a/scripts/validate-apps.sh
+++ b/scripts/validate-apps.sh
@@ -26,6 +26,10 @@ SCHEMA_FILE="$UNIVERSAL_REPO/schemas/app-schema-v1.json"
 SPECIFIC_APP=""
 VERBOSE=false
 STRICT=false
+CHECK_LINKS=false
+LINK_JOBS=20
+LINK_TIMEOUT=15
+LINK_EXCLUDE_APPS=("_example")
 
 # Counters
 TOTAL_VALIDATED=0
@@ -44,11 +48,16 @@ OPTIONS:
     -a, --app NAME          Validate specific app only
     -s, --strict            Fail on warnings
     -v, --verbose          Verbose output
+    --check-links           Also verify visual URLs (icon/thumbnail/logo/screenshots)
+                            resolve HTTP 200 (network check, runs after schema validation)
+    --link-jobs N           Max parallel link checks (default: 20)
+    --link-timeout N        Per-request timeout in seconds (default: 15)
 
 EXAMPLES:
     $0                      # Validate all apps
     $0 -a jellyseerr       # Validate specific app
     $0 --strict            # Strict validation
+    $0 --check-links       # Also verify image URLs resolve 200
 
 EOF
 }
@@ -60,6 +69,9 @@ while [[ $# -gt 0 ]]; do
         -a|--app) SPECIFIC_APP="$2"; shift 2 ;;
         -s|--strict) STRICT=true; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
+        --check-links) CHECK_LINKS=true; shift ;;
+        --link-jobs) LINK_JOBS="$2"; shift 2 ;;
+        --link-timeout) LINK_TIMEOUT="$2"; shift 2 ;;
         *) print_error "Unknown option: $1"; usage; exit 1 ;;
     esac
 done
@@ -338,6 +350,95 @@ validate_app() {
     return 0
 }
 
+# Check that visual URLs (icon/thumbnail/logo/screenshots) resolve HTTP 200
+check_image_links() {
+    local workdir url_map status_file
+    workdir="$(mktemp -d)"
+    url_map="$workdir/url_map.tsv"
+    status_file="$workdir/status.tsv"
+    > "$url_map"
+    > "$status_file"
+
+    echo ""
+    print_info "Checking visual URLs resolve HTTP 200..."
+
+    local app_dir app_name app_json
+    for app_dir in "$APPS_DIR"/*/; do
+        app_name="$(basename "$app_dir")"
+
+        if [[ -n "$SPECIFIC_APP" && "$app_name" != "$SPECIFIC_APP" ]]; then
+            continue
+        fi
+
+        local skip=false
+        for excl in "${LINK_EXCLUDE_APPS[@]}"; do
+            [[ "$app_name" == "$excl" ]] && skip=true
+        done
+        [[ "$skip" == true ]] && continue
+
+        app_json="$app_dir/app.json"
+        [[ -f "$app_json" ]] || continue
+
+        python3 -c "
+import json, sys
+try:
+    d = json.load(open('$app_json'))
+except Exception:
+    sys.exit()
+v = d.get('visual', {})
+for k in ['icon', 'thumbnail', 'logo']:
+    if v.get(k):
+        print(f'$app_name\t{k}\t{v[k]}')
+for s in v.get('screenshots', []) or []:
+    print(f'$app_name\tscreenshot\t{s}')
+" >> "$url_map"
+    done
+
+    local total_urls
+    total_urls=$(wc -l < "$url_map" | tr -d ' ')
+    print_info "Found $total_urls URL reference(s). Checking (parallel: $LINK_JOBS)..."
+
+    check_one() {
+        local app="$1" field="$2" url="$3"
+        local code
+        code=$(curl -s -o /dev/null -w "%{http_code}" -L --max-time "$LINK_TIMEOUT" "$url" 2>/dev/null || echo "000")
+        printf '%s\t%s\t%s\t%s\n' "$code" "$app" "$field" "$url" >> "$status_file"
+    }
+    export -f check_one
+    export LINK_TIMEOUT status_file
+
+    local job_count=0
+    while IFS=$'\t' read -r app field url; do
+        [[ -z "$url" ]] && continue
+        check_one "$app" "$field" "$url" &
+        job_count=$((job_count + 1))
+        if [[ "$job_count" -ge "$LINK_JOBS" ]]; then
+            wait
+            job_count=0
+        fi
+    done < "$url_map"
+    wait
+
+    local failed
+    failed=$(awk -F'\t' '$1!=200' "$status_file")
+
+    if [[ -z "$failed" ]]; then
+        print_success "All $total_urls image URL(s) resolved 200."
+        rm -rf "$workdir"
+        return 0
+    fi
+
+    local fail_count
+    fail_count=$(echo -n "$failed" | grep -c . || true)
+    print_error "$fail_count broken image URL(s):"
+    echo "$failed" | sort | while IFS=$'\t' read -r code app field url; do
+        echo -e "  ${RED}[$code]${NC} $app ($field): $url"
+    done
+
+    rm -rf "$workdir"
+    return 1
+}
+
 # Print summary
 print_summary() {
     echo ""
@@ -377,8 +478,13 @@ main() {
     fi
     
     print_summary
-    
-    if [[ $TOTAL_FAILED -gt 0 ]]; then
+
+    local link_check_failed=false
+    if [[ "$CHECK_LINKS" == "true" ]]; then
+        check_image_links || link_check_failed=true
+    fi
+
+    if [[ $TOTAL_FAILED -gt 0 ]] || [[ "$link_check_failed" == "true" ]]; then
         exit 1
     fi
 }

--- a/scripts/validate-apps.sh
+++ b/scripts/validate-apps.sh
@@ -87,6 +87,11 @@ check_dependencies() {
         print_error "yq not found. Install: brew install yq"
         exit 1
     fi
+
+    if [[ "$CHECK_LINKS" == "true" ]] && ! command -v python3 &> /dev/null; then
+        print_error "python3 not found (required for --check-links)"
+        exit 1
+    fi
 }
 
 # Validate JSON syntax
@@ -404,8 +409,6 @@ for s in v.get('screenshots', []) or []:
         code=$(curl -s -o /dev/null -w "%{http_code}" -L --max-time "$LINK_TIMEOUT" "$url" 2>/dev/null || echo "000")
         printf '%s\t%s\t%s\t%s\n' "$code" "$app" "$field" "$url" >> "$status_file"
     }
-    export -f check_one
-    export LINK_TIMEOUT status_file
 
     local job_count=0
     while IFS=$'\t' read -r app field url; do


### PR DESCRIPTION
## Summary
- Audited all 240 apps' visual URLs (icon/thumbnail/logo/screenshots) — 304 unique URLs checked for HTTP 200.
- Fixed 3 broken thumbnails: lobe-chat (stale big-bear-casaos repo path), spoolman (wrong screenshot filename), mailpit (GitHub blob page instead of raw image).

## Test plan
- [x] All 304 unique visual URLs re-checked, all return 200 (excluding intentional `_example` template placeholders)
- [x] `scripts/validate-apps.sh -a <app>` passed for lobe-chat, spoolman, mailpit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three broken thumbnail URLs across `lobe-chat`, `spoolman`, and `mailpit`, and adds an optional `--check-links` flag to `scripts/validate-apps.sh` that validates all visual URLs (icon/thumbnail/logo/screenshots) return HTTP 200.

- **lobe-chat**: Thumbnail redirected from the defunct `big-bear-casaos` repo path to the correct `big-bear-universal-apps` path, matching the existing screenshot URL pattern.
- **spoolman**: Filename typo corrected (`screenshots-1.png` → `screenshot-1.png`).
- **mailpit**: GitHub blob page URL replaced with a jsdelivr CDN raw URL (logo.png reused as thumbnail since no distinct screenshot exists).
- **validate-apps.sh**: New `--check-links` mode collects URLs via inline Python3, then runs parallel `curl` checks with configurable concurrency (`--link-jobs`) and timeout (`--link-timeout`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the app.json fixes are straightforward URL corrections, and the new --check-links script feature is opt-in with no impact on existing validation runs.

All three app.json changes are minimal, targeted URL fixes with no logic or schema implications. The new --check-links feature in the script is gated behind a flag and does not alter the existing validation path; issues noted are theoretical edge cases that would not affect any current app in the repo.

No files require special attention; the validate-apps.sh additions are the most complex change but are well-isolated.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/lobe-chat/app.json | Thumbnail URL corrected from stale big-bear-casaos repo path to the current big-bear-universal-apps repo path; change is accurate and consistent with the screenshots URL in the same file. |
| apps/spoolman/app.json | Thumbnail filename typo fixed (screenshots-1.png → screenshot-1.png); corrects a broken URL with no other changes. |
| apps/mailpit/app.json | Thumbnail changed from an unrenderable GitHub blob page URL to a jsdelivr CDN raw URL; thumbnail now points to logo.png (same as icon and logo fields) since no distinct screenshot exists for this app. |
| scripts/validate-apps.sh | Adds opt-in --check-links flag that collects visual URLs from all app.json files via an inline Python3 snippet and validates each with curl in parallel; shell variable interpolation inside the Python string literal and concurrent appends to a shared status file are minor concerns. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([validate-apps.sh invoked]) --> B{--check-links flag?}
    B -- No --> C[Schema validation only]
    B -- Yes --> D[check_dependencies: require python3]
    D --> E[Loop app dirs → python3 extracts URLs to url_map.tsv]
    E --> F{SPECIFIC_APP set?}
    F -- Yes --> G[Filter to that app only]
    F -- No --> H[Process all apps\nexcluding LINK_EXCLUDE_APPS]
    G --> I
    H --> I[Batch curl checks in parallel\nup to LINK_JOBS at a time]
    I --> J[Each check_one writes\nhttp_code to status_file]
    J --> K[awk filters status_file\nfor non-200 lines]
    K --> L{Any failures?}
    L -- No --> M[print_success\ncleanup workdir\nreturn 0]
    L -- Yes --> N[print_error with broken URLs\ncleanup workdir\nreturn 1]
    C --> O{TOTAL_FAILED > 0?}
    M --> O
    N --> O
    O -- Yes --> P([exit 1])
    O -- No --> Q([exit 0])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([validate-apps.sh invoked]) --> B{--check-links flag?}
    B -- No --> C[Schema validation only]
    B -- Yes --> D[check_dependencies: require python3]
    D --> E[Loop app dirs → python3 extracts URLs to url_map.tsv]
    E --> F{SPECIFIC_APP set?}
    F -- Yes --> G[Filter to that app only]
    F -- No --> H[Process all apps\nexcluding LINK_EXCLUDE_APPS]
    G --> I
    H --> I[Batch curl checks in parallel\nup to LINK_JOBS at a time]
    I --> J[Each check_one writes\nhttp_code to status_file]
    J --> K[awk filters status_file\nfor non-200 lines]
    K --> L{Any failures?}
    L -- No --> M[print_success\ncleanup workdir\nreturn 0]
    L -- Yes --> N[print_error with broken URLs\ncleanup workdir\nreturn 1]
    C --> O{TOTAL_FAILED > 0?}
    M --> O
    N --> O
    O -- Yes --> P([exit 1])
    O -- No --> Q([exit 0])
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(scripts): address premerge review fi..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/6d36476e14874292e639ee24f2bd1c4d9560ae84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43878517)</sub>

<!-- /greptile_comment -->