### PR TITLE
fix(ente): bind socat bridge dual-stack so museum can reach object storage

### DIFF
--- a/apps/ente/README.md
+++ b/apps/ente/README.md
@@ -50,6 +50,8 @@ Generate new museum keys with Ente's tool: `go run tools/gen-random-keys/main.go
 | `socat`      | Bridges museum's `localhost:3200` to `minio:3200`.  |
 | `minio-init` | One-shot job that creates the storage buckets.      |
 
+The `socat` bridge binds dual-stack via `TCP6-LISTEN:...,ipv6only=0` because inside the museum container `localhost` resolves to `::1` before `127.0.0.1`. Reverting to `TCP-LISTEN:` (IPv4-only) leaves museum unable to reach object storage on that address family, so uploads and downloads all fail even though every container still looks healthy. This intentionally diverges from upstream Ente's compose, so an upstream sync must not revert it.
+
 ## Links
 
 - Documentation: https://help.ente.io/self-hosting/

--- a/apps/ente/docker-compose.yml
+++ b/apps/ente/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     depends_on:
       - museum
       - minio
-    command: TCP-LISTEN:3200,fork,reuseaddr TCP:minio:3200
+    command: TCP6-LISTEN:3200,fork,reuseaddr,ipv6only=0 TCP:minio:3200
     restart: unless-stopped
 
   web:

--- a/scripts/validate-apps.sh
+++ b/scripts/validate-apps.sh
@@ -331,7 +331,19 @@ validate_app() {
         print_warning "  docker-compose.yml contains x-casaos extensions (should be clean)"
         warnings=$((warnings + 1))
     fi
-    
+
+    local single_stack_listeners=$(yq eval '.services | to_entries | .[] | select(.value.command // "" | tostring | test("(?i)\b(TCP[46]?-(LISTEN|L)):")) | select((.value.command | tostring | test("(?i)ipv6only=0")) | not) | .key' "$compose_file" 2>&1 || true)
+    if [[ "$single_stack_listeners" == Error:* ]]; then
+        print_error "  could not inspect services for single-stack listeners: $single_stack_listeners"
+        errors=$((errors + 1))
+    elif [[ -n "$single_stack_listeners" ]]; then
+        while IFS= read -r service_name; do
+            [[ -z "$service_name" ]] && continue
+            print_error "  service '$service_name' listens single-stack (use TCP6-LISTEN:<port>,fork,reuseaddr,ipv6only=0 so localhost resolving to ::1 still connects)"
+            errors=$((errors + 1))
+        done <<< "$single_stack_listeners"
+    fi
+
     # Summary for this app
     if [[ $errors -gt 0 ]]; then
         print_error "$app_name: FAILED ($errors errors, $warnings warnings)"

--- a/scripts/validate-apps.sh
+++ b/scripts/validate-apps.sh
@@ -332,8 +332,8 @@ validate_app() {
         warnings=$((warnings + 1))
     fi
 
-    local single_stack_listeners=$(yq eval '.services | to_entries | .[] | select(.value.command // "" | tostring | test("(?i)\b(TCP[46]?-(LISTEN|L)):")) | select((.value.command | tostring | test("(?i)ipv6only=0")) | not) | .key' "$compose_file" 2>&1 || true)
-    if [[ "$single_stack_listeners" == Error:* ]]; then
+    local single_stack_listeners
+    if ! single_stack_listeners=$(yq eval '.services | to_entries | .[] | select(.value.command // "" | tostring | test("(?i)\b(TCP[46]?-(LISTEN|L)):")) | select((.value.command | tostring | test("(?i)(^|[,\\s])ipv6only=0([,\\s]|$)")) | not) | .key' "$compose_file" 2>&1); then
         print_error "  could not inspect services for single-stack listeners: $single_stack_listeners"
         errors=$((errors + 1))
     elif [[ -n "$single_stack_listeners" ]]; then


### PR DESCRIPTION
Ente's socat bridge bound IPv4-only, but `localhost` resolves to `::1` first inside museum — so every museum→object-storage call was refused while the whole stack still looked healthy.

Fix is `TCP6-LISTEN:3200,fork,reuseaddr,ipv6only=0`; verified live that `localhost:3200` goes from refused to exit 0, with IPv4 unaffected.

Also adds a `validate-apps.sh` guard (CI-enforced, unlike the JS suite) that fails any `*-LISTEN` command missing `ipv6only=0`.

Fixes #2471

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Ente’s socat bridge to bind dual-stack and documents why that divergence from upstream is required.
- Uses `TCP6-LISTEN` with `ipv6only=0` so museum can reach object storage through either localhost address family.
- Adds validation intended to reject socat listener commands that omit dual-stack configuration.
- Improves validation error handling and tightens recognition of the `ipv6only=0` option.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the validation guard still fails to detect the single-stack listener configurations it is intended to reject.

The reply states that the escaped-boundary issue would be fixed, but the current expression still uses a single `\b` inside the yq string; only the separate `ipv6only=0` matching and command-error handling changed, leaving the reported guard failure outstanding.

**Files Needing Attention:** scripts/validate-apps.sh

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/ente/docker-compose.yml | Changes the object-storage bridge from IPv4-only listening to a dual-stack TCP6 listener. |
| apps/ente/README.md | Documents the localhost resolution failure and the required dual-stack socat configuration. |
| scripts/validate-apps.sh | Adds a CI validation guard for dual-stack listeners, but the previously reported escaped-boundary defect remains in the listener-selection regex. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(validate): detect yq failure by exit..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/0367caf5448f18f9d811cb1c3333f55151d837bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53109905)</sub>

**Context used:**

- Knowledge Base — [Universal App Format](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/universal-app-format.md)
- Knowledge Base — [Validation and Sync](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/validation-and-sync.md)

<!-- /greptile_comment -->