### PR TITLE
Add CineDock

### DIFF
--- a/apps/cinedock/app.json
+++ b/apps/cinedock/app.json
@@ -1,0 +1,138 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "cinedock",
+    "name": "CineDock",
+    "description": "CineDock gives Plex, Emby or Jellyfin an enhanced browsing experience on the NVIDIA Shield TV, on an Amazon Fire TV Stick, or in a browser on your computer or tablet.",
+    "tagline": "Rediscover your library.",
+    "version": "4.1.6",
+    "author": "CineDock",
+    "developer": "CineDock",
+    "category": "Media",
+    "license": "MIT",
+    "homepage": "https://github.com/cinedock/unraid-templates",
+    "source": "big-bear-universal",
+    "created": "2026-08-11T21:08:51Z",
+    "updated": "2026-08-11T21:08:51Z"
+  },
+  "visual": {
+    "icon": "https://raw.githubusercontent.com/cinedock/unraid-templates/main/cinedock-icon.png",
+    "thumbnail": "https://raw.githubusercontent.com/cinedock/unraid-templates/main/cinedock-icon.png",
+    "screenshots": [],
+    "logo": "https://raw.githubusercontent.com/cinedock/unraid-templates/main/cinedock-icon.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/cinedock/unraid-templates#readme",
+    "repository": "https://github.com/cinedock/unraid-templates",
+    "issues": "https://github.com/cinedock/unraid-templates/issues",
+    "support": "https://github.com/cinedock/unraid-templates/issues"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "cinedock",
+    "default_port": "8945",
+    "main_image": "ghcr.io/cinedock/cinedock",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "TMDB_API_KEY",
+        "default": "",
+        "description": "Optional TMDB API key for actor biographies, filmographies, and trailer fallback. It can also be added later in CineDock Settings.",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/config",
+        "description": "CineDock connection settings and caches"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8945",
+        "host": "8945",
+        "protocol": "tcp",
+        "description": "CineDock web interface"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": {
+        "en_us": "CineDock requires an existing reachable Plex, Emby, or Jellyfin server. Recommended host capacity is one CPU core, 1 GB available RAM, and 4 GB free application storage. No GPU or media-folder mount is needed because the media server handles streaming and transcoding."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8945",
+      "volume_mappings": {
+        "cinedock_config": "/DATA/AppData/$AppID/config"
+      },
+      "port": "8945",
+      "category": "Media"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "Media",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "8945"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "cinedock_config": "config"
+      },
+      "port": "8945"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8945"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8945"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "cinedock_config": "config"
+      },
+      "port": "10196",
+      "app_port": "8945"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "media",
+    "plex",
+    "emby",
+    "jellyfin",
+    "cinedock"
+  ]
+}

