### PR TITLE
Add PodFetch

### DIFF
--- a/apps/podfetch/app.json
+++ b/apps/podfetch/app.json
@@ -1,0 +1,171 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "podfetch",
+    "name": "PodFetch",
+    "description": "PodFetch is a sleek and efficient self-hosted podcast manager written in Rust. It automatically downloads new episodes, offers a web UI for listening and managing podcasts, and provides a GPodder-compatible sync API so you can keep using podcast apps like AntennaPod.",
+    "tagline": "Sleek podcast downloader with GPodder sync",
+    "version": "5.2.2",
+    "author": "SamTV12345",
+    "developer": "SamTV12345",
+    "category": "Media",
+    "license": "Apache-2.0",
+    "homepage": "https://samtv12345.github.io/PodFetch/",
+    "source": "big-bear-universal",
+    "created": "2026-07-18T00:00:00Z",
+    "updated": "2026-07-18T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/podfetch.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/podfetch.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://samtv12345.github.io/PodFetch/",
+    "repository": "https://github.com/SamTV12345/PodFetch",
+    "issues": "https://github.com/SamTV12345/PodFetch/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "app",
+    "default_port": "8000",
+    "main_image": "samuel19982/podfetch",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "DATABASE_URL",
+        "default": "sqlite:///app/db/podcast.db",
+        "description": "SQLite database location (or a PostgreSQL connection string)",
+        "required": false
+      },
+      {
+        "name": "POLLING_INTERVAL",
+        "default": "300",
+        "description": "Minutes between checks for new episodes",
+        "required": false
+      },
+      {
+        "name": "BASIC_AUTH",
+        "default": "false",
+        "description": "Set to true to enable login (required for GPodder sync); also set USERNAME and PASSWORD",
+        "required": false
+      },
+      {
+        "name": "USERNAME",
+        "default": "",
+        "description": "Admin username when BASIC_AUTH is enabled",
+        "required": false
+      },
+      {
+        "name": "PASSWORD",
+        "default": "",
+        "description": "Admin password when BASIC_AUTH is enabled",
+        "required": false
+      },
+      {
+        "name": "GPODDER_INTEGRATION_ENABLED",
+        "default": "false",
+        "description": "Set to true to enable the GPodder-compatible sync API for apps like AntennaPod",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/app/podcasts",
+        "description": "Downloaded podcast episodes"
+      },
+      {
+        "container": "/app/db",
+        "description": "SQLite database"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8000",
+        "host": "8000",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "/",
+    "tips": {
+      "after_install": {
+        "en_us": "Access the web UI at http://your-server:8000. To sync with mobile apps like AntennaPod, set BASIC_AUTH=true, USERNAME, PASSWORD and GPODDER_INTEGRATION_ENABLED=true, then create users via the web UI (User Administration > Invites)."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8000",
+      "volume_mappings": {
+        "podfetch_podcasts": "/DATA/AppData/$AppID/podcasts",
+        "podfetch_db": "/DATA/AppData/$AppID/db"
+      },
+      "category": "Media"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "Media",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "8000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "port": "8000",
+      "volume_mappings": {
+        "podfetch_podcasts": "podfetch/podcasts",
+        "podfetch_db": "podfetch/db"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8000"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "18000",
+      "volume_mappings": {
+        "podfetch_podcasts": "podfetch/podcasts",
+        "podfetch_db": "podfetch/db"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "podcast",
+    "gpodder",
+    "media"
+  ]
+}

--- a/apps/podfetch/app.json
+++ b/apps/podfetch/app.json
@@ -61,13 +61,13 @@
       },
       {
         "name": "USERNAME",
-        "default": "",
+        "default": "bigbear",
         "description": "Admin username when BASIC_AUTH is enabled",
         "required": false
       },
       {
         "name": "PASSWORD",
-        "default": "",
+        "default": "15c40698-3cd9-40ce-8039-e8d80fc1a030",
         "description": "Admin password when BASIC_AUTH is enabled",
         "required": false
       },
@@ -101,6 +101,9 @@
     "scheme": "http",
     "path": "/",
     "tips": {
+      "before_install": {
+        "en_us": "Before installing, change the default PASSWORD in the app settings to a secure password."
+      },
       "after_install": {
         "en_us": "Access the web UI at http://your-server:8000. To sync with mobile apps like AntennaPod, set BASIC_AUTH=true, USERNAME, PASSWORD and GPODDER_INTEGRATION_ENABLED=true, then create users via the web UI (User Administration > Invites)."
       }

--- a/apps/podfetch/docker-compose.yml
+++ b/apps/podfetch/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     environment:
       - DATABASE_URL=sqlite:///app/db/podcast.db
       - POLLING_INTERVAL=300
+      - BASIC_AUTH=${BASIC_AUTH:-false}
+      - USERNAME=${USERNAME:-}
+      - PASSWORD=${PASSWORD:-}
+      - GPODDER_INTEGRATION_ENABLED=${GPODDER_INTEGRATION_ENABLED:-false}
     restart: unless-stopped
     networks:
       - podfetch-network

--- a/apps/podfetch/docker-compose.yml
+++ b/apps/podfetch/docker-compose.yml
@@ -1,0 +1,29 @@
+name: podfetch
+
+services:
+  app:
+    image: samuel19982/podfetch:v5.2.2@sha256:b6473cc2fef5a3f1cbebab18ba56e198ee95fe8b3524e57c54d1d1e012c4045f
+    container_name: podfetch
+    ports:
+      - "8000:8000"
+    volumes:
+      - podfetch_podcasts:/app/podcasts
+      - podfetch_db:/app/db
+    environment:
+      - DATABASE_URL=sqlite:///app/db/podcast.db
+      - POLLING_INTERVAL=300
+    restart: unless-stopped
+    networks:
+      - podfetch-network
+
+networks:
+  podfetch-network:
+    driver: bridge
+
+volumes:
+  podfetch_podcasts:
+    name: podfetch_podcasts
+    driver: local
+  podfetch_db:
+    name: podfetch_db
+    driver: local

--- a/apps/podfetch/docker-compose.yml
+++ b/apps/podfetch/docker-compose.yml
@@ -12,10 +12,10 @@ services:
     environment:
       - DATABASE_URL=sqlite:///app/db/podcast.db
       - POLLING_INTERVAL=300
-      - BASIC_AUTH=${BASIC_AUTH:-false}
-      - USERNAME=${USERNAME:-}
-      - PASSWORD=${PASSWORD:-}
-      - GPODDER_INTEGRATION_ENABLED=${GPODDER_INTEGRATION_ENABLED:-false}
+      - BASIC_AUTH=false
+      - USERNAME=bigbear
+      - PASSWORD=15c40698-3cd9-40ce-8039-e8d80fc1a030
+      - GPODDER_INTEGRATION_ENABLED=false
     restart: unless-stopped
     networks:
       - podfetch-network


### PR DESCRIPTION
## Add PodFetch (universal app format)

Follow-up to https://github.com/bigbeartechworld/big-bear-casaos/issues/6338 where @dragonfire1119 pointed me to this repository — thanks!

**App:** PodFetch 5.2.2 — self-hosted podcast manager (Rust, Apache-2.0)
**Upstream:** https://github.com/SamTV12345/PodFetch (I am the upstream author and maintainer)
**Docs:** https://samtv12345.github.io/PodFetch/

PodFetch automatically downloads new podcast episodes, offers a web UI for listening and managing podcasts, and provides a GPodder-compatible sync API so users can keep using podcast apps like AntennaPod.

### Details

- `apps/podfetch/app.json` following `apps/_example` and SCHEMA.md (spec_version 1.0)
- Clean universal `docker-compose.yml`, image `samuel19982/podfetch:v5.2.2` pinned by multi-arch digest (amd64 + arm64)
- Data in named volumes `/app/podcasts` and `/app/db` (SQLite), with CasaOS/Runtipi/Umbrel volume mappings in `compatibility`
- Optional auth + GPodder env vars documented in `deployment.environment_variables`; app runs with sensible defaults without any of them

Happy to adjust anything to your conventions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds PodFetch 5.2.2, a self-hosted podcast manager with GPodder sync support, as a new universal app definition. The compose file is well-formed with a digest-pinned image, named volumes, and all the auth/GPodder env vars are present.

- `app.json` follows the spec_version 1.0 schema with correct metadata, platform compatibility blocks for CasaOS/Umbrel/Runtipi/Portainer/Dockge/Cosmos, and properly documented optional env vars.
- `docker-compose.yml` pins the image by multi-arch digest, maps both data volumes, and exposes port 8000.
- `SERVER_URL` (which the GPodder sync API uses to generate client-facing redirect URLs) is absent from both files; without it the mobile sync feature will return `localhost` to external clients.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only gap is a missing SERVER_URL variable that only affects GPodder mobile sync when accessed via a non-localhost hostname.

Both files are well-structured additions with no breaking logic. The image is pinned by digest, volumes are correctly named, and all previously flagged auth env vars are present. The one actionable finding — SERVER_URL not being surfaced in the compose file or app.json — only affects a specific feature (GPodder mobile sync) in a specific deployment scenario (external hostname), and the app works normally without it for local access and basic podcast downloading.

**Files Needing Attention:** apps/podfetch/app.json — SERVER_URL should be added to deployment.environment_variables

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/podfetch/app.json | New app definition; metadata, visual, ports, volumes, and platform compatibility all look correct. SERVER_URL is absent from deployment.environment_variables and docker-compose.yml, which could affect GPodder mobile sync when the app is accessed at a non-localhost hostname. |
| apps/podfetch/docker-compose.yml | Clean compose file; image is pinned by digest, volumes are named, env vars (BASIC_AUTH, USERNAME, PASSWORD, GPODDER_INTEGRATION_ENABLED) are present. SERVER_URL is absent. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Browser / Podcast App
    participant PodFetch as PodFetch (port 8000)
    participant Volume as Named Volumes<br/>(podcasts, db)
    participant Feed as Podcast RSS Feed

    User->>PodFetch: HTTP GET /
    PodFetch-->>User: Web UI

    User->>PodFetch: Add podcast feed URL
    PodFetch->>Feed: Fetch RSS (every POLLING_INTERVAL minutes)
    Feed-->>PodFetch: Episode list
    PodFetch->>Volume: Download episodes → /app/podcasts

    User->>PodFetch: GET /api/2/auth/login (GPodder sync)
    Note over PodFetch: Requires BASIC_AUTH=true
    PodFetch-->>User: Auth token + SERVER_URL

    User->>PodFetch: Sync subscriptions / episode actions
    PodFetch->>Volume: Persist state → /app/db (SQLite)
```

<sub>Reviews (3): Last reviewed commit: ["fix podfetch environment defaults"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/d68aac5ded294ab23baa7c3bcb37d9ca43a187d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45295896)</sub>

<!-- /greptile_comment -->