### PR TITLE
Add Buzz relay by Block

### DIFF
--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -10,15 +10,21 @@ Self-hostable workspace for humans and agents from Block, built on the Nostr pro
 
 A single process serves all three. Health and metrics listen on ports 8080 and 9102 inside the container and are intentionally not published.
 
-## Multi-device access
+## Set RELAY_URL first
 
-`RELAY_URL` defaults to `ws://localhost:3000`, which only resolves on the server itself. To connect from another device, edit the `relay` service in `docker-compose.yml` and replace `localhost` with the server LAN IP or domain:
+Buzz serves the web interface only for the exact address set in `RELAY_URL`. The default is `ws://localhost:3000`, which works when browsing from the server itself. Opening the app from any other device returns:
+
+```
+relay: no community is configured for this host
+```
+
+To fix it, edit the `relay` service in `docker-compose.yml` and replace `localhost` with the address you browse to, then restart the relay:
 
 ```
 RELAY_URL: ws://192.168.1.50:3000
 ```
 
-Restart the relay after changing it.
+Use the same value for Nostr clients: `ws://192.168.1.50:3000`. Behind a reverse proxy or domain, set `RELAY_URL` to that hostname instead, matching the port users connect on.
 
 ## Secrets
 

--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -18,13 +18,16 @@ Buzz serves the web interface only for the exact address set in `RELAY_URL`. The
 relay: no community is configured for this host
 ```
 
-To fix it, edit the `relay` service in `docker-compose.yml` and replace `localhost` with the address you browse to, then restart the relay:
+To fix it, edit the `relay` service in `docker-compose.yml` and replace `localhost` in **both** of these with the address you browse to, then restart the relay:
 
 ```
 RELAY_URL: ws://192.168.1.50:3000
+BUZZ_MEDIA_BASE_URL: http://192.168.1.50:3000/media
 ```
 
-Use the same value for Nostr clients: `ws://192.168.1.50:3000`. Behind a reverse proxy or domain, set `RELAY_URL` to that hostname instead, matching the port users connect on.
+Change them together. `BUZZ_MEDIA_BASE_URL` is not derived from `RELAY_URL`, and it is written into the URL of every uploaded file. Leaving it on `localhost` publishes media links that only work on the server, and links already published cannot be corrected by changing it later.
+
+Use the same value for Nostr clients: `ws://192.168.1.50:3000`. Behind a reverse proxy or domain, set both to that hostname instead, matching the port users connect on.
 
 ## Secrets
 

--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -58,11 +58,13 @@ Use the printed secret key as `BUZZ_RELAY_PRIVATE_KEY`. Keep it stable across re
 
 Rotate the database, Redis, and MinIO secrets **before first start**. PostgreSQL and MinIO read their credentials only when their volume is first initialised, so editing the compose file later leaves the relay presenting a password the server never accepted and it restarts in a loop. Redis is the exception and picks up the new value on restart.
 
-To change the database password after data exists, update it in PostgreSQL first, then edit `DATABASE_URL` to match:
+To change the database password after data exists, update it in PostgreSQL first:
 
 ```bash
 docker exec -it buzz-postgres psql -U buzz -c "ALTER USER buzz WITH PASSWORD 'new-password';"
 ```
+
+Then edit `docker-compose.yml` and set the new password in **both** places — `DATABASE_URL` on the `relay` service and `POSTGRES_PASSWORD` on the `postgres` service — and restart. `POSTGRES_PASSWORD` is ignored while the volume exists, but leaving it stale re-seeds the old password if `buzz_postgres_data` is ever recreated, and the relay would then fail to authenticate.
 
 Changing the MinIO root credentials after first start means recreating the `buzz_minio_data` volume, which deletes stored media.
 

--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -44,7 +44,15 @@ docker exec buzz-relay buzz-admin generate-key
 
 Use the printed secret key as `BUZZ_RELAY_PRIVATE_KEY`. Keep it stable across restarts and back it up; changing it changes the relay's identity.
 
