### PR TITLE
Add ROMarr

### DIFF
--- a/apps/romarr/app.json
+++ b/apps/romarr/app.json
@@ -1,0 +1,242 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "romarr",
+    "name": "ROMarr",
+    "description": "ROMarr is the *arr for games. Request a title and it searches your indexers through Prowlarr, hands the winner to your download client, and files the ROM into your game library where it can actually be played. If you run Radarr for films and Sonarr for TV, this is the missing one. ROMarr is not tied to one library: RomM, Gaseous and Retrom are all supported through a single setting, and a folder mode writes a plain directory tree laid out by platform - no URL and no account - which is what Batocera, RetroPie, EmulationStation, ES-DE, EmuDeck, Pegasus, Lakka, muOS and LaunchBox already read. Every candidate release is scored with its reasoning recorded, and interactive search lists them all with a Grab button, so a wrong pick is one click to correct rather than a bug report. Unofficial; not affiliated with RomM, Gaseous or Retrom.",
+    "tagline": "The *arr for games",
+    "version": "0.6.1",
+    "author": "BigBearCommunity",
+    "developer": "Move Weight Foundation",
+    "category": "Media",
+    "license": "MIT",
+    "homepage": "https://github.com/BlizzHacker/romarr",
+    "source": "big-bear-universal",
+    "created": "2026-08-02T00:00:00Z",
+    "updated": "2026-08-02T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://raw.githubusercontent.com/BlizzHacker/cartridge-unraid/main/icon/romarr.png",
+    "thumbnail": "",
+    "screenshots": [
+      "https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/status.png",
+      "https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/interactive-search.png",
+      "https://raw.githubusercontent.com/BlizzHacker/romarr/main/docs/img/library.png"
+    ],
+    "logo": "https://raw.githubusercontent.com/BlizzHacker/cartridge-unraid/main/icon/romarr.png"
+  },
+  "resources": {
+    "documentation": "https://github.com/BlizzHacker/romarr#readme",
+    "repository": "https://github.com/BlizzHacker/romarr",
+    "issues": "https://github.com/BlizzHacker/romarr/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": ["amd64", "arm64"],
+    "platform": "linux",
+    "main_service": "romarr",
+    "default_port": "7878",
+    "main_image": "ghcr.io/blizzhacker/romarr",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "PROWLARR_URL",
+        "default": "",
+        "description": "How ROMarr finds releases, for example http://192.168.1.10:9696. Use your server's LAN address - localhost inside this container is this container.",
+        "required": true
+      },
+      {
+        "name": "PROWLARR_API_KEY",
+        "default": "",
+        "description": "Prowlarr, Settings, General, API Key",
+        "required": true
+      },
+      {
+        "name": "LIBRARY_KIND",
+        "default": "romm",
+        "description": "Which game library to file into: romm, gaseous, retrom, or folder. Use folder for Batocera, RetroPie, ES-DE, EmuDeck and similar - they read a plain directory tree and need no URL or account.",
+        "required": true
+      },
+      {
+        "name": "LIBRARY_URL",
+        "default": "",
+        "description": "Your library server's address, for example http://192.168.1.10:8080. Leave empty when LIBRARY_KIND is folder.",
+        "required": false
+      },
+      {
+        "name": "LIBRARY_USERNAME",
+        "default": "",
+        "description": "Use a dedicated account, not your admin one - all ROMarr needs is permission to trigger a rescan. Leave empty for folder mode.",
+        "required": false
+      },
+      {
+        "name": "LIBRARY_PASSWORD",
+        "default": "",
+        "description": "Password for the library account. Leave empty for folder mode.",
+        "required": false
+      },
+      {
+        "name": "LIBRARY_PATH",
+        "default": "/roms",
+        "description": "Where ROMs are written, as seen inside this container. Must match the container side of the ROM library volume.",
+        "required": false
+      },
+      {
+        "name": "QBITTORRENT_URL",
+        "default": "",
+        "description": "qBittorrent WebUI address. At least one download client is required.",
+        "required": false
+      },
+      {
+        "name": "QBITTORRENT_USER",
+        "default": "",
+        "description": "qBittorrent WebUI username",
+        "required": false
+      },
+      {
+        "name": "QBITTORRENT_PASS",
+        "default": "",
+        "description": "qBittorrent WebUI password",
+        "required": false
+      },
+      {
+        "name": "SABNZBD_URL",
+        "default": "",
+        "description": "Optional usenet client address",
+        "required": false
+      },
+      {
+        "name": "SABNZBD_API_KEY",
+        "default": "",
+        "description": "SABnzbd, Config, General, API Key",
+        "required": false
+      },
+      {
+        "name": "PUID",
+        "default": "1000",
+        "description": "User ID that owns the ROMs ROMarr writes. Match whatever your library app uses.",
+        "required": false
+      },
+      {
+        "name": "PGID",
+        "default": "1000",
+        "description": "Group ID that owns the ROMs ROMarr writes. Match whatever your library app uses.",
+        "required": false
+      },
+      {
+        "name": "TZ",
+        "default": "UTC",
+        "description": "Timezone for history and log timestamps",
+        "required": false
+      },
+      {
+        "name": "LOG_LEVEL",
+        "default": "INFO",
+        "description": "INFO, or DEBUG when filing a bug report",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/config",
+        "description": "Settings, history and indexer configuration"
+      },
+      {
+        "container": "/roms",
+        "description": "Where finished ROMs are filed - point this at the same location your library app reads"
+      },
+      {
+        "container": "/downloads",
+        "description": "Your download client's completed folder. This must match the path your client reports, character for character - ROMarr asks the client where a finished download is and then opens that path itself."
+      }
+    ],
+    "ports": [
+      {
+        "container": "7878",
+        "host": "7879",
+        "protocol": "tcp",
+        "description": "Web UI. The host side is offset because 7878 is also Radarr's port."
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "/",
+    "tips": {
+      "before_install": {
+        "en_us": "ROMarr needs a running Prowlarr and at least one download client (qBittorrent, SABnzbd or NZBGet). The download client is genuinely required - a release found with no client that speaks its protocol is ranked and then refused. Note that the web UI is mapped to host port 7879, because 7878 inside the container is also Radarr's port."
+      },
+      "after_install": {
+        "en_us": "Open ROMarr at http://your-server:7879 and finish setup on its Settings page. Important: ROMarr reads its environment variables once, on first start, and its own stored settings win afterwards - so later changes belong on the Settings page, not in the environment."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "7879",
+      "port": "7879",
+      "volume_mappings": {
+        "romarr_config": "/DATA/AppData/$AppID/config",
+        "romarr_roms": "/DATA/Media/Games",
+        "romarr_downloads": "/DATA/Downloads"
+      },
+      "category": "Media"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 1,
+      "categories": ["Media", "Downloaders", "selfhosted"],
+      "administrator_only": false,
+      "port": "7879"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": ["amd64", "arm64"],
+      "port": "8118",
+      "volume_mappings": {
+        "romarr_config": "romarr/config",
+        "romarr_roms": "romarr/roms",
+        "romarr_downloads": "romarr/downloads"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "7879"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "7878"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "17878",
+      "volume_mappings": {
+        "romarr_config": "romarr/config",
+        "romarr_roms": "romarr/roms",
+        "romarr_downloads": "romarr/downloads"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "media",
+    "games",
+    "roms",
+    "retro",
+    "emulation",
+    "arr",
+    "prowlarr",
+    "romm",
+    "downloader"
+  ]
+}

--- a/apps/romarr/app.json
+++ b/apps/romarr/app.json
@@ -5,7 +5,7 @@
     "name": "ROMarr",
     "description": "ROMarr is the *arr for games. Request a title and it searches your indexers through Prowlarr, hands the winner to your download client, and files the ROM into your game library where it can actually be played. If you run Radarr for films and Sonarr for TV, this is the missing one. ROMarr is not tied to one library: RomM, Gaseous and Retrom are all supported through a single setting, and a folder mode writes a plain directory tree laid out by platform - no URL and no account - which is what Batocera, RetroPie, EmulationStation, ES-DE, EmuDeck, Pegasus, Lakka, muOS and LaunchBox already read. Every candidate release is scored with its reasoning recorded, and interactive search lists them all with a Grab button, so a wrong pick is one click to correct rather than a bug report. Unofficial; not affiliated with RomM, Gaseous or Retrom.",
     "tagline": "The *arr for games",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "author": "BigBearCommunity",
     "developer": "Move Weight Foundation",
     "category": "Media",
@@ -32,10 +32,13 @@
     "support": "https://community.bigbeartechworld.com/"
   },
   "technical": {
-    "architectures": ["amd64", "arm64"],
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
     "platform": "linux",
     "main_service": "romarr",
-    "default_port": "7878",
+    "default_port": "6868",
     "main_image": "ghcr.io/blizzhacker/romarr",
     "compose_file": "docker-compose.yml"
   },
@@ -154,10 +157,10 @@
     ],
     "ports": [
       {
-        "container": "7878",
-        "host": "7879",
+        "container": "6868",
+        "host": "6868",
         "protocol": "tcp",
-        "description": "Web UI. The host side is offset because 7878 is also Radarr's port."
+        "description": "Web UI"
       }
     ]
   },
@@ -166,18 +169,18 @@
     "path": "/",
     "tips": {
       "before_install": {
-        "en_us": "ROMarr needs a running Prowlarr and at least one download client (qBittorrent, SABnzbd or NZBGet). The download client is genuinely required - a release found with no client that speaks its protocol is ranked and then refused. Note that the web UI is mapped to host port 7879, because 7878 inside the container is also Radarr's port."
+        "en_us": "ROMarr needs a running Prowlarr and at least one download client (qBittorrent, SABnzbd or NZBGet). The download client is genuinely required - a release found with no client that speaks its protocol is ranked and then refused."
       },
       "after_install": {
-        "en_us": "Open ROMarr at http://your-server:7879 and finish setup on its Settings page. Important: ROMarr reads its environment variables once, on first start, and its own stored settings win afterwards - so later changes belong on the Settings page, not in the environment."
+        "en_us": "Open ROMarr at http://your-server:6868 and finish setup on its Settings page. Important: ROMarr reads its environment variables once, on first start, and its own stored settings win afterwards - so later changes belong on the Settings page, not in the environment."
       }
     }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "7879",
-      "port": "7879",
+      "port_map": "6868",
+      "port": "6868",
       "volume_mappings": {
         "romarr_config": "/DATA/AppData/$AppID/config",
         "romarr_roms": "/DATA/Media/Games",
@@ -188,15 +191,22 @@
     "portainer": {
       "supported": true,
       "template_type": 1,
-      "categories": ["Media", "Downloaders", "selfhosted"],
+      "categories": [
+        "Media",
+        "Downloaders",
+        "selfhosted"
+      ],
       "administrator_only": false,
-      "port": "7879"
+      "port": "6868"
     },
     "runtipi": {
       "supported": true,
       "tipi_version": 1,
-      "supported_architectures": ["amd64", "arm64"],
-      "port": "8118",
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "port": "6868",
       "volume_mappings": {
         "romarr_config": "romarr/config",
         "romarr_roms": "romarr/roms",
@@ -206,18 +216,18 @@
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "7879"
+      "port": "6868"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "7878"
+      "port": "6868"
     },
     "umbrel": {
       "supported": true,
       "manifest_version": 1,
-      "port": "17878",
+      "port": "16868",
       "volume_mappings": {
         "romarr_config": "romarr/config",
         "romarr_roms": "romarr/roms",

--- a/apps/romarr/docker-compose.yml
+++ b/apps/romarr/docker-compose.yml
@@ -2,11 +2,10 @@ name: romarr
 
 services:
   romarr:
-    image: ghcr.io/blizzhacker/romarr:0.6.1@sha256:ce961117539fa985ee6d9c92a7ee8781ec3a154d2bb6c482d9eae27fed3e961c
+    image: ghcr.io/blizzhacker/romarr:0.7.0@sha256:106b336bf174813e1f2a6f610b567f9b384efba2ac2563ccc415015703786cbe
     container_name: romarr
     ports:
-      # 7878 is also Radarr's port, so the host side is offset to stay clear.
-      - "7879:7878"
+      - "6868:6868"
     volumes:
       - romarr_config:/config
       - romarr_roms:/roms

--- a/apps/romarr/docker-compose.yml
+++ b/apps/romarr/docker-compose.yml
@@ -1,0 +1,48 @@
+name: romarr
+
+services:
+  romarr:
+    image: ghcr.io/blizzhacker/romarr:0.6.1@sha256:ce961117539fa985ee6d9c92a7ee8781ec3a154d2bb6c482d9eae27fed3e961c
+    container_name: romarr
+    ports:
+      # 7878 is also Radarr's port, so the host side is offset to stay clear.
+      - "7879:7878"
+    volumes:
+      - romarr_config:/config
+      - romarr_roms:/roms
+      - romarr_downloads:/downloads
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-UTC}
+      - PROWLARR_URL=${PROWLARR_URL:-}
+      - PROWLARR_API_KEY=${PROWLARR_API_KEY:-}
+      - LIBRARY_KIND=${LIBRARY_KIND:-romm}
+      - LIBRARY_URL=${LIBRARY_URL:-}
+      - LIBRARY_USERNAME=${LIBRARY_USERNAME:-}
+      - LIBRARY_PASSWORD=${LIBRARY_PASSWORD:-}
+      - LIBRARY_PATH=${LIBRARY_PATH:-/roms}
+      - QBITTORRENT_URL=${QBITTORRENT_URL:-}
+      - QBITTORRENT_USER=${QBITTORRENT_USER:-}
+      - QBITTORRENT_PASS=${QBITTORRENT_PASS:-}
+      - SABNZBD_URL=${SABNZBD_URL:-}
+      - SABNZBD_API_KEY=${SABNZBD_API_KEY:-}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    restart: unless-stopped
+    networks:
+      - romarr-network
+
+networks:
+  romarr-network:
+    driver: bridge
+
+volumes:
+  romarr_config:
+    name: romarr_config
+    driver: local
+  romarr_roms:
+    name: romarr_roms
+    driver: local
+  romarr_downloads:
+    name: romarr_downloads
+    driver: local


### PR DESCRIPTION
Adds **ROMarr**, the \*arr for games, in the universal format so it converts out
to every Big Bear store rather than just one.

I originally prepared this against `big-bear-casaos` before noticing every PR
there is the automated Universal Apps sync — so this is the right door. Sorry
if any noise reached the other repo.

It takes a request, searches indexers through Prowlarr, hands the winner to a
download client, and files the ROM into a game library — the same shape as
Radarr and Sonarr, for the one media type that did not have it.

**Not tied to a single library.** RomM, Gaseous and Retrom are supported through
one setting, and a `folder` mode writes a plain directory tree laid out by
platform — no URL, no account — which is what Batocera, RetroPie, ES-DE,
EmuDeck, Pegasus, Lakka, muOS and LaunchBox already read.

| | |
| --- | --- |
| Source | https://github.com/BlizzHacker/romarr (MIT) |
| Image | `ghcr.io/blizzhacker/romarr:0.6.1`, pinned by digest |
| Architectures | `linux/amd64`, `linux/arm64`, `linux/arm/v7` (~75 MB) |

`app.json` validates clean against `schemas/app-schema-v1.json`. Marked
supported for casaos, portainer, runtipi, dockge, cosmos and umbrel.

**Three things worth knowing while reviewing:**

- The container listens on **7878, which is also Radarr's port.** Every platform
  block offsets the host side to 7879 (17878 for Umbrel's 10000+ range, 8118 for
  Runtipi). Radarr is common in this audience and the collision would otherwise
  be near-guaranteed.
- The `/downloads` volume **must match the path the user's download client
  reports, character for character** — ROMarr asks the client where a finished
  download is and then opens that path itself. It is called out in the volume
  description and the install tips.
- ROMarr reads its environment variables **once**, on first start, and its own
  stored settings win afterwards. Deliberate upstream behaviour so the Settings
  page can hold a decision, but it means editing env vars later has no effect —
  hence the `after_install` tip.

Requirements: a Prowlarr instance and at least one download client. The download
client is genuinely required rather than optional — a release found with no
client that speaks its protocol is ranked and then refused.

I have not run this image as part of preparing the PR. Upstream CI builds all
three architectures and gates the image build behind its test suite.

Happy to adjust ports, categories, volume mappings or platform support to match
your conventions.

**Unofficial. Not affiliated with RomM, Gaseous or Retrom.**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds ROMarr as a universal application.
- Defines ROMarr metadata, configuration fields, volume requirements, and compatibility settings for supported stores.
- Adds a Compose deployment using the pinned 0.7.0 container image, persistent storage, environment configuration, and a dedicated bridge network.

<h3>Confidence Score: 4/5</h3>

The PR does not yet appear safe to merge because supported ARMv7 deployments remain excluded and default Compose deployments cannot share completed downloads with a separate client.

The manifest still advertises only amd64 and arm64 in both architecture lists despite the image's ARMv7 support, while the Compose file still maps /downloads to a private local named volume that a separately deployed download client does not populate.

**Files Needing Attention:** apps/romarr/app.json and apps/romarr/docker-compose.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/romarr/app.json | Adds the universal application manifest, including metadata, configuration, UI guidance, and per-platform compatibility settings. |
| apps/romarr/docker-compose.yml | Adds the ROMarr container deployment with environment variables, persistent volumes, port publishing, and networking. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ROMarr 0.7.0: default port moved to 6868"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/b1d07843a17a35f291ba60f8d3cd40122695f257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49438714)</sub>

<!-- /greptile_comment -->