### PR TITLE
fix(casaos): harden convert_to_casaos against yq expression injection

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -22,6 +22,9 @@ jobs:
           sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
 
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Run converter test suite
         run: bash scripts/tests/test-convert-casaos.sh
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -8,6 +8,23 @@ on:
       - 'scripts/**'
 
 jobs:
+  converter-tests:
+    name: Converter Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Run converter test suite
+        run: bash scripts/tests/test-convert-casaos.sh
+
   validate-apps:
     name: Validate App Definitions
     runs-on: ubuntu-latest

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -608,46 +608,46 @@ convert_to_casaos() {
     # Update the name to include big-bear- prefix for CasaOS
     local current_name=$(yq eval '.name' "$compose_file")
     if [[ "$current_name" != "big-bear-"* ]]; then
-        yq eval ".name = \"big-bear-$current_name\"" -i "$compose_file"
+        current_name="$current_name" yq eval '.name = ("big-bear-" + strenv(current_name))' -i "$compose_file"
     fi
     
     # Add x-casaos sections to compose file
     # Add top-level x-casaos
-    yq eval ".x-casaos.architectures = $APP_ARCHITECTURES" -i "$compose_file"
-    yq eval ".x-casaos.id = \"com.bigbeartechworld.$APP_ID\"" -i "$compose_file"
-    yq eval ".x-casaos.main = \"$APP_MAIN_SERVICE\"" -i "$compose_file"
-    yq eval ".x-casaos.description.en_US = \"$APP_DESCRIPTION\"" -i "$compose_file"
+    APP_ARCHITECTURES="$APP_ARCHITECTURES" yq eval '.x-casaos.architectures = (env(APP_ARCHITECTURES) | ... style="")' -i "$compose_file"
+    APP_ID="$APP_ID" yq eval '.x-casaos.id = ("com.bigbeartechworld." + strenv(APP_ID))' -i "$compose_file"
+    APP_MAIN_SERVICE="$APP_MAIN_SERVICE" yq eval '.x-casaos.main = strenv(APP_MAIN_SERVICE)' -i "$compose_file"
+    APP_DESCRIPTION="$APP_DESCRIPTION" yq eval '.x-casaos.description.en_US = strenv(APP_DESCRIPTION)' -i "$compose_file"
     
     # Add screenshot_link if screenshots exist
     local screenshots=$(jq -c '.visual.screenshots // []' "$app_dir/app.json")
     local screenshot_count=$(echo "$screenshots" | jq 'length')
     if [[ "$screenshot_count" -gt 0 ]]; then
-        yq eval ".x-casaos.screenshot_link = $screenshots" -i "$compose_file"
+        screenshots="$screenshots" yq eval '.x-casaos.screenshot_link = (env(screenshots) | ... style="")' -i "$compose_file"
     fi
     
-    yq eval ".x-casaos.tagline.en_US = \"$APP_TAGLINE\"" -i "$compose_file"
-    yq eval ".x-casaos.developer = \"$APP_DEVELOPER\"" -i "$compose_file"
-    yq eval ".x-casaos.author = \"$APP_AUTHOR\"" -i "$compose_file"
-    yq eval ".x-casaos.icon = \"$APP_ICON\"" -i "$compose_file"
-    yq eval ".x-casaos.thumbnail = \"$APP_THUMBNAIL\"" -i "$compose_file"
+    APP_TAGLINE="$APP_TAGLINE" yq eval '.x-casaos.tagline.en_US = strenv(APP_TAGLINE)' -i "$compose_file"
+    APP_DEVELOPER="$APP_DEVELOPER" yq eval '.x-casaos.developer = strenv(APP_DEVELOPER)' -i "$compose_file"
+    APP_AUTHOR="$APP_AUTHOR" yq eval '.x-casaos.author = strenv(APP_AUTHOR)' -i "$compose_file"
+    APP_ICON="$APP_ICON" yq eval '.x-casaos.icon = strenv(APP_ICON)' -i "$compose_file"
+    APP_THUMBNAIL="$APP_THUMBNAIL" yq eval '.x-casaos.thumbnail = strenv(APP_THUMBNAIL)' -i "$compose_file"
     
     # Add tips if they exist
     local tips_before_install=$(jq -r '.ui.tips.before_install.en_us // ""' "$app_dir/app.json")
     if [[ -n "$tips_before_install" && "$tips_before_install" != "null" ]]; then
         # Escape the multiline string for yq and use style="literal" for proper formatting
         local tips_json=$(jq -c '.ui.tips.before_install // {}' "$app_dir/app.json")
-        yq eval ".x-casaos.tips.before_install = $tips_json" -i "$compose_file"
+        tips_json="$tips_json" yq eval '.x-casaos.tips.before_install = (env(tips_json) | ... style="")' -i "$compose_file"
         if [[ "$(yq eval '.x-casaos.tips.before_install | has("en_us")' "$compose_file")" == "true" ]]; then
             yq eval '.x-casaos.tips.before_install.en_US = .x-casaos.tips.before_install.en_us | del(.x-casaos.tips.before_install.en_us)' -i "$compose_file"
         fi
     fi
 
-    yq eval ".x-casaos.title.en_US = \"$APP_NAME\"" -i "$compose_file"
-    yq eval ".x-casaos.category = \"$casaos_category\"" -i "$compose_file"
+    APP_NAME="$APP_NAME" yq eval '.x-casaos.title.en_US = strenv(APP_NAME)' -i "$compose_file"
+    casaos_category="$casaos_category" yq eval '.x-casaos.category = strenv(casaos_category)' -i "$compose_file"
     
     # Use platform-specific port if defined, otherwise use default
     local casaos_port="${PORT_CASAOS:-$APP_DEFAULT_PORT}"
-    yq eval ".x-casaos.port_map = \"$casaos_port\"" -i "$compose_file"
+    casaos_port="$casaos_port" yq eval '.x-casaos.port_map = strenv(casaos_port)' -i "$compose_file"
     
     # Add descriptive comments to x-casaos section using perl (works on both macOS and Linux)
     # Add comment before architectures
@@ -701,12 +701,12 @@ convert_to_casaos() {
         
         # Add environment variables for this service
         # Environment can be either an array of "KEY=VALUE" strings or an object {KEY: VALUE}
-        local env_format=$(yq eval ".services[\"$service_name\"].environment | type" "$compose_file" 2>/dev/null || echo "null")
+        local env_format=$(service_name="$service_name" yq eval '.services[strenv(service_name)].environment | type' "$compose_file" 2>/dev/null || echo "null")
         local env_index=0
         
         if [[ "$env_format" == "!!seq" ]]; then
             # Array format: ["KEY=VALUE", ...]
-            local service_envs=$(yq eval ".services[\"$service_name\"].environment | .[]" "$compose_file" 2>/dev/null || echo "")
+            local service_envs=$(service_name="$service_name" yq eval '.services[strenv(service_name)].environment | .[]' "$compose_file" 2>/dev/null || echo "")
             while IFS= read -r env_entry; do
                 [[ -z "$env_entry" ]] && continue
                 
@@ -719,13 +719,13 @@ convert_to_casaos() {
                 fi
                 
                 # Add to x-casaos with proper escaping
-                yq eval ".services.[\"$service_name\"].x-casaos.envs[$env_index].container = \"$env_key\"" -i "$compose_file" 2>/dev/null || true
-                yq eval ".services.[\"$service_name\"].x-casaos.envs[$env_index].description.en_US = \"Container Variable: $env_key\"" -i "$compose_file" 2>/dev/null || true
+                service_name="$service_name" env_key="$env_key" env_index="$env_index" yq eval '.services[strenv(service_name)].x-casaos.envs[env(env_index)].container = strenv(env_key)' -i "$compose_file" 2>/dev/null || true
+                service_name="$service_name" env_key="$env_key" env_index="$env_index" yq eval '.services[strenv(service_name)].x-casaos.envs[env(env_index)].description.en_US = ("Container Variable: " + strenv(env_key))' -i "$compose_file" 2>/dev/null || true
                 env_index=$((env_index + 1))
             done <<< "$service_envs"
         elif [[ "$env_format" == "!!map" ]]; then
             # Object format: {KEY: VALUE, ...}
-            local service_envs=$(yq eval ".services[\"$service_name\"].environment | keys | .[]" "$compose_file" 2>/dev/null || echo "")
+            local service_envs=$(service_name="$service_name" yq eval '.services[strenv(service_name)].environment | keys | .[]' "$compose_file" 2>/dev/null || echo "")
             while IFS= read -r env_key; do
                 [[ -z "$env_key" ]] && continue
                 
@@ -735,26 +735,26 @@ convert_to_casaos() {
                 fi
                 
                 # Add to x-casaos with proper escaping
-                yq eval ".services.[\"$service_name\"].x-casaos.envs[$env_index].container = \"$env_key\"" -i "$compose_file" 2>/dev/null || true
-                yq eval ".services.[\"$service_name\"].x-casaos.envs[$env_index].description.en_US = \"Container Variable: $env_key\"" -i "$compose_file" 2>/dev/null || true
+                service_name="$service_name" env_key="$env_key" env_index="$env_index" yq eval '.services[strenv(service_name)].x-casaos.envs[env(env_index)].container = strenv(env_key)' -i "$compose_file" 2>/dev/null || true
+                service_name="$service_name" env_key="$env_key" env_index="$env_index" yq eval '.services[strenv(service_name)].x-casaos.envs[env(env_index)].description.en_US = ("Container Variable: " + strenv(env_key))' -i "$compose_file" 2>/dev/null || true
                 env_index=$((env_index + 1))
             done <<< "$service_envs"
         fi
         
         # Add volumes for this service (handles both short-form and long-form syntax)
-        local vol_count=$(yq eval ".services[\"$service_name\"].volumes | length" "$compose_file" 2>/dev/null || echo "0")
+        local vol_count=$(service_name="$service_name" yq eval '.services[strenv(service_name)].volumes | length' "$compose_file" 2>/dev/null || echo "0")
         local vol_index=0
         for ((i=0; i<vol_count; i++)); do
             # Check if entry is a string (short-form) or object (long-form)
-            local vol_type=$(yq eval ".services[\"$service_name\"].volumes[$i] | type" "$compose_file" 2>/dev/null)
+            local vol_type=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].volumes[env(i)] | type' "$compose_file" 2>/dev/null)
             local container_path=""
 
             if [[ "$vol_type" == "!!map" ]]; then
                 # Long-form: extract target field
-                container_path=$(yq eval ".services[\"$service_name\"].volumes[$i].target" "$compose_file" 2>/dev/null)
+                container_path=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].volumes[env(i)].target' "$compose_file" 2>/dev/null)
             else
                 # Short-form: extract path after first colon
-                local vol_str=$(yq eval ".services[\"$service_name\"].volumes[$i]" "$compose_file" 2>/dev/null)
+                local vol_str=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].volumes[env(i)]' "$compose_file" 2>/dev/null)
                 container_path="${vol_str#*:}"
                 container_path="${container_path%%:*}"
                 # Only accept absolute or relative paths as container paths
@@ -765,24 +765,24 @@ convert_to_casaos() {
                 continue
             fi
 
-            yq eval ".services.[\"$service_name\"].x-casaos.volumes[$vol_index].container = \"$container_path\"" -i "$compose_file" 2>/dev/null || true
-            yq eval ".services.[\"$service_name\"].x-casaos.volumes[$vol_index].description.en_US = \"Container Path: $container_path\"" -i "$compose_file" 2>/dev/null || true
+            service_name="$service_name" container_path="$container_path" vol_index="$vol_index" yq eval '.services[strenv(service_name)].x-casaos.volumes[env(vol_index)].container = strenv(container_path)' -i "$compose_file" 2>/dev/null || true
+            service_name="$service_name" container_path="$container_path" vol_index="$vol_index" yq eval '.services[strenv(service_name)].x-casaos.volumes[env(vol_index)].description.en_US = ("Container Path: " + strenv(container_path))' -i "$compose_file" 2>/dev/null || true
             vol_index=$((vol_index + 1))
         done
         
         # Add ports for this service (handles both short-form and long-form syntax)
-        local port_count=$(yq eval ".services[\"$service_name\"].ports | length" "$compose_file" 2>/dev/null || echo "0")
+        local port_count=$(service_name="$service_name" yq eval '.services[strenv(service_name)].ports | length' "$compose_file" 2>/dev/null || echo "0")
         local port_index=0
         for ((i=0; i<port_count; i++)); do
-            local port_type=$(yq eval ".services[\"$service_name\"].ports[$i] | type" "$compose_file" 2>/dev/null)
+            local port_type=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].ports[env(i)] | type' "$compose_file" 2>/dev/null)
             local container_port=""
 
             if [[ "$port_type" == "!!map" ]]; then
                 # Long-form: extract target field
-                container_port=$(yq eval ".services[\"$service_name\"].ports[$i].target" "$compose_file" 2>/dev/null)
+                container_port=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].ports[env(i)].target' "$compose_file" 2>/dev/null)
             else
                 # Short-form: extract container port
