### PR TITLE
chore: add per-platform youtube video links

### DIFF
--- a/apps/btop/app.json
+++ b/apps/btop/app.json
@@ -108,7 +108,8 @@
         "btop_config": "/DATA/AppData/$AppID/config"
       },
       "port": "7681",
-      "category": "Others"
+      "category": "Others",
+      "youtube": "https://youtu.be/chaRoQV1V2I"
     },
     "portainer": {
       "supported": true,
@@ -130,12 +131,14 @@
       "volume_mappings": {
         "btop_config": "config"
       },
-      "port": "7681"
+      "port": "7681",
+      "youtube": "https://youtu.be/5ShJdw99nS8"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "7681"
+      "port": "7681",
+      "youtube": "https://youtu.be/xv9Bp0jCyN4"
     },
     "cosmos": {
       "supported": true,

--- a/apps/dockpeek/app.json
+++ b/apps/dockpeek/app.json
@@ -119,7 +119,8 @@
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "3420"
+      "port": "3420",
+      "youtube": "https://youtu.be/WYOT9szhDUI"
     },
     "cosmos": {
       "supported": true,

--- a/apps/obsidian-livesync/app.json
+++ b/apps/obsidian-livesync/app.json
@@ -78,7 +78,8 @@
         "obsidian-livesync_data_local.ini": "/DATA/AppData/$AppID/data/local.ini"
       },
       "port": "5984",
-      "category": "Developer"
+      "category": "Developer",
+      "youtube": "https://youtu.be/-n1abMPLmFg"
     },
     "portainer": {
       "supported": true,

--- a/apps/passwordpusher-v2/app.json
+++ b/apps/passwordpusher-v2/app.json
@@ -93,7 +93,8 @@
         "passwordpusher-v2_storage": "/DATA/AppData/$AppID/storage"
       },
       "port": "5101",
-      "category": "Others"
+      "category": "Others",
+      "youtube": "https://youtu.be/7Ej56MDo95g"
     },
     "portainer": {
       "supported": true,


### PR DESCRIPTION
## Summary

### Added
- youtube field to compatibility blocks (casaos/runtipi/dockge) for btop, dockpeek, obsidian-livesync, and passwordpusher-v2 app.json files

## Changes
- apps/btop/app.json
- apps/dockpeek/app.json
- apps/obsidian-livesync/app.json
- apps/passwordpusher-v2/app.json

## Test Plan
- [ ] Verified app.json validates

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds platform-specific YouTube tutorial metadata to four universal app definitions.
- Adds CasaOS links for btop, Obsidian Livesync, and Password Pusher v2.
- Adds Runtipi and Dockge links for btop.
- Adds a Dockge link for Dockpeek.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the Runtipi and Dockge links are propagated into their generated platform outputs or removed from this change.

The CasaOS additions work, but the conversion pipeline silently drops all newly added Runtipi and Dockge YouTube overrides, defeating the stated per-platform behavior.

**Files Needing Attention:** apps/btop/app.json and apps/dockpeek/app.json

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/btop/app.json | Adds CasaOS, Runtipi, and Dockge tutorial overrides, but the latter two are not propagated by their converters. |
| apps/dockpeek/app.json | Adds a Dockge tutorial override that the Dockge converter silently discards. |
| apps/obsidian-livesync/app.json | Adds a valid CasaOS tutorial override that the CasaOS converter consumes. |
| apps/passwordpusher-v2/app.json | Adds a valid CasaOS tutorial override that the CasaOS converter consumes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/btop/app.json:141
**Dockge video overrides are discarded**

When btop or Dockpeek is converted for Dockge, the converter neither reads `compatibility.dockge.youtube` nor emits a YouTube field, causing both newly added platform-specific tutorial links to be absent from the generated metadata.

### Issue 2
apps/btop/app.json:135
**Runtipi video override is discarded**

When btop is converted for Runtipi, the converter neither reads `compatibility.runtipi.youtube` nor emits a YouTube field, causing the newly added platform-specific tutorial link to be absent from the generated configuration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add per-platform youtube video li..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/cc9fbc22f4c4d1b96c872e0d598d55101314635b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48014271)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Universal App Format](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/universal-app-format.md)

<!-- /greptile_comment -->