### PR TITLE
fix: strip digest pin before extracting version in update-app-version script

### DIFF
--- a/.github/scripts/update-app-version.js
+++ b/.github/scripts/update-app-version.js
@@ -2,6 +2,29 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
+function extractVersion(imageTag) {
+  const taggedImage = imageTag.split('@')[0];
+  const versionMatch = taggedImage.match(/:([^:]+)$/);
+
+  if (!versionMatch) {
+    return null;
+  }
+
+  const newVersion = versionMatch[1];
+
+  if (newVersion === 'latest' || newVersion === 'stable') {
+    return null;
+  }
+
+  if (!newVersion.match(/^(v)?\d+/)) {
+    return null;
+  }
+
+  return newVersion;
+}
+
+module.exports = { extractVersion };
+
 /**
  * Updates app.json version based on docker-compose.yml image version
  * This script is run automatically when Renovate updates docker-compose.yml files
@@ -86,33 +109,14 @@ async function updateAppVersion() {
         console.log(`Target service: ${targetService}`);
         console.log(`Image tag: ${imageTag}`);
 
-        // Strip any digest pin (e.g. repo:tag@sha256:...) before extracting the
-        // version. A tag cannot contain '@', so the segment before '@' is the tag
-        // and the hex after it is a digest, not a version.
-        const taggedImage = imageTag.split('@')[0];
+        const newVersion = extractVersion(imageTag);
 
-        // Extract version from image tag (e.g., "budibase/budibase:3.22.4" -> "3.22.4")
-        const versionMatch = taggedImage.match(/:([^:]+)$/);
-        
-        if (!versionMatch) {
-          console.log('Could not extract version from image tag');
+        if (!newVersion) {
+          console.log('Could not extract a semver version from image tag');
           continue;
         }
 
-        let newVersion = versionMatch[1];
         console.log(`Extracted version: ${newVersion}`);
-
-        // Skip if version is "latest" or "stable"
-        if (newVersion === 'latest' || newVersion === 'stable') {
-          console.log(`Skipping non-semver version tag: ${newVersion}`);
-          continue;
-        }
-        
-        // Check if version starts with digits or 'v' followed by digits
-        if (!newVersion.match(/^(v)?\d+/)) {
-          console.log(`Skipping non-semver version tag: ${newVersion}`);
-          continue;
-        }
 
         const currentVersion = appJson.metadata?.version;
         console.log(`Current version in app.json: ${currentVersion}`);
@@ -159,5 +163,6 @@ async function updateAppVersion() {
   }
 }
 
-// Run the script
-updateAppVersion();
+if (require.main === module) {
+  updateAppVersion();
+}

--- a/.github/scripts/update-app-version.js
+++ b/.github/scripts/update-app-version.js
@@ -86,8 +86,13 @@ async function updateAppVersion() {
         console.log(`Target service: ${targetService}`);
         console.log(`Image tag: ${imageTag}`);
 
+        // Strip any digest pin (e.g. repo:tag@sha256:...) before extracting the
+        // version. A tag cannot contain '@', so the segment before '@' is the tag
+        // and the hex after it is a digest, not a version.
+        const taggedImage = imageTag.split('@')[0];
+
         // Extract version from image tag (e.g., "budibase/budibase:3.22.4" -> "3.22.4")
-        const versionMatch = imageTag.match(/:([^:]+)$/);
+        const versionMatch = taggedImage.match(/:([^:]+)$/);
         
         if (!versionMatch) {
           console.log('Could not extract version from image tag');

--- a/.github/scripts/update-app-version.test.js
+++ b/.github/scripts/update-app-version.test.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('bun:test');
+const { extractVersion } = require('./update-app-version.js');
+
+test('extracts version from a plain tagged image', () => {
+  expect(extractVersion('budibase/budibase:3.22.4')).toBe('3.22.4');
+});
+
+test('extracts version from a v-prefixed tag', () => {
+  expect(extractVersion('amir20/dozzle:v10.6.9')).toBe('v10.6.9');
+});
+
+test('strips digest pin before extracting version', () => {
+  expect(
+    extractVersion(
+      'baserow/baserow:2.3.1@sha256:496889c4fe22ee6b632698c3c74f7ccaee734c8002b5ebc8d194c5fcacffc98a'
+    )
+  ).toBe('2.3.1');
+});
+
+test('skips latest tag even when digest-pinned', () => {
+  expect(
+    extractVersion('ente/server:latest@sha256:77f2a5244e8e515e66c3d737ed2ed89907e440d51d22435d7cf55e9c33623632')
+  ).toBe(null);
+});
+
+test('skips digest-only reference with no tag', () => {
+  expect(
+    extractVersion('ghcr.io/org/app@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789')
+  ).toBe(null);
+});
+
+test('skips stable tag', () => {
+  expect(extractVersion('someorg/someapp:stable')).toBe(null);
+});
+
+test('skips non-semver tag', () => {
+  expect(extractVersion('someorg/someapp:nightly')).toBe(null);
+});

--- a/apps/baserow/app.json
+++ b/apps/baserow/app.json
@@ -5,7 +5,7 @@
     "name": "Baserow",
     "description": "Create your own online database without technical experience. Our user-friendly no-code tool gives you the powers of a developer without leaving your browser.",
     "tagline": "Baserow",
-    "version": "2.2.2",
+    "version": "2.3.1",
     "author": "BigBearTechWorld",
     "developer": "baserow",
     "category": "BigBearCasaOS",

--- a/apps/baserow/app.json
+++ b/apps/baserow/app.json
@@ -5,7 +5,7 @@
     "name": "Baserow",
     "description": "Create your own online database without technical experience. Our user-friendly no-code tool gives you the powers of a developer without leaving your browser.",
     "tagline": "Baserow",
-    "version": "496889c4fe22ee6b632698c3c74f7ccaee734c8002b5ebc8d194c5fcacffc98a",
+    "version": "2.2.2",
     "author": "BigBearTechWorld",
     "developer": "baserow",
     "category": "BigBearCasaOS",

--- a/apps/dozzle/app.json
+++ b/apps/dozzle/app.json
@@ -5,7 +5,7 @@
     "name": "Dozzle",
     "description": "Dozzle is a real-time log viewer for docker containers.",
     "tagline": "Dozzle is a real-time log viewer for docker containers.",
-    "version": "v10.6.8",
+    "version": "v10.6.9",
     "author": "BigBearTechWorld",
     "developer": "amir20",
     "category": "BigBearCasaOS",

--- a/apps/dozzle/app.json
+++ b/apps/dozzle/app.json
@@ -5,7 +5,7 @@
     "name": "Dozzle",
     "description": "Dozzle is a real-time log viewer for docker containers.",
     "tagline": "Dozzle is a real-time log viewer for docker containers.",
-    "version": "6f4644814cce31e11fe80f2610515df6a5a2e40120b4087c298a72df8d65866b",
+    "version": "v10.6.8",
     "author": "BigBearTechWorld",
     "developer": "amir20",
     "category": "BigBearCasaOS",

--- a/apps/ente/app.json
+++ b/apps/ente/app.json
@@ -5,7 +5,7 @@
     "name": "Ente Photos",
     "description": "Ente is a self-hosted, end-to-end encrypted platform to store, share, and rediscover your photos and videos across all your devices.",
     "tagline": "End-to-end encrypted photo storage",
-    "version": "77f2a5244e8e515e66c3d737ed2ed89907e440d51d22435d7cf55e9c33623632",
+    "version": "latest",
     "author": "BigBearTechWorld",
     "developer": "ente-io",
     "category": "BigBearCasaOS",

--- a/apps/matterbridge/app.json
+++ b/apps/matterbridge/app.json
@@ -5,7 +5,7 @@
     "name": "Matterbridge",
     "description": "Matterbridge is a Matter plugin manager that allows you to have all your Matter devices up and running in a couple of minutes without having to deal with the pairing process for each individual device. It creates a device that can be paired with any ecosystem, such as Apple Home, Google Home, Amazon Alexa, Home Assistant, or any other platform supporting Matter.",
     "tagline": "Matter plugin manager for smart home devices",
-    "version": "6e2a0bcc14613842cc77fa697827bb280b68f23f51e26f467bb3f8cf768b6df5",
+    "version": "3.9.3",
     "author": "BigBearTechWorld",
     "developer": "Luligu",
     "category": "BigBearCasaOS",

--- a/apps/matterbridge/app.json
+++ b/apps/matterbridge/app.json
@@ -5,7 +5,7 @@
     "name": "Matterbridge",
     "description": "Matterbridge is a Matter plugin manager that allows you to have all your Matter devices up and running in a couple of minutes without having to deal with the pairing process for each individual device. It creates a device that can be paired with any ecosystem, such as Apple Home, Google Home, Amazon Alexa, Home Assistant, or any other platform supporting Matter.",
     "tagline": "Matter plugin manager for smart home devices",
-    "version": "3.9.3",
+    "version": "3.9.4",
     "author": "BigBearTechWorld",
     "developer": "Luligu",
     "category": "BigBearCasaOS",

--- a/apps/odysseus/app.json
+++ b/apps/odysseus/app.json
@@ -5,7 +5,7 @@
     "name": "Odysseus",
     "description": "Odysseus is a self-hosted AI workspace. It bundles chat, web search via SearXNG, and a ChromaDB vector store so you can run your own private AI environment with the LLM provider of your choice.",
     "tagline": "Self-hosted AI workspace",
-    "version": "920c84bd54fc3d95fdbc678dd33e13ebdfce4684f33d6d217d25a8fc933e066f",
+    "version": "2026.06.29",
     "author": "BigBearTechWorld",
     "developer": "pewdiepie-archdaemon",
     "category": "BigBearCasaOS",

--- a/apps/odysseus/app.json
+++ b/apps/odysseus/app.json
@@ -5,7 +5,7 @@
     "name": "Odysseus",
     "description": "Odysseus is a self-hosted AI workspace. It bundles chat, web search via SearXNG, and a ChromaDB vector store so you can run your own private AI environment with the LLM provider of your choice.",
     "tagline": "Self-hosted AI workspace",
-    "version": "2026.06.29",
+    "version": "2026.07.06",
     "author": "BigBearTechWorld",
     "developer": "pewdiepie-archdaemon",
     "category": "BigBearCasaOS",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Universal app definitions for Big Bear platforms",
   "main": "",
   "scripts": {
-    "generate-readme": "bun .github/scripts/readme-generator.ts"
+    "generate-readme": "bun .github/scripts/readme-generator.ts",
+    "test": "bun test ./.github/scripts/update-app-version.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Fix version-checker script misreading sha256 digest as app version when image tag is digest-pinned (repo:tag@sha256:...)
- Split on '@' before extracting version so tag (not digest hex) is used
- Regenerate correct version values for baserow, dozzle, ente, matterbridge, odysseus

## Changes
- .github/scripts/update-app-version.js — strip digest pin before version regex match
- apps/{baserow,dozzle,ente,matterbridge,odysseus}/app.json — version field corrected from sha256 hex to actual tag

## Test Plan
- [ ] Tested locally
- [ ] Manual QA completed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the `update-app-version.js` CI script where digest-pinned image references (`repo:tag@sha256:...`) caused the version extractor to capture the sha256 hex string instead of the actual tag. The fix extracts the logic into a standalone `extractVersion()` helper that strips the digest suffix before running the version regex.

- **Script refactor**: `extractVersion()` is pulled into its own exported function with an `@`-split guard; the `require.main === module` idiom is added so the script can be safely `require()`d by tests without side effects.
- **New test suite**: `update-app-version.test.js` covers the primary fix (digest-pinned tags), plain and v-prefixed tags, digest-only references (no tag), and non-semver skip cases.
- **Data corrections**: Five `app.json` files (`baserow`, `dozzle`, `matterbridge`, `odysseus`, `ente`) have their `version` fields corrected from sha256 hex values to the actual image tags.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused, well-tested bug fix with no impact on runtime behavior beyond correcting the version extraction logic.

The refactored extractVersion function correctly handles digest-pinned images, plain tags, and all previously tested patterns. The require.main === module guard is a standard Node.js pattern that prevents unintended execution on import. The five app.json corrections are straightforward data fixes aligned with the actual image tags. No existing behavior is broken.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/update-app-version.js | Extracts digest-stripping logic into a testable extractVersion() function exported via module.exports, adds require.main === module guard to prevent updateAppVersion() from running on import, and removes the inline version checks now consolidated in the helper. |
| .github/scripts/update-app-version.test.js | New test file covering the core fix (digest-pinned tag extraction), plus plain tags, v-prefixed tags, latest/stable skips, and non-semver tags using bun:test. |
| apps/baserow/app.json | Version corrected from sha256 hex digest to actual image tag 2.3.1. |
| apps/dozzle/app.json | Version corrected from sha256 hex digest to actual image tag v10.6.9. |
| apps/ente/app.json | Version corrected from sha256 hex digest to latest; accurately reflects the digest-pinned latest tag in docker-compose. |
| apps/matterbridge/app.json | Version corrected from sha256 hex digest to actual image tag 3.9.4. |
| apps/odysseus/app.json | Version corrected from sha256 hex digest to date-based tag 2026.07.06, which correctly passes the ^(v)?\d+ semver filter. |
| package.json | Adds test script to run the new bun test file via bun test. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[imageTag from docker-compose.yml] --> B[Split on @ to strip digest pin]
    B --> C{Has colon for version?}
    C -- no --> D[return null - skip update]
    C -- yes --> E[Extract tag after last colon]
    E --> F{Tag is latest or stable?}
    F -- yes --> D
    F -- no --> G{Tag starts with digit or v+digit?}
    G -- no --> D
    G -- yes --> H[return version string]
    H --> I{Different from current app.json version?}
    I -- no --> J[Log: already up to date]
    I -- yes --> K[Write updated app.json and set has_changes=true]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[imageTag from docker-compose.yml] --> B[Split on @ to strip digest pin]
    B --> C{Has colon for version?}
    C -- no --> D[return null - skip update]
    C -- yes --> E[Extract tag after last colon]
    E --> F{Tag is latest or stable?}
    F -- yes --> D
    F -- no --> G{Tag starts with digit or v+digit?}
    G -- no --> D
    G -- yes --> H[return version string]
    H --> I{Different from current app.json version?}
    I -- no --> J[Log: already up to date]
    I -- yes --> K[Write updated app.json and set has_changes=true]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: correct stale app.json versions and..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/f15d107b3b59b4101a09d3c70d47d5bc38f2f891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44203557)</sub>

<!-- /greptile_comment -->