-                local port_str=$(yq eval ".services[\"$service_name\"].ports[$i]" "$compose_file" 2>/dev/null)
+                local port_str=$(service_name="$service_name" i="$i" yq eval '.services[strenv(service_name)].ports[env(i)]' "$compose_file" 2>/dev/null)
                 container_port="${port_str##*:}"
                 container_port="${container_port%%/*}"
             fi
@@ -791,8 +791,8 @@ convert_to_casaos() {
                 continue
             fi
 
-            yq eval ".services.[\"$service_name\"].x-casaos.ports[$port_index].container = \"$container_port\"" -i "$compose_file" 2>/dev/null || true
-            yq eval ".services.[\"$service_name\"].x-casaos.ports[$port_index].description.en_US = \"Container Port: $container_port\"" -i "$compose_file" 2>/dev/null || true
+            service_name="$service_name" container_port="$container_port" port_index="$port_index" yq eval '.services[strenv(service_name)].x-casaos.ports[env(port_index)].container = strenv(container_port)' -i "$compose_file" 2>/dev/null || true
+            service_name="$service_name" container_port="$container_port" port_index="$port_index" yq eval '.services[strenv(service_name)].x-casaos.ports[env(port_index)].description.en_US = ("Container Port: " + strenv(container_port))' -i "$compose_file" 2>/dev/null || true
             port_index=$((port_index + 1))
         done
         
@@ -818,18 +818,18 @@ convert_to_casaos() {
                 [[ -z "$vol_name" ]] && continue
                 
                 # Get the count of volumes in this service
-                local vol_count=$(yq eval ".services.$service_name.volumes | length" "$compose_file" 2>/dev/null || echo "0")
-                
+                local vol_count=$(service_name="$service_name" yq eval '.services[strenv(service_name)].volumes | length' "$compose_file" 2>/dev/null || echo "0")
+
                 for ((j=0; j<vol_count; j++)); do
-                    local vol_type=$(yq eval ".services.$service_name.volumes[$j] | type" "$compose_file" 2>/dev/null)
+                    local vol_type=$(service_name="$service_name" j="$j" yq eval '.services[strenv(service_name)].volumes[env(j)] | type' "$compose_file" 2>/dev/null)
                     local container_path=""
                     local is_match=false
 
                     if [[ "$vol_type" == "!!map" ]]; then
                         # Long-form: check if .source matches the named volume
-                        local vol_source=$(yq eval ".services.$service_name.volumes[$j].source" "$compose_file" 2>/dev/null)
+                        local vol_source=$(service_name="$service_name" j="$j" yq eval '.services[strenv(service_name)].volumes[env(j)].source' "$compose_file" 2>/dev/null)
                         if [[ "$vol_source" == "$vol_name" ]]; then
-                            container_path=$(yq eval ".services.$service_name.volumes[$j].target" "$compose_file" 2>/dev/null)
+                            container_path=$(service_name="$service_name" j="$j" yq eval '.services[strenv(service_name)].volumes[env(j)].target' "$compose_file" 2>/dev/null)
                             if [[ "$container_path" == /* ]] || [[ "$container_path" == ./* ]]; then
                                 is_match=true
                             else
@@ -837,7 +837,7 @@ convert_to_casaos() {
                             fi
                         fi
                     else
-                        local vol_entry=$(yq eval ".services.$service_name.volumes[$j]" "$compose_file")
+                        local vol_entry=$(service_name="$service_name" j="$j" yq eval '.services[strenv(service_name)].volumes[env(j)]' "$compose_file")
                         # Skip if this is already a bind mount (starts with / or ./)
                         if [[ "$vol_entry" == /* ]] || [[ "$vol_entry" == ./* ]]; then
                             continue
@@ -875,7 +875,7 @@ convert_to_casaos() {
                         fi
 
                         # Replace the volume entry with a short-form bind mount string
-                        yq eval ".services.$service_name.volumes[$j] = \"$casaos_path\"" -i "$compose_file"
+                        service_name="$service_name" j="$j" casaos_path="$casaos_path" yq eval '.services[strenv(service_name)].volumes[env(j)] = strenv(casaos_path)' -i "$compose_file"
                     fi
                 done
             done <<< "$volume_names"

--- a/scripts/tests/test-convert-casaos.sh
+++ b/scripts/tests/test-convert-casaos.sh
@@ -3,6 +3,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(dirname "$(dirname "$SCRIPT_DIR")")"
 source "$REPO/scripts/convert-to-platforms.sh" --source-only 2>/dev/null || true
+# The sourced converter runs `set -e`, which would abort this harness on the
+# first failing assertion instead of reporting every result.
+set +e
 
 fail=0
 assert_eq() { # $1=actual $2=expected $3=label
@@ -75,9 +78,48 @@ assert_eq "$AFTER_META" "$BEFORE_META" "metadata.category unchanged"
 MISSING=0
 for d in "$TMP_APPS"/*/; do
   v=$(jq -r '.compatibility.casaos.category // "MISSING"' "$d/app.json")
-  [[ "$v" == "MISSING" ]] && MISSING=$((MISSING+1))
+  [[ "$v" == "MISSING" ]] && MISSING=$((MISSING+1)) || true
 done
 assert_eq "$MISSING" "0" "all apps have casaos.category"
 rm -rf "$TMP_APPS"
+
+# --- yq expression injection is inert (issue #2478) ---
+TMP_INJ="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_INJ/apps/"
+echo "CANARY_FILE_CONTENT_2478" > "$TMP_INJ/canary.txt"
+PAYLOAD='" | .x-casaos.pwned = load_str("'"$TMP_INJ"'/canary.txt") | .x-casaos.author = "'
+INJ_APP="$TMP_INJ/apps/uptime-kuma/app.json"
+jq --arg p "$PAYLOAD" '.metadata.description = $p | .metadata.tagline = $p' "$INJ_APP" > "$INJ_APP.tmp" && mv "$INJ_APP.tmp" "$INJ_APP"
+bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_INJ/apps" -o "$TMP_INJ/out" >/dev/null 2>&1
+INJ_CF="$TMP_INJ/out/casaos/uptime-kuma/docker-compose.yml"
+assert_eq "$([[ -f "$INJ_CF" ]] && echo yes)" "yes" "injection: compose still produced"
+assert_eq "$(yq eval '.x-casaos | has("pwned")' "$INJ_CF" 2>/dev/null)" "false" "injection: no injected key"
+if grep -q "CANARY_FILE_CONTENT_2478" "$INJ_CF"; then echo "FAIL: injection: canary file content leaked into output"; fail=1; else echo "ok: injection: no foreign file content"; fi
+assert_eq "$(yq eval '.x-casaos.description.en_US' "$INJ_CF" 2>/dev/null)" "$PAYLOAD" "injection: payload stored as literal string"
+rm -rf "$TMP_INJ"
+
+# --- JSON blobs keep block style (naive env() would reflow them to flow style) ---
+TMP_STYLE="$(mktemp -d)"
+bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a adguard-home -o "$TMP_STYLE" >/dev/null 2>&1
+SCF="$TMP_STYLE/casaos/adguard-home/docker-compose.yml"
+if grep -qE '^\s+screenshot_link: \[' "$SCF"; then echo "FAIL: screenshot_link reflowed to flow style"; fail=1; else echo "ok: screenshot_link block style"; fi
+assert_eq "$(yq eval '.x-casaos.screenshot_link | length' "$SCF")" "3" "screenshot_link parsed as sequence"
+assert_eq "$(yq eval '.x-casaos.architectures | tag' "$SCF")" "!!seq" "architectures still a sequence"
+if grep -qE '^\s+en_US: \|' "$SCF"; then echo "ok: tips literal block scalar preserved"; else echo "FAIL: tips lost literal block scalar"; fail=1; fi
+if grep -qE '^\s+"en_[a-zA-Z]+":' "$SCF"; then echo "FAIL: blob keys became quoted"; fail=1; else echo "ok: blob keys unquoted"; fi
+rm -rf "$TMP_STYLE"
+
+# --- dotted service names address correctly (bracket form, not dot form) ---
+TMP_DOT="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_DOT/apps/"
+DOT_DIR="$TMP_DOT/apps/uptime-kuma"
+DOT_SVC=$(yq eval '.services | keys | .[0]' "$DOT_DIR/docker-compose.yml")
+DOT_SVC="$DOT_SVC" yq eval '.services["svc.v2"] = .services[strenv(DOT_SVC)] | del(.services[strenv(DOT_SVC)]) | .volumes.testvol = null | .services["svc.v2"].volumes = ["testvol:/data"]' -i "$DOT_DIR/docker-compose.yml"
+jq '.deployment.main_service = "svc.v2"' "$DOT_DIR/app.json" > "$DOT_DIR/app.json.tmp" && mv "$DOT_DIR/app.json.tmp" "$DOT_DIR/app.json"
+bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_DOT/apps" -o "$TMP_DOT/out" >/dev/null 2>&1
+DCF="$TMP_DOT/out/casaos/uptime-kuma/docker-compose.yml"
+assert_eq "$(yq eval '.services | keys | length' "$DCF" 2>/dev/null)" "1" "dotted name: no bogus split key"
+assert_eq "$(yq eval '.services["svc.v2"].volumes[0]' "$DCF" 2>/dev/null)" '/DATA/AppData/$AppID/testvol:/data' "dotted name: volume converted to bind mount"
+rm -rf "$TMP_DOT"
 
 exit $fail

--- a/scripts/tests/test-convert-casaos.sh
+++ b/scripts/tests/test-convert-casaos.sh
@@ -84,29 +84,60 @@ assert_eq "$MISSING" "0" "all apps have casaos.category"
 rm -rf "$TMP_APPS"
 
 # --- yq expression injection is inert (issue #2478) ---
-TMP_INJ="$(mktemp -d)"
-cp -R "$REPO/apps/." "$TMP_INJ/apps/"
-echo "CANARY_FILE_CONTENT_2478" > "$TMP_INJ/canary.txt"
-PAYLOAD='" | .x-casaos.pwned = load_str("'"$TMP_INJ"'/canary.txt") | .x-casaos.author = "'
-INJ_APP="$TMP_INJ/apps/uptime-kuma/app.json"
-jq --arg p "$PAYLOAD" '.metadata.description = $p | .metadata.tagline = $p' "$INJ_APP" > "$INJ_APP.tmp" && mv "$INJ_APP.tmp" "$INJ_APP"
-bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_INJ/apps" -o "$TMP_INJ/out" >/dev/null 2>&1
-INJ_CF="$TMP_INJ/out/casaos/uptime-kuma/docker-compose.yml"
-assert_eq "$([[ -f "$INJ_CF" ]] && echo yes)" "yes" "injection: compose still produced"
-assert_eq "$(yq eval '.x-casaos | has("pwned")' "$INJ_CF" 2>/dev/null)" "false" "injection: no injected key"
-if grep -q "CANARY_FILE_CONTENT_2478" "$INJ_CF"; then echo "FAIL: injection: canary file content leaked into output"; fail=1; else echo "ok: injection: no foreign file content"; fi
-assert_eq "$(yq eval '.x-casaos.description.en_US' "$INJ_CF" 2>/dev/null)" "$PAYLOAD" "injection: payload stored as literal string"
-rm -rf "$TMP_INJ"
+# Every attacker-controlled app.json field feeding a yq expression gets the payload,
+# so reintroducing interpolation at any one site fails the suite.
+for INJ_FIELD in metadata.description metadata.tagline metadata.author metadata.developer metadata.name visual.icon visual.thumbnail technical.main_service; do
+  TMP_INJ="$(mktemp -d)"
+  cp -R "$REPO/apps/." "$TMP_INJ/apps/"
+  echo "CANARY_FILE_CONTENT_2478" > "$TMP_INJ/canary.txt"
+  PAYLOAD='" | .x-casaos.pwned = load_str("'"$TMP_INJ"'/canary.txt") | .x-casaos.zz = "'
+  INJ_APP="$TMP_INJ/apps/uptime-kuma/app.json"
+  jq --arg p "$PAYLOAD" --arg f "$INJ_FIELD" 'setpath($f | split("."); $p)' "$INJ_APP" > "$INJ_APP.tmp" && mv "$INJ_APP.tmp" "$INJ_APP"
+  bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_INJ/apps" -o "$TMP_INJ/out" >/dev/null 2>&1
+  INJ_CF="$TMP_INJ/out/casaos/uptime-kuma/docker-compose.yml"
+  assert_eq "$([[ -s "$INJ_CF" ]] && echo yes)" "yes" "injection[$INJ_FIELD]: compose still produced"
+  assert_eq "$(yq eval '.x-casaos | has("pwned")' "$INJ_CF" 2>/dev/null)" "false" "injection[$INJ_FIELD]: no injected key"
+  if [[ -s "$INJ_CF" ]] && ! grep -q "CANARY_FILE_CONTENT_2478" "$INJ_CF"; then echo "ok: injection[$INJ_FIELD]: no foreign file content"; else echo "FAIL: injection[$INJ_FIELD]: canary file content leaked into output"; fail=1; fi
+  rm -rf "$TMP_INJ"
+done
+
+# --- payload survives verbatim (proves it is stored as data, not dropped) ---
+TMP_LIT="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_LIT/apps/"
+LIT_PAYLOAD='" | .x-casaos.pwned = load_str("/etc/hostname") | .x-casaos.zz = "'
+LIT_APP="$TMP_LIT/apps/uptime-kuma/app.json"
+jq --arg p "$LIT_PAYLOAD" '.metadata.description = $p | .metadata.author = $p' "$LIT_APP" > "$LIT_APP.tmp" && mv "$LIT_APP.tmp" "$LIT_APP"
+bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_LIT/apps" -o "$TMP_LIT/out" >/dev/null 2>&1
+LIT_CF="$TMP_LIT/out/casaos/uptime-kuma/docker-compose.yml"
+assert_eq "$(yq eval '.x-casaos.description.en_US' "$LIT_CF" 2>/dev/null)" "$LIT_PAYLOAD" "injection: payload stored as literal string"
+assert_eq "$(yq eval '.x-casaos.author' "$LIT_CF" 2>/dev/null)" "$LIT_PAYLOAD" "injection: author payload stored as literal string"
+rm -rf "$TMP_LIT"
+
+# --- compose-derived values are inert too (env keys, volume paths, ports) ---
+TMP_CINJ="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_CINJ/apps/"
+echo "CANARY_COMPOSE_2478" > "$TMP_CINJ/canary.txt"
+CPAYLOAD='" | .x-casaos.pwned = load_str("'"$TMP_CINJ"'/canary.txt") | .x-casaos.zz = "'
+CINJ_DIR="$TMP_CINJ/apps/uptime-kuma"
+CINJ_SVC=$(yq eval '.services | keys | .[0]' "$CINJ_DIR/docker-compose.yml")
+CINJ_SVC="$CINJ_SVC" CPAYLOAD="$CPAYLOAD" yq eval '.services[strenv(CINJ_SVC)].environment[strenv(CPAYLOAD)] = "x" | .services[strenv(CINJ_SVC)].volumes += ["/tmp/src:" + strenv(CPAYLOAD)]' -i "$CINJ_DIR/docker-compose.yml"
+bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a uptime-kuma -i "$TMP_CINJ/apps" -o "$TMP_CINJ/out" >/dev/null 2>&1
+CINJ_CF="$TMP_CINJ/out/casaos/uptime-kuma/docker-compose.yml"
+assert_eq "$([[ -s "$CINJ_CF" ]] && echo yes)" "yes" "compose injection: compose still produced"
+assert_eq "$(yq eval '.x-casaos | has("pwned")' "$CINJ_CF" 2>/dev/null)" "false" "compose injection: no injected key"
+if [[ -s "$CINJ_CF" ]] && ! grep -q "CANARY_COMPOSE_2478" "$CINJ_CF"; then echo "ok: compose injection: no foreign file content"; else echo "FAIL: compose injection: canary file content leaked into output"; fail=1; fi
+rm -rf "$TMP_CINJ"
 
 # --- JSON blobs keep block style (naive env() would reflow them to flow style) ---
 TMP_STYLE="$(mktemp -d)"
 bash "$REPO/scripts/convert-to-platforms.sh" -p casaos -a adguard-home -o "$TMP_STYLE" >/dev/null 2>&1
 SCF="$TMP_STYLE/casaos/adguard-home/docker-compose.yml"
-if grep -qE '^\s+screenshot_link: \[' "$SCF"; then echo "FAIL: screenshot_link reflowed to flow style"; fail=1; else echo "ok: screenshot_link block style"; fi
+assert_eq "$([[ -s "$SCF" ]] && echo yes)" "yes" "style: compose produced"
+if [[ -s "$SCF" ]] && ! grep -qE '^\s+screenshot_link: \[' "$SCF"; then echo "ok: screenshot_link block style"; else echo "FAIL: screenshot_link reflowed to flow style"; fail=1; fi
 assert_eq "$(yq eval '.x-casaos.screenshot_link | length' "$SCF")" "3" "screenshot_link parsed as sequence"
 assert_eq "$(yq eval '.x-casaos.architectures | tag' "$SCF")" "!!seq" "architectures still a sequence"
 if grep -qE '^\s+en_US: \|' "$SCF"; then echo "ok: tips literal block scalar preserved"; else echo "FAIL: tips lost literal block scalar"; fail=1; fi
-if grep -qE '^\s+"en_[a-zA-Z]+":' "$SCF"; then echo "FAIL: blob keys became quoted"; fail=1; else echo "ok: blob keys unquoted"; fi
+if [[ -s "$SCF" ]] && ! grep -qE '^\s+"en_[a-zA-Z]+":' "$SCF"; then echo "ok: blob keys unquoted"; else echo "FAIL: blob keys became quoted"; fail=1; fi
 rm -rf "$TMP_STYLE"
 
 # --- dotted service names address correctly (bracket form, not dot form) ---


### PR DESCRIPTION
Values from `app.json` were string-interpolated into `yq eval` expressions, so a crafted value could break out of the string literal and reach yq's file-read operators. All 40 sites in `convert_to_casaos()` now pass values via environment + `strenv()`/`env()`, never as expression source.

Output verified byte-identical across all 242 apps, with one intentional divergence (`maybe-finance`: a literal `\n` in a shell snippet was previously expanded into a real newline, breaking the copy-paste command).

Fixes #2478

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens CasaOS conversion by moving dynamic values out of yq expression source and into environment-backed `strenv()`/`env()` lookups.
- Converts app metadata, service names, indexes, environment keys, paths, and ports without string interpolation.
- Adds regression coverage for app- and compose-derived expression-injection payloads, literal preservation, structured-value formatting, and dotted service names.
- Runs the CasaOS converter test suite as a dedicated pull-request job.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/convert-to-platforms.sh | Replaces dynamically interpolated yq expressions throughout CasaOS conversion with environment-backed values while preserving structured YAML types and styles. |
| scripts/tests/test-convert-casaos.sh | Adds end-to-end regression tests covering expression injection, literal payload preservation, structured metadata formatting, and dynamic service addressing. |
| .github/workflows/validate-pr.yml | Adds a dedicated pull-request job that installs converter dependencies and runs the CasaOS test suite. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["app.json and docker-compose.yml values"] --> B["Shell environment variables"]
  B --> C["yq strenv() / env() data nodes"]
  C --> D["CasaOS docker-compose.yml"]
  T["Injection regression suite"] --> C
  T --> D
  W["Pull-request workflow"] --> T
```

<sub>Reviews (3): Last reviewed commit: ["ci: install bun for converter test suite"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/48980b548f13e312ed875708cbbe76e95a0ca406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53121604)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Conversion Pipeline](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/conversion-pipeline.md)
- Knowledge Base — [Validation and Sync](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/validation-and-sync.md)
- Knowledge Base — [CI/CD Automation](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/ci-automation.md)
</details>

<!-- /greptile_comment -->