--- a/apps/cinedock/docker-compose.yml
+++ b/apps/cinedock/docker-compose.yml
@@ -1,0 +1,18 @@
+name: big-bear-cinedock
+
+services:
+  cinedock:
+    container_name: big-bear-cinedock
+    image: ghcr.io/cinedock/cinedock:4.1.6@sha256:0a1d8e9c1316a2a72a0accafc52ae92be8f3edc99017137e0c9d5ebbeb94bc39
+    restart: unless-stopped
+    ports:
+      - "8945:8945"
+    environment:
+      TMDB_API_KEY: "${TMDB_API_KEY:-}"
+    volumes:
+      - cinedock_config:/config
+
+volumes:
+  cinedock_config:
+    name: cinedock_config
+    driver: local

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1357,10 +1357,19 @@ convert_to_runtipi() {
         esac
     fi
     
+    # Keep the existing tag-derived behavior for unpinned images, but preserve
+    # an exact digest-pinned reference from the generated Compose service.
+    local runtipi_image="$APP_MAIN_IMAGE:$APP_VERSION"
+    local compose_image
+    compose_image=$(yq eval ".services[\"$app_name\"].image // \"\"" "$compose_file")
+    if [[ "$compose_image" == *@sha256:* ]]; then
+        runtipi_image="$compose_image"
+    fi
+
     # Create docker-compose.json using jq
     jq -n \
         --arg name "$app_name" \
-        --arg image "$APP_MAIN_IMAGE:$APP_VERSION" \
+        --arg image "$runtipi_image" \
         --argjson port "$runtipi_port" \
         '{
             schemaVersion: 2,

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1099,10 +1099,18 @@ convert_to_runtipi() {
     # Remove the 'name' field for Runtipi
     yq eval 'del(.name)' -i "$compose_file"
     
-    # Rename main service to app_name
-    local services=$(yq eval '.services | keys | .[0]' "$compose_file")
-    if [[ "$services" != "$app_name" ]]; then
-        yq eval ".services.\"$app_name\" = .services.\"$services\" | del(.services.\"$services\")" -i "$compose_file"
+    # Read and rename the configured main service rather than whichever service
+    # sorts first in a multi-service Compose file.
+    local compose_image
+    compose_image=$(yq eval ".services[\"$APP_MAIN_SERVICE\"].image // \"\"" "$compose_file")
+    if [[ -z "$compose_image" || "$compose_image" == "null" ]]; then
+        print_error "Missing image for configured main service $APP_MAIN_SERVICE in $app_name"
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        return 1
+    fi
+
+    if [[ "$APP_MAIN_SERVICE" != "$app_name" ]]; then
+        yq eval ".services[\"$app_name\"] = .services[\"$APP_MAIN_SERVICE\"] | del(.services[\"$APP_MAIN_SERVICE\"])" -i "$compose_file"
     fi
     
     # Set container name
@@ -1360,9 +1368,13 @@ convert_to_runtipi() {
     # Keep the existing tag-derived behavior for unpinned images, but preserve
     # an exact digest-pinned reference from the generated Compose service.
     local runtipi_image="$APP_MAIN_IMAGE:$APP_VERSION"
-    local compose_image
-    compose_image=$(yq eval ".services[\"$app_name\"].image // \"\"" "$compose_file")
-    if [[ "$compose_image" == *@sha256:* ]]; then
+    if [[ "$compose_image" == *@* ]] && ! [[ "$compose_image" =~ @sha256:[[:xdigit:]]{64}$ ]]; then
+        print_error "Invalid SHA-256 image digest for $app_name: $compose_image"
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        return 1
+    fi
+
+    if [[ "$compose_image" =~ @sha256:[[:xdigit:]]{64}$ ]]; then
         runtipi_image="$compose_image"
     fi
 

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(dirname "$(dirname "$SCRIPT_DIR")")"
+CONVERTER="${CONVERTER:-$REPO/scripts/convert-to-platforms.sh}"
+
+fail=0
+assert_eq() { # $1=actual $2=expected $3=label
+  if [[ "$1" != "$2" ]]; then echo "FAIL: $3 — got '$1' want '$2'"; fail=1; else echo "ok: $3"; fi
+}
+
+TMP_OUT="$(mktemp -d)"
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+bash "$CONVERTER" -p runtipi -a cinedock -o "$TMP_OUT" >/dev/null 2>&1
+
+SOURCE_IMAGE=$(yq eval '.services.cinedock.image' "$REPO/apps/cinedock/docker-compose.yml")
+RUNTIPI_IMAGE=$(jq -r '.services[] | select(.isMain == true).image' "$TMP_OUT/runtipi/cinedock/docker-compose.json")
+MAIN_IMAGE=$(jq -r '.technical.main_image' "$REPO/apps/cinedock/app.json")
+VERSION=$(jq -r '.metadata.version' "$REPO/apps/cinedock/app.json")
+DIGEST=${SOURCE_IMAGE##*@sha256:}
+
+if [[ "$SOURCE_IMAGE" == "$MAIN_IMAGE:$VERSION@sha256:"* ]] && [[ "$DIGEST" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "ok: CineDock source image is digest-pinned"
+else
+  echo "FAIL: CineDock source image is not digest-pinned"
+  fail=1
+fi
+
+assert_eq "$RUNTIPI_IMAGE" "$SOURCE_IMAGE" "Runtipi preserves CineDock image digest"
+
+exit $fail

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -10,13 +10,14 @@ assert_eq() { # $1=actual $2=expected $3=label
   if [[ "$1" != "$2" ]]; then echo "FAIL: $3 — got '$1' want '$2'"; fail=1; else echo "ok: $3"; fi
 }
 
-TMP_OUT="$(mktemp -d)"
-trap 'rm -rf "$TMP_OUT"' EXIT
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
 
-bash "$CONVERTER" -p runtipi -a cinedock -o "$TMP_OUT" >/dev/null 2>&1
+CINEDOCK_OUT="$TMP_ROOT/cinedock-out"
+bash "$CONVERTER" -p runtipi -a cinedock -o "$CINEDOCK_OUT" >/dev/null 2>&1
 
 SOURCE_IMAGE=$(yq eval '.services.cinedock.image' "$REPO/apps/cinedock/docker-compose.yml")
-RUNTIPI_IMAGE=$(jq -r '.services[] | select(.isMain == true).image' "$TMP_OUT/runtipi/cinedock/docker-compose.json")
+RUNTIPI_IMAGE=$(jq -r '.services[] | select(.isMain == true).image' "$CINEDOCK_OUT/runtipi/cinedock/docker-compose.json")
 MAIN_IMAGE=$(jq -r '.technical.main_image' "$REPO/apps/cinedock/app.json")
 VERSION=$(jq -r '.metadata.version' "$REPO/apps/cinedock/app.json")
 DIGEST=${SOURCE_IMAGE##*@sha256:}
@@ -29,5 +30,52 @@ else
 fi
 
 assert_eq "$RUNTIPI_IMAGE" "$SOURCE_IMAGE" "Runtipi preserves CineDock image digest"
+
+# A multi-service, unpinned fixture proves that technical.main_service wins
+# over alphabetical service order while retaining the legacy tag fallback.
+FIXTURE_APPS="$TMP_ROOT/apps"
+FIXTURE_DIR="$FIXTURE_APPS/unpinned"
+FIXTURE_OUT="$TMP_ROOT/unpinned-out"
+mkdir -p "$FIXTURE_DIR"
+jq '.metadata.id = "unpinned" |
+    .metadata.name = "Unpinned Test" |
+    .metadata.version = "9.8.7" |
+    .visual.icon = "" |
+    .visual.thumbnail = "" |
+    .visual.logo = "" |
+    .technical.main_image = "example/unpinned" |
+    .technical.main_service = "main-service" |
+    .compatibility.runtipi.folder_name = "unpinned"' \
+  "$REPO/apps/cinedock/app.json" > "$FIXTURE_DIR/app.json"
+cp "$REPO/apps/cinedock/docker-compose.yml" "$FIXTURE_DIR/docker-compose.yml"
+yq eval '.services."main-service" = .services.cinedock |
+         .services."main-service".image = "example/unpinned:9.8.7" |
+         del(.services.cinedock) |
+         .services."aaa-helper".image = "example/helper:1"' \
+  -i "$FIXTURE_DIR/docker-compose.yml"
+
+bash "$CONVERTER" -p runtipi -a unpinned -i "$FIXTURE_APPS" -o "$FIXTURE_OUT" >/dev/null 2>&1
+UNPINNED_IMAGE=$(jq -r '.services[] | select(.isMain == true).image' "$FIXTURE_OUT/runtipi/unpinned/docker-compose.json")
+assert_eq "$UNPINNED_IMAGE" "example/unpinned:9.8.7" "Unpinned main service retains tag-derived image"
+assert_eq "$(yq eval '.services.unpinned.image' "$FIXTURE_OUT/runtipi/unpinned/docker-compose.yml")" \
+  "example/unpinned:9.8.7" "Configured main service is renamed"
+assert_eq "$(yq eval '.services."aaa-helper".image' "$FIXTURE_OUT/runtipi/unpinned/docker-compose.yml")" \
+  "example/helper:1" "Helper service is preserved"
+
+# Any digest marker must be a complete, end-anchored SHA-256 value.
+assert_digest_rejected() { # $1=image $2=output slug $3=label
+  yq eval ".services.\"main-service\".image = \"$1\"" -i "$FIXTURE_DIR/docker-compose.yml"
+  if bash "$CONVERTER" -p runtipi -a unpinned -i "$FIXTURE_APPS" -o "$TMP_ROOT/$2-out" >/dev/null 2>&1; then
+    echo "FAIL: $3 was accepted"
+    fail=1
+  else
+    echo "ok: $3 is rejected"
+  fi
+}
+
+assert_digest_rejected "example/unpinned:9.8.7@sha256:abc123" \
+  "short-digest" "short SHA-256 digest"
+assert_digest_rejected "example/unpinned:9.8.7@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-trailing" \
+  "trailing-digest" "SHA-256 digest with trailing content"
 
 exit $fail


### PR DESCRIPTION
## Summary

- add CineDock 4.1.6 using the official multi-architecture image pinned to OCI index digest sha256:0a1d8e9c1316a2a72a0accafc52ae92be8f3edc99017137e0c9d5ebbeb94bc39
- persist CineDock settings and caches at /config and expose its web interface on port 8945
- include the optional TMDB_API_KEY setting and the official CineDock icon
- declare converter compatibility for CasaOS, Portainer, Runtipi, Dockge, Cosmos, and Umbrel after inspecting generated output for each platform

No GPU or media-folder mount is required because the existing Plex, Emby, or Jellyfin server handles streaming and transcoding. Platform compatibility here describes successful package conversion; downstream store discovery remains subject to each platform's normal publishing and sync process.

## Validation

- ./scripts/validate-apps.sh -a cinedock --strict --verbose --check-links: PASS (1 passed, 0 failed, 0 warnings; all three asset URLs HTTP 200)
- ./scripts/convert-to-platforms.sh -a cinedock --validate --verbose: PASS (all six platform outputs, 0 errors)
- docker compose -f apps/cinedock/docker-compose.yml config -q: PASS
- git diff --cached --check: PASS
- docker buildx imagetools inspect ghcr.io/cinedock/cinedock:4.1.6: OCI index and linux/amd64 plus linux/arm64 manifests confirmed

The local converter noted only that its optional image conversion utility was unavailable; the upstream workflow installs ImageMagick before conversion.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the CineDock 4.1.6 universal app definition and updates Runtipi conversion to select the configured main service and preserve validated digest-pinned images.

- Defines CineDock metadata, deployment settings, persistent configuration storage, and six-platform compatibility.
- Pins the multi-architecture CineDock image to an OCI digest.
- Adds Runtipi conversion coverage for main-service selection and digest handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cinedock/app.json | Adds a consistent CineDock universal-app definition with deployment and platform compatibility metadata. |
| apps/cinedock/docker-compose.yml | Adds a single-service CineDock deployment with a digest-pinned image, exposed UI port, optional API key, and persistent configuration volume. |
| scripts/convert-to-platforms.sh | Updates Runtipi conversion to use the configured main service and retain complete SHA-256-pinned image references. |
| scripts/tests/test-convert-runtipi.sh | Adds regression assertions for CineDock digest preservation, configured main-service selection, helper retention, and malformed digest rejection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["CineDock app.json"] --> C["Runtipi converter"]
  B["CineDock docker-compose.yml<br/>configured main service + pinned image"] --> C
  C --> D["Rename configured main service"]
  C --> E["Validate and preserve SHA-256 digest"]
  D --> F["Runtipi docker-compose.yml"]
  E --> G["Runtipi docker-compose.json"]
```

<sub>Reviews (3): Last reviewed commit: ["Harden Runtipi image selection"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/2c6902a3cbafa9a26495b8befd0b0ae5e46c20e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52369362)</sub>

**Context used:**

- Knowledge Base — [Universal App Format](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/universal-app-format.md)
- Knowledge Base — [Conversion Pipeline](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/conversion-pipeline.md)

<!-- /greptile_comment -->