### PR TITLE
fix(umbrel): attach main service to default network so app_proxy can resolve APP_HOST

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run converter test suite
         run: bash scripts/tests/test-convert-casaos.sh
 
+      - name: Run Umbrel converter test suite
+        run: bash scripts/tests/test-convert-umbrel.sh
+
   validate-apps:
     name: Validate App Definitions
     runs-on: ubuntu-latest

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1934,14 +1934,15 @@ convert_to_umbrel() {
         local svc="$main_service"
         export svc
         local networks_kind=$(yq eval '.services[strenv(svc)].networks | type' "$output_dir/docker-compose.yml" 2>/dev/null)
-        local has_default=$(yq eval '[.services[strenv(svc)].networks // [] | (.[] // (. | keys | .[])) | select(. == "default")] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
+        local has_default=$(yq eval '[.services[strenv(svc)].networks // [] | (select(type == "!!map") | keys) // (select(type == "!!seq")) | .[] | select(. == "default")] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
         if [[ "$networks_kind" == "!!seq" || "$networks_kind" == "!!map" ]] && [[ "$has_default" == "0" ]]; then
             local append_expr='.services[strenv(svc)].networks += ["default"]'
             [[ "$networks_kind" == "!!map" ]] && append_expr='.services[strenv(svc)].networks.default = null'
-            if yq eval "$append_expr" "$output_dir/docker-compose.yml" > "$temp_compose" 2>/dev/null && [[ -s "$temp_compose" ]]; then
-                mv "$temp_compose" "$output_dir/docker-compose.yml"
+            local network_temp=$(mktemp)
+            if yq eval "$append_expr" "$output_dir/docker-compose.yml" > "$network_temp" 2>/dev/null && [[ -s "$network_temp" ]]; then
+                mv "$network_temp" "$output_dir/docker-compose.yml"
             else
-                rm -f "$temp_compose"
+                rm -f "$network_temp"
                 print_error "$app_name: failed to attach main service to Umbrel default network"
                 TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
             fi

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1929,8 +1929,19 @@ convert_to_umbrel() {
             yq eval ".services = {\"app_proxy\": {\"environment\": {\"APP_HOST\": \"${folder_name}_${main_service}_1\", \"APP_PORT\": \"$container_port\"}}} + .services" "$output_dir/docker-compose.yml" > "$temp_compose"
             mv "$temp_compose" "$output_dir/docker-compose.yml"
         fi
+
+        # app_proxy resolves APP_HOST only on Umbrel's default network (umbrel_main_network)
+        local svc="$main_service"
+        export svc
+        local main_networks=$(yq eval '.services[strenv(svc)].networks // [] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
+        local has_default=$(yq eval '[.services[strenv(svc)].networks // [] | .[] | select(. == "default")] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
+        if [[ "$main_networks" =~ ^[0-9]+$ ]] && [[ "$main_networks" -gt 0 ]] && [[ "$has_default" == "0" ]]; then
+            yq eval '.services[strenv(svc)].networks += ["default"]' "$output_dir/docker-compose.yml" > "$temp_compose"
+            mv "$temp_compose" "$output_dir/docker-compose.yml"
+        fi
+        unset svc
     fi
-    
+
     # Convert named volumes to ${APP_DATA_DIR} bind mounts for Umbrel
     # First, get list of named volumes
     local named_volumes=$(yq eval '.volumes | keys | .[]' "$output_dir/docker-compose.yml" 2>/dev/null || echo "")

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1933,11 +1933,18 @@ convert_to_umbrel() {
         # app_proxy resolves APP_HOST only on Umbrel's default network (umbrel_main_network)
         local svc="$main_service"
         export svc
-        local main_networks=$(yq eval '.services[strenv(svc)].networks // [] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
-        local has_default=$(yq eval '[.services[strenv(svc)].networks // [] | .[] | select(. == "default")] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
-        if [[ "$main_networks" =~ ^[0-9]+$ ]] && [[ "$main_networks" -gt 0 ]] && [[ "$has_default" == "0" ]]; then
-            yq eval '.services[strenv(svc)].networks += ["default"]' "$output_dir/docker-compose.yml" > "$temp_compose"
-            mv "$temp_compose" "$output_dir/docker-compose.yml"
+        local networks_kind=$(yq eval '.services[strenv(svc)].networks | type' "$output_dir/docker-compose.yml" 2>/dev/null)
+        local has_default=$(yq eval '[.services[strenv(svc)].networks // [] | (.[] // (. | keys | .[])) | select(. == "default")] | length' "$output_dir/docker-compose.yml" 2>/dev/null)
+        if [[ "$networks_kind" == "!!seq" || "$networks_kind" == "!!map" ]] && [[ "$has_default" == "0" ]]; then
+            local append_expr='.services[strenv(svc)].networks += ["default"]'
+            [[ "$networks_kind" == "!!map" ]] && append_expr='.services[strenv(svc)].networks.default = null'
+            if yq eval "$append_expr" "$output_dir/docker-compose.yml" > "$temp_compose" 2>/dev/null && [[ -s "$temp_compose" ]]; then
+                mv "$temp_compose" "$output_dir/docker-compose.yml"
+            else
+                rm -f "$temp_compose"
+                print_error "$app_name: failed to attach main service to Umbrel default network"
+                TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+            fi
         fi
         unset svc
     fi

--- a/scripts/tests/test-convert-umbrel.sh
+++ b/scripts/tests/test-convert-umbrel.sh
@@ -106,6 +106,7 @@ assert_eq "$(yq eval '.services.app.networks.custom_network.aliases | join(",")'
 
 cp "$MAPNET" "$TMP/mapnet-first.yml"
 bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -a mapnet -p umbrel -o "$TMP/out" > /dev/null 2>&1
+assert_eq "$?" "0" "map-style rerun exits 0"
 diff -q "$TMP/mapnet-first.yml" "$MAPNET" > /dev/null 2>&1
 assert_eq "$?" "0" "map-style rerun is byte-identical"
 
@@ -130,6 +131,7 @@ assert_eq "$(yq eval '.services.app.networks.default.aliases | join(",")' "$MAPD
 section "idempotency: re-running the converter does not append default twice"
 cp "$CUSTOM" "$TMP/first-run.yml"
 bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -p umbrel -o "$TMP/out" > /dev/null 2>&1
+assert_eq "$?" "0" "second run exits 0"
 assert_eq "$(main_networks "$CUSTOM" app)" "custom_network,default" "second run keeps a single default"
 diff -q "$TMP/first-run.yml" "$CUSTOM" > /dev/null 2>&1
 assert_eq "$?" "0" "second run output is byte-identical"

--- a/scripts/tests/test-convert-umbrel.sh
+++ b/scripts/tests/test-convert-umbrel.sh
@@ -87,6 +87,24 @@ assert_eq "$(main_networks "$CUSTOM" sidecar)" "custom_network" "sibling service
 assert_eq "$(main_networks "$TMP/out/umbrel/big-bear-umbrel-defaultnet/docker-compose.yml" app)" "" "main service with no networks key is untouched"
 assert_eq "$(main_networks "$TMP/out/umbrel/big-bear-umbrel-hasdefault/docker-compose.yml" app)" "custom_network,default" "existing default is not duplicated"
 
+section "map-style networks: attached without corrupting the compose file"
+make_app "$TMP" "mapnet" 'services:
+  app:
+    image: nginx:alpine
+    networks:
+      custom_network:
+        aliases:
+          - internal
+networks:
+  custom_network:
+    driver: bridge
+'
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -a mapnet -p umbrel -o "$TMP/out" > "$TMP/map.log" 2>&1
+MAPNET="$TMP/out/umbrel/big-bear-umbrel-mapnet/docker-compose.yml"
+assert_eq "$(yq eval '.services.app.networks | has("default")' "$MAPNET" 2>/dev/null)" "true" "map-style networks gains default"
+assert_eq "$(yq eval '.services.app.networks.custom_network.aliases | join(",")' "$MAPNET" 2>/dev/null)" "internal" "map-style networks keeps existing entries"
+assert_eq "$(yq eval '.services.app.image' "$MAPNET" 2>/dev/null)" "nginx:alpine" "map-style compose file is not truncated"
+
 section "idempotency: re-running the converter does not append default twice"
 cp "$CUSTOM" "$TMP/first-run.yml"
 bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -p umbrel -o "$TMP/out" > /dev/null 2>&1

--- a/scripts/tests/test-convert-umbrel.sh
+++ b/scripts/tests/test-convert-umbrel.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(dirname "$(dirname "$SCRIPT_DIR")")"
+set +e
+
+fail=0
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [[ "$actual" != "$expected" ]]; then echo "FAIL: $label — got '$actual' want '$expected'"; fail=1; else echo "ok: $label"; fi
+}
+section() { echo; echo "== $1 =="; }
+
+main_networks() {
+  local file="$1"
+  export UMB_SVC="$2"
+  yq eval '.services[strenv(UMB_SVC)].networks // [] | join(",")' "$file"
+}
+
+make_app() {
+  local root="$1" name="$2" compose="$3"
+  mkdir -p "$root/apps/$name"
+  printf '%s' "$compose" > "$root/apps/$name/docker-compose.yml"
+  cat > "$root/apps/$name/app.json" <<JSON
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "$name",
+    "name": "$name",
+    "description": "test app",
+    "tagline": "test",
+    "version": "1.0.0",
+    "author": "test",
+    "developer": "test",
+    "category": "BigBearCasaOS"
+  },
+  "technical": { "main_service": "app", "default_port": "8080", "main_image": "nginx", "compose_file": "docker-compose.yml" },
+  "deployment": { "ports": [{ "container": "8080", "host": "8080", "protocol": "tcp" }] },
+  "compatibility": { "umbrel": { "supported": true, "port": "10001", "app_port": "8080" } }
+}
+JSON
+}
+
+section "app_proxy reachability: main service must be on Umbrel's default network"
+# Umbrel's app_proxy only ever attaches to umbrel_main_network (its compose `default`).
+# A main service pinned to custom networks alone never registers its container name
+# there, so APP_HOST resolution fails while the app itself is healthy (issue #2301).
+TMP="$(mktemp -d)"
+
+make_app "$TMP" "customnet" 'services:
+  app:
+    image: nginx:alpine
+    networks:
+      - custom_network
+  sidecar:
+    image: redis:alpine
+    networks:
+      - custom_network
+networks:
+  custom_network:
+    driver: bridge
+'
+
+make_app "$TMP" "defaultnet" 'services:
+  app:
+    image: nginx:alpine
+'
+
+make_app "$TMP" "hasdefault" 'services:
+  app:
+    image: nginx:alpine
+    networks:
+      - custom_network
+      - default
+networks:
+  custom_network:
+    driver: bridge
+'
+
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -p umbrel -o "$TMP/out" > "$TMP/run.log" 2>&1
+assert_eq "$?" "0" "converter exits 0"
+
+CUSTOM="$TMP/out/umbrel/big-bear-umbrel-customnet/docker-compose.yml"
+assert_eq "$(main_networks "$CUSTOM" app)" "custom_network,default" "custom-network-only main service gains default"
+assert_eq "$(main_networks "$CUSTOM" sidecar)" "custom_network" "sibling services are left alone"
+
+assert_eq "$(main_networks "$TMP/out/umbrel/big-bear-umbrel-defaultnet/docker-compose.yml" app)" "" "main service with no networks key is untouched"
+assert_eq "$(main_networks "$TMP/out/umbrel/big-bear-umbrel-hasdefault/docker-compose.yml" app)" "custom_network,default" "existing default is not duplicated"
+
+section "idempotency: re-running the converter does not append default twice"
+cp "$CUSTOM" "$TMP/first-run.yml"
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -p umbrel -o "$TMP/out" > /dev/null 2>&1
+assert_eq "$(main_networks "$CUSTOM" app)" "custom_network,default" "second run keeps a single default"
+diff -q "$TMP/first-run.yml" "$CUSTOM" > /dev/null 2>&1
+assert_eq "$?" "0" "second run output is byte-identical"
+
+section "host networking: no app_proxy, no network rewrite"
+make_app "$TMP" "hostnet" 'services:
+  app:
+    image: nginx:alpine
+    network_mode: host
+'
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -p umbrel -o "$TMP/out" > /dev/null 2>&1
+HOSTNET="$TMP/out/umbrel/big-bear-umbrel-hostnet/docker-compose.yml"
+assert_eq "$(yq eval '.services.app_proxy // "ABSENT"' "$HOSTNET")" "ABSENT" "host-network app gets no app_proxy"
+assert_eq "$(yq eval '.services.app.network_mode' "$HOSTNET")" "host" "host-network app keeps network_mode: host"
+assert_eq "$(main_networks "$HOSTNET" app)" "" "host-network app gains no networks"
+
+rm -rf "$TMP"
+
+section "catalog: every app_proxy target resolves on the default network"
+if [[ "${UMBREL_FULL_RUN:-0}" == "1" ]]; then
+  TMP_FULL="$(mktemp -d)"
+  bash "$REPO/scripts/convert-to-platforms.sh" -p umbrel -o "$TMP_FULL/out" > "$TMP_FULL/run.log" 2>&1
+  UNREACHABLE=0
+  for F in "$TMP_FULL"/out/umbrel/*/docker-compose.yml; do
+    HOST="$(yq eval '.services.app_proxy.environment.APP_HOST // ""' "$F")"
+    [[ -z "$HOST" ]] && continue
+    for SVC in $(yq eval '.services | keys | .[]' "$F"); do
+      [[ "$SVC" == "app_proxy" ]] && continue
+      case "$HOST" in *"_${SVC}_1")
+        NETS="$(main_networks "$F" "$SVC")"
+        if [[ -n "$NETS" ]] && [[ ",$NETS," != *",default,"* ]]; then
+          UNREACHABLE=$((UNREACHABLE+1)); echo "UNREACHABLE: $(basename "$(dirname "$F")") [$SVC] -> $NETS"
+        fi
+      ;; esac
+    done
+  done
+  assert_eq "$UNREACHABLE" "0" "no app_proxy target is stranded off the default network"
+  rm -rf "$TMP_FULL"
+else
+  echo "ok: catalog case skipped (set UMBREL_FULL_RUN=1 to enable)"
+fi
+
+exit $fail

--- a/scripts/tests/test-convert-umbrel.sh
+++ b/scripts/tests/test-convert-umbrel.sh
@@ -103,7 +103,29 @@ bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -a mapnet -p umbrel 
 MAPNET="$TMP/out/umbrel/big-bear-umbrel-mapnet/docker-compose.yml"
 assert_eq "$(yq eval '.services.app.networks | has("default")' "$MAPNET" 2>/dev/null)" "true" "map-style networks gains default"
 assert_eq "$(yq eval '.services.app.networks.custom_network.aliases | join(",")' "$MAPNET" 2>/dev/null)" "internal" "map-style networks keeps existing entries"
-assert_eq "$(yq eval '.services.app.image' "$MAPNET" 2>/dev/null)" "nginx:alpine" "map-style compose file is not truncated"
+
+cp "$MAPNET" "$TMP/mapnet-first.yml"
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -a mapnet -p umbrel -o "$TMP/out" > /dev/null 2>&1
+diff -q "$TMP/mapnet-first.yml" "$MAPNET" > /dev/null 2>&1
+assert_eq "$?" "0" "map-style rerun is byte-identical"
+
+make_app "$TMP" "mapdefault" 'services:
+  app:
+    image: nginx:alpine
+    networks:
+      custom_network:
+        aliases:
+          - internal
+      default:
+        aliases:
+          - myapp
+networks:
+  custom_network:
+    driver: bridge
+'
+bash "$REPO/scripts/convert-to-platforms.sh" -i "$TMP/apps" -a mapdefault -p umbrel -o "$TMP/out" > /dev/null 2>&1
+MAPDEF="$TMP/out/umbrel/big-bear-umbrel-mapdefault/docker-compose.yml"
+assert_eq "$(yq eval '.services.app.networks.default.aliases | join(",")' "$MAPDEF" 2>/dev/null)" "myapp" "map-style existing default keeps its config"
 
 section "idempotency: re-running the converter does not append default twice"
 cp "$CUSTOM" "$TMP/first-run.yml"


### PR DESCRIPTION
Umbrel's `app_proxy` only attaches to `umbrel_main_network`, so a main service pinned to a custom bridge alone never registers a resolvable DNS name — the app runs healthy while the proxy loops on "cannot be found".

The converter now appends `default` to the main service's networks when it declares custom networks without it. Verified by booting the converted app under Umbrel's real topology: proxy resolves `APP_HOST` and gets `{"status":"healthy"}`.

Affected 71 of 218 Umbrel apps, not just odysseus. Adds `test-convert-umbrel.sh` (confirmed failing without the fix) and wires it into CI.

Fixes #2301

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates Umbrel conversion so a proxied main service with custom networks also joins the default network, allowing `app_proxy` to resolve it.
- Preserves existing sequence- and map-style network declarations while adding `default` when absent.
- Adds Umbrel converter coverage for network handling, host networking, and idempotent reruns.
- Runs the Umbrel converter suite in PR validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/convert-to-platforms.sh | Adds the Umbrel default network to proxied main services with sequence- or map-style custom network declarations while preserving existing configuration. |
| scripts/tests/test-convert-umbrel.sh | Adds focused conversion tests, and the current exit-status assertions correctly prevent failed idempotency reruns from passing against stale output. |
| .github/workflows/validate-pr.yml | Adds the Umbrel converter test suite to the existing PR validation job. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Source[Universal app compose] --> Convert[Umbrel converter]
    Convert --> Check{Main service has custom networks?}
    Check -->|No| Preserve[Preserve network configuration]
    Check -->|Yes, default absent| Attach[Attach main service to default network]
    Check -->|Yes, default present| Preserve
    Attach --> Proxy[app_proxy resolves APP_HOST]
    Preserve --> Output[Generated Umbrel compose]
    Proxy --> Output
```

<sub>Reviews (4): Last reviewed commit: ["test(umbrel): assert converter reruns su..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/49d369630b698b169192204cfe2396fb1e7cf8a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53148062)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Conversion Pipeline](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/conversion-pipeline.md)
- Knowledge Base — [Validation and Sync](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/validation-and-sync.md)
- Knowledge Base — [CI/CD Automation](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/ci-automation.md)
</details>

<!-- /greptile_comment -->