-Rotate the database, Redis, and MinIO secrets before first start. Changing them after data exists requires updating the credentials inside PostgreSQL, Redis, and MinIO as well.
+Rotate the database, Redis, and MinIO secrets **before first start**. PostgreSQL and MinIO read their credentials only when their volume is first initialised, so editing the compose file later leaves the relay presenting a password the server never accepted and it restarts in a loop. Redis is the exception and picks up the new value on restart.
+
+To change the database password after data exists, update it in PostgreSQL first, then edit `DATABASE_URL` to match:
+
+```bash
+docker exec -it buzz-postgres psql -U buzz -c "ALTER USER buzz WITH PASSWORD 'new-password';"
+```
+
+Changing the MinIO root credentials after first start means recreating the `buzz_minio_data` volume, which deletes stored media.
 
 ## Closed relay mode
 

--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -1,0 +1,91 @@
+# Buzz
+
+Self-hostable workspace for humans and agents from Block, built on the Nostr protocol.
+
+## Access
+
+- Web interface: `http://<server>:3000`
+- Nostr relay (WebSocket): `ws://<server>:3000`
+- REST API: `http://<server>:3000`
+
+A single process serves all three. Health and metrics listen on ports 8080 and 9102 inside the container and are intentionally not published.
+
+## Multi-device access
+
+`RELAY_URL` defaults to `ws://localhost:3000`, which only resolves on the server itself. To connect from another device, edit the `relay` service in `docker-compose.yml` and replace `localhost` with the server LAN IP or domain:
+
+```
+RELAY_URL: ws://192.168.1.50:3000
+```
+
+Restart the relay after changing it.
+
+## Secrets
+
+This app ships with fixed placeholder secrets so it starts with no configuration. **They are published in a public repository. Rotate them before real use.** In `docker-compose.yml`, replace every occurrence of:
+
+- `7c0d0f000f4cdafc380ab93c413d97deceff42e273c97200d3fb35ad74e29231` - relay signing key
+- `change-me-pg-7Kd2mQ9xR4vT` - PostgreSQL password (`relay` and `postgres`)
+- `change-me-redis-3Fn8pL5wZ6yB` - Redis password (`relay` and `redis`)
+- `change-me-s3-access-J4hN7qX2` - MinIO access key (`relay`, `minio`, `minio-init`)
+- `change-me-s3-secret-W9cR3tY6uM8k` - MinIO secret key (`relay`, `minio`, `minio-init`)
+
+Generate a new relay key with:
+
+```bash
+docker exec buzz-relay buzz-admin generate-key
+```
+
+Use the printed secret key as `BUZZ_RELAY_PRIVATE_KEY`. Keep it stable across restarts and back it up; changing it changes the relay's identity.
+
+Rotate the database, Redis, and MinIO secrets before first start. Changing them after data exists requires updating the credentials inside PostgreSQL, Redis, and MinIO as well.
+
+## Closed relay mode
+
+By default the relay is open: any client with its own Nostr keypair can connect. To restrict it to approved members, set both of these on the `relay` service and restart:
+
+```
+BUZZ_REQUIRE_RELAY_MEMBERSHIP: "true"
+RELAY_OWNER_PUBKEY: <your 64-character hex pubkey>
+```
+
+The relay will not start with membership enabled unless `RELAY_OWNER_PUBKEY` is a valid 64-character hex key. Manage members with:
+
+```bash
+docker exec buzz-relay buzz-admin add-member --pubkey <npub-or-hex>
+docker exec buzz-relay buzz-admin list-members
+docker exec buzz-relay buzz-admin remove-member --pubkey <npub-or-hex>
+```
+
+When adding several members, wait a second between commands to avoid timestamp collisions in the roster event.
+
+## Architecture
+
+| Service | Purpose |
+|---|---|
+| `relay` | Nostr relay, REST API, git storage, and web interface on port 3000. |
+| `postgres` | Application database. |
+| `redis` | Pub/sub and cache. |
+| `minio` | S3-compatible object storage for media and git objects. |
+| `minio-init` | One-shot job that creates the storage bucket. |
+
+## Volumes
+
+| Volume | Container path | Purpose |
+|---|---|---|
+| `buzz_postgres_data` | `/var/lib/postgresql/data` | PostgreSQL database. |
+| `buzz_redis_data` | `/data` | Redis append-only file. |
+| `buzz_minio_data` | `/data` | Media and git objects. |
+| `buzz_git_data` | `/data/git` | Git repository data. |
+
+Back up `buzz_postgres_data` together with `buzz_minio_data` and `buzz_git_data` from the same maintenance window, plus the secrets listed above.
+
+## Notes
+
+The relay verifies at every start that its object storage supports atomic conditional writes, which adds a short delay before it becomes healthy. If MinIO is misconfigured the relay refuses to start rather than risk corrupting git data.
+
+## Links
+
+- Guide: https://engineering.block.xyz/blog/run-your-own-buzz-relay
+- Source: https://github.com/block/buzz
+- Support: https://community.bigbeartechworld.com/

--- a/apps/buzz/README.md
+++ b/apps/buzz/README.md
@@ -14,20 +14,29 @@ A single process serves all three. Health and metrics listen on ports 8080 and 9
 
 Buzz serves the web interface only for the exact address set in `RELAY_URL`. The default is `ws://localhost:3000`, which works when browsing from the server itself. Opening the app from any other device returns:
 
-```
+```text
 relay: no community is configured for this host
 ```
 
 To fix it, edit the `relay` service in `docker-compose.yml` and replace `localhost` in **both** of these with the address you browse to, then restart the relay:
 
-```
+```yaml
 RELAY_URL: ws://192.168.1.50:3000
 BUZZ_MEDIA_BASE_URL: http://192.168.1.50:3000/media
 ```
 
 Change them together. `BUZZ_MEDIA_BASE_URL` is not derived from `RELAY_URL`, and it is written into the URL of every uploaded file. Leaving it on `localhost` publishes media links that only work on the server, and links already published cannot be corrected by changing it later.
 
-Use the same value for Nostr clients: `ws://192.168.1.50:3000`. Behind a reverse proxy or domain, set both to that hostname instead, matching the port users connect on.
+Use the same value for Nostr clients: `ws://192.168.1.50:3000`.
+
+Behind a reverse proxy serving HTTPS, use the secure schemes instead, matching the hostname and port users connect on:
+
+```yaml
+RELAY_URL: wss://buzz.example.com
+BUZZ_MEDIA_BASE_URL: https://buzz.example.com/media
+```
+
+A page served over HTTPS cannot open a plaintext `ws://` connection, so `wss://` is required there rather than optional. On a plain LAN address without a proxy, traffic is unencrypted; put the relay behind a TLS proxy before exposing it outside a trusted network.
 
 ## Secrets
 
@@ -61,7 +70,7 @@ Changing the MinIO root credentials after first start means recreating the `buzz
 
 By default the relay is open: any client with its own Nostr keypair can connect. To restrict it to approved members, set both of these on the `relay` service and restart:
 
-```
+```yaml
 BUZZ_REQUIRE_RELAY_MEMBERSHIP: "true"
 RELAY_OWNER_PUBKEY: <your 64-character hex pubkey>
 ```

--- a/apps/buzz/app.json
+++ b/apps/buzz/app.json
@@ -112,7 +112,7 @@
       "supported": true,
       "port_map": "3000",
       "port": "3000",
-      "category": "Social",
+      "category": "Developer",
       "volume_mappings": {
         "buzz_postgres_data": "/DATA/AppData/$AppID/postgres_data",
         "buzz_redis_data": "/DATA/AppData/$AppID/redis_data",

--- a/apps/buzz/app.json
+++ b/apps/buzz/app.json
@@ -54,6 +54,12 @@
         "required": true
       },
       {
+        "name": "BUZZ_MEDIA_BASE_URL",
+        "default": "http://localhost:3000/media",
+        "description": "Base URL written into the link of every uploaded file. Change localhost to the same address used in RELAY_URL. Links published before this is corrected cannot be fixed later.",
+        "required": true
+      },
+      {
         "name": "RELAY_OWNER_PUBKEY",
         "default": "",
         "description": "Owner Nostr public key as 64-character hex. Only needed when BUZZ_REQUIRE_RELAY_MEMBERSHIP is true.",
@@ -103,7 +109,7 @@
         "en_us": "This app ships with placeholder secrets so it starts without configuration. Rotate BUZZ_RELAY_PRIVATE_KEY and the change-me database, Redis, and S3 passwords before using it for anything real. See the app README."
       },
       "after_install": {
-        "en_us": "Set RELAY_URL to the address you browse to, for example ws://192.168.1.50:3000, then restart. Buzz serves its web interface only for the address in RELAY_URL, so with the localhost default any other device gets 'no community is configured for this host'. Nostr clients use the same ws:// address."
+        "en_us": "Set RELAY_URL and BUZZ_MEDIA_BASE_URL to the address you browse to, for example ws://192.168.1.50:3000 and http://192.168.1.50:3000/media, then restart. Buzz serves its web interface only for the address in RELAY_URL, so with the localhost default any other device gets 'no community is configured for this host'. Nostr clients use the same ws:// address."
       }
     }
   },

--- a/apps/buzz/app.json
+++ b/apps/buzz/app.json
@@ -50,7 +50,7 @@
       {
         "name": "RELAY_URL",
         "default": "ws://localhost:3000",
-        "description": "URL clients use to reach this relay. Change localhost to the server LAN IP or domain so other devices can connect.",
+        "description": "Address this relay answers on. Buzz serves its web interface only for this exact host and port, so change localhost to the server LAN IP or domain or other devices get 'no community is configured for this host'.",
         "required": true
       },
       {
@@ -103,7 +103,7 @@
         "en_us": "This app ships with placeholder secrets so it starts without configuration. Rotate BUZZ_RELAY_PRIVATE_KEY and the change-me database, Redis, and S3 passwords before using it for anything real. See the app README."
       },
       "after_install": {
-        "en_us": "Open http://your-server:3000 for the web interface. Nostr clients connect to ws://your-server:3000. Change RELAY_URL from localhost to your server IP so other devices can connect."
+        "en_us": "Set RELAY_URL to the address you browse to, for example ws://192.168.1.50:3000, then restart. Buzz serves its web interface only for the address in RELAY_URL, so with the localhost default any other device gets 'no community is configured for this host'. Nostr clients use the same ws:// address."
       }
     }
   },

--- a/apps/buzz/app.json
+++ b/apps/buzz/app.json
@@ -1,0 +1,182 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "buzz",
+    "name": "Buzz",
+    "description": "Buzz is a self-hostable workspace for humans and agents from Block. It runs a Nostr relay, a REST bridge, git-over-object-storage, and a web interface from a single Rust binary, so you can host your own community and agent infrastructure.",
+    "tagline": "Self-hosted workspace and Nostr relay for humans and agents",
+    "version": "latest",
+    "author": "BigBearTechWorld",
+    "developer": "block",
+    "category": "BigBearCasaOS",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/block/buzz",
+    "source": "big-bear-universal",
+    "created": "2026-08-03T00:00:00Z",
+    "updated": "2026-08-03T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/block/buzz@main/desktop/public/app-icon@2x.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/block/buzz@main/desktop/public/app-icon@2x.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://engineering.block.xyz/blog/run-your-own-buzz-relay",
+    "repository": "https://github.com/block/buzz",
+    "issues": "https://github.com/block/buzz/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "relay",
+    "default_port": "3000",
+    "main_image": "ghcr.io/block/buzz",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "BUZZ_RELAY_PRIVATE_KEY",
+        "default": "7c0d0f000f4cdafc380ab93c413d97deceff42e273c97200d3fb35ad74e29231",
+        "description": "Relay signing identity as 64-character hex. This default is published in a public repository, so replace it before real use. Generate one with: docker exec buzz-relay buzz-admin generate-key",
+        "required": true
+      },
+      {
+        "name": "RELAY_URL",
+        "default": "ws://localhost:3000",
+        "description": "URL clients use to reach this relay. Change localhost to the server LAN IP or domain so other devices can connect.",
+        "required": true
+      },
+      {
+        "name": "RELAY_OWNER_PUBKEY",
+        "default": "",
+        "description": "Owner Nostr public key as 64-character hex. Only needed when BUZZ_REQUIRE_RELAY_MEMBERSHIP is true.",
+        "required": false
+      },
+      {
+        "name": "BUZZ_REQUIRE_RELAY_MEMBERSHIP",
+        "default": "false",
+        "description": "Set to true to run a closed relay that only approved members can use. Requires RELAY_OWNER_PUBKEY.",
+        "required": false
+      },
+      {
+        "name": "BUZZ_AUTO_MIGRATE",
+        "default": "true",
+        "description": "Runs database migrations on start. Leave enabled so the schema is created on first launch.",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/var/lib/postgresql/data",
+        "description": "PostgreSQL database storage"
+      },
+      {
+        "container": "/data",
+        "description": "Redis append-only file and MinIO object storage"
+      },
+      {
+        "container": "/data/git",
+        "description": "Git repository data"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Web UI, Nostr WebSocket relay, and REST API"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": {
+        "en_us": "This app ships with placeholder secrets so it starts without configuration. Rotate BUZZ_RELAY_PRIVATE_KEY and the change-me database, Redis, and S3 passwords before using it for anything real. See the app README."
+      },
+      "after_install": {
+        "en_us": "Open http://your-server:3000 for the web interface. Nostr clients connect to ws://your-server:3000. Change RELAY_URL from localhost to your server IP so other devices can connect."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3000",
+      "port": "3000",
+      "category": "Social",
+      "volume_mappings": {
+        "buzz_postgres_data": "/DATA/AppData/$AppID/postgres_data",
+        "buzz_redis_data": "/DATA/AppData/$AppID/redis_data",
+        "buzz_minio_data": "/DATA/AppData/$AppID/minio_data",
+        "buzz_git_data": "/DATA/AppData/$AppID/git_data"
+      }
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "3000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "port": "3000",
+      "volume_mappings": {
+        "buzz_postgres_data": "postgres_data",
+        "buzz_redis_data": "redis_data",
+        "buzz_minio_data": "minio_data",
+        "buzz_git_data": "git_data"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "3000"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "10195",
+      "app_port": "3000",
+      "volume_mappings": {
+        "buzz_postgres_data": "postgres_data",
+        "buzz_redis_data": "redis_data",
+        "buzz_minio_data": "minio_data",
+        "buzz_git_data": "git_data"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "nostr",
+    "relay",
+    "social",
+    "agents"
+  ]
+}

--- a/apps/buzz/docker-compose.yml
+++ b/apps/buzz/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       BUZZ_RELAY_PRIVATE_KEY: 7c0d0f000f4cdafc380ab93c413d97deceff42e273c97200d3fb35ad74e29231
       BUZZ_SERVE_GIT_WEB_GUI: "true"
       RELAY_URL: ws://localhost:3000
+      BUZZ_MEDIA_BASE_URL: http://localhost:3000/media
     volumes:
       - buzz_git_data:/data/git
     depends_on:

--- a/apps/buzz/docker-compose.yml
+++ b/apps/buzz/docker-compose.yml
@@ -1,0 +1,146 @@
+name: buzz
+
+services:
+  relay:
+    image: ghcr.io/block/buzz:main@sha256:ac050947da4e474dda3b10850eb249cb1ee735ceb4544213c2017650c0226c49
+    container_name: buzz-relay
+    ports:
+      - "3000:3000"
+    environment:
+      BUZZ_BIND_ADDR: 0.0.0.0:3000
+      BUZZ_HEALTH_PORT: "8080"
+      BUZZ_METRICS_PORT: "9102"
+      DATABASE_URL: postgres://buzz:change-me-pg-7Kd2mQ9xR4vT@postgres:5432/buzz
+      REDIS_URL: redis://:change-me-redis-3Fn8pL5wZ6yB@redis:6379
+      BUZZ_S3_ENDPOINT: http://minio:9000
+      BUZZ_S3_ADDRESSING_STYLE: path
+      BUZZ_S3_ACCESS_KEY: change-me-s3-access-J4hN7qX2
+      BUZZ_S3_SECRET_KEY: change-me-s3-secret-W9cR3tY6uM8k
+      BUZZ_S3_BUCKET: buzz-media
+      BUZZ_GIT_REPO_PATH: /data/git
+      BUZZ_AUTO_MIGRATE: "true"
+      BUZZ_GIT_CONFORMANCE_PROBE: "true"
+      BUZZ_REQUIRE_AUTH_TOKEN: "true"
+      BUZZ_REQUIRE_RELAY_MEMBERSHIP: "false"
+      BUZZ_RELAY_PRIVATE_KEY: 7c0d0f000f4cdafc380ab93c413d97deceff42e273c97200d3fb35ad74e29231
+      BUZZ_SERVE_GIT_WEB_GUI: "true"
+      RELAY_URL: ws://localhost:3000
+    volumes:
+      - buzz_git_data:/data/git
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/8080; printf \"GET /_readiness HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q \"200 OK\" <&3'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - buzz_network
+
+  postgres:
+    image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+    container_name: buzz-postgres
+    environment:
+      POSTGRES_DB: buzz
+      POSTGRES_USER: buzz
+      POSTGRES_PASSWORD: change-me-pg-7Kd2mQ9xR4vT
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - buzz_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - buzz_network
+
+  redis:
+    image: redis:7-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
+    container_name: buzz-redis
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "change-me-redis-3Fn8pL5wZ6yB"]
+    environment:
+      REDIS_PASSWORD: change-me-redis-3Fn8pL5wZ6yB
+    volumes:
+      - buzz_redis_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz_network
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+    container_name: buzz-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: change-me-s3-access-J4hN7qX2
+      MINIO_ROOT_PASSWORD: change-me-s3-secret-W9cR3tY6uM8k
+    volumes:
+      - buzz_minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - buzz_network
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+    container_name: buzz-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      BUZZ_S3_ACCESS_KEY: change-me-s3-access-J4hN7qX2
+      BUZZ_S3_SECRET_KEY: change-me-s3-secret-W9cR3tY6uM8k
+      BUZZ_S3_BUCKET: buzz-media
+    entrypoint: >
+      /bin/sh -euc '
+        mc alias set local http://minio:9000 "$${BUZZ_S3_ACCESS_KEY}" "$${BUZZ_S3_SECRET_KEY}"
+        mc mb --ignore-existing "local/$${BUZZ_S3_BUCKET}"
+        mc anonymous set none "local/$${BUZZ_S3_BUCKET}"
+      '
+    restart: "no"
+    networks:
+      - buzz_network
+
+networks:
+  buzz_network:
+    driver: bridge
+
+volumes:
+  buzz_postgres_data:
+    name: buzz_postgres_data
+    driver: local
+  buzz_redis_data:
+    name: buzz_redis_data
+    driver: local
+  buzz_minio_data:
+    name: buzz_minio_data
+    driver: local
+  buzz_git_data:
+    name: buzz_git_data
+    driver: local

--- a/scripts/casaos-category-map.json
+++ b/scripts/casaos-category-map.json
@@ -238,5 +238,6 @@
   "write-freely": "Social",
   "zigbee2mqtt": "Home",
   "zipline": "Others",
-  "zotero": "Others"
+  "zotero": "Others",
+  "buzz": "Social"
 }

--- a/scripts/casaos-category-map.json
+++ b/scripts/casaos-category-map.json
@@ -239,5 +239,5 @@
   "zigbee2mqtt": "Home",
   "zipline": "Others",
   "zotero": "Others",
-  "buzz": "Social"
+  "buzz": "Developer"
 }


### PR DESCRIPTION
Adds Buzz (block.xyz) as a five-service stack: relay + PostgreSQL 17 + Redis 7 + MinIO. Closes #2705.

Pinned `BUZZ_AUTO_MIGRATE=true` (upstream defaults false, leaving a fresh DB schemaless) and `BUZZ_SERVE_GIT_WEB_GUI=true` so the Open button serves the web UI instead of raw NIP-11 JSON.

Verified on a live stack: relay healthy in ~15s, `/` returns HTML. Placeholder secrets are documented for rotation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Buzz as a self-hosted five-service application stack.
- Defines the Buzz relay with PostgreSQL, Redis, MinIO, and bucket initialization.
- Adds deployment metadata and compatibility settings for six supported platforms.
- Documents host configuration, TLS proxying, secret rotation, closed-relay mode, storage, and backups.
- Maps Buzz to the CasaOS Developer category.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/buzz/docker-compose.yml | Defines the relay and its PostgreSQL, Redis, MinIO, initialization, health-check, network, and persistent-volume dependencies. |
| apps/buzz/app.json | Adds Buzz metadata, deployment inputs, UI guidance, and compatibility configuration for all supported platforms. |
| apps/buzz/README.md | Documents access, required URL configuration, TLS deployment guidance, secret rotation, relay membership, and persistence. |
| scripts/casaos-category-map.json | Assigns Buzz to the CasaOS Developer category. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Client[Web UI / Nostr / REST clients] -->|Port 3000| Relay[Buzz relay]
    Relay --> PostgreSQL[(PostgreSQL 17)]
    Relay --> Redis[(Redis 7)]
    Relay --> MinIO[(MinIO)]
    Init[minio-init] -->|Creates bucket| MinIO
    Relay --> Git[(Git data volume)]
```

<sub>Reviews (4): Last reviewed commit: ["docs(buzz): rotate POSTGRES\_PASSWORD alo..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/ed08253aa10f9bdd9538f5d4d6986c652fa8aa8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49852635)</sub>

<!-- /greptile_comment -->