### PR TITLE
Add cairn

### DIFF
--- a/apps/cairn/app.json
+++ b/apps/cairn/app.json
@@ -1,0 +1,132 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "cairn",
+    "name": "cairn",
+    "description": "cairn is the page you hand to the people you host services for: family, a club, whoever ends up using your server. One YAML file in, a static multilingual directory out, with no account to create, no database and no outbound requests. It shows your services and nothing else: no widgets, no Docker socket, no metrics. Each service can show a live status pill pulled from Gatus or Uptime Kuma, so visitors see what is up before they click, and cairn serves its own legal and privacy pages. It ships as a single static Go binary in a FROM scratch image, around 4 MB to pull, and it writes nothing at runtime, so it runs read-only with every Linux capability dropped.",
+    "tagline": "The directory page for the people you host services for",
+    "version": "1.19.3",
+    "author": "MorganKryze",
+    "developer": "MorganKryze",
+    "category": "Productivity",
+    "license": "GPL-3.0",
+    "homepage": "https://cairn.libresoftware.cloud",
+    "source": "big-bear-universal",
+    "created": "2026-08-19T00:00:00Z",
+    "updated": "2026-08-19T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/cairn.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/cairn.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/MorganKryze/cairn/tree/main/docs",
+    "repository": "https://github.com/MorganKryze/cairn",
+    "issues": "https://github.com/MorganKryze/cairn/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "app",
+    "default_port": "8080",
+    "main_image": "morgankryze/cairn",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [],
+    "volumes": [
+      {
+        "container": "/config",
+        "description": "The YAML files that describe your services; cairn only ever reads this folder"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8080",
+        "host": "8080",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "/",
+    "tips": {
+      "before_install": {
+        "en_us": "cairn needs no environment variable and no secret to run. It is configured entirely by YAML files you place in its config folder, so there is nothing to fill in before installing."
+      },
+      "after_install": {
+        "en_us": "Open http://your-server:8080. With an empty config folder cairn serves a getting-started page instead of failing, so the first run always works. Create a services.yaml in the config folder and cairn picks it up within seconds, with no restart. If a file is invalid, cairn keeps the previous configuration and logs which key it did not recognise. Full reference: https://github.com/MorganKryze/cairn/tree/main/docs"
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8080",
+      "volume_mappings": {
+        "cairn_config": "/DATA/AppData/$AppID/config"
+      },
+      "category": "Productivity"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "Productivity",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "8080"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "port": "8080",
+      "volume_mappings": {
+        "cairn_config": "cairn/config"
+      }
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8080"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8080"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "port": "18080",
+      "volume_mappings": {
+        "cairn_config": "cairn/config"
+      }
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "dashboard",
+    "homepage",
+    "startpage",
+    "directory",
+    "multilingual"
+  ]
+}

--- a/apps/cairn/docker-compose.yml
+++ b/apps/cairn/docker-compose.yml
@@ -1,0 +1,31 @@
+name: cairn
+
+services:
+  app:
+    image: morgankryze/cairn:1.19.3@sha256:a3e1d149e5aa31bcb7b21f62370ddb4a5369d90c3cdf2fc3ac34fad820e88471
+    container_name: cairn
+    ports:
+      - "8080:8080"
+    volumes:
+      - cairn_config:/config:ro
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/cairn", "-healthcheck"]
+      interval: 30s
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - cairn-network
+
+networks:
+  cairn-network:
+    driver: bridge
+
+volumes:
+  cairn_config:
+    name: cairn_config
+    driver: local


### PR DESCRIPTION
Adds **cairn** to the universal catalogue: `apps/cairn/app.json` and
`apps/cairn/docker-compose.yml`, nothing else.

I opened #2757 two weeks ago suggesting cairn. Opening the PR instead so there is
nothing left for you to write.

**What cairn is:** the directory page for the people you host services for. You
hand it to your family, your club or your members. One YAML file in, a static
multilingual directory out, with no account to create, no database and no
outbound requests. Each service can show a live status pill pulled from Gatus or
Uptime Kuma. It is a single static Go binary in a `FROM scratch` image, around
4 MB to pull, and it writes nothing at runtime.

I'm its author. Tell me if anything is in the wrong shape and I'll fix it.

**How I validated it** on a fresh clone, before opening:

- `./scripts/validate-apps.sh -a cairn`: PASSED, 0 errors, 0 warnings
- `./scripts/convert-to-platforms.sh -a cairn`: all 6 platforms, 0 errors
- `scripts/tests/test-convert-casaos.sh` and `test-convert-umbrel.sh`: pass
- checked the generated CasaOS compose still carries `read_only`,
  `cap_drop: ALL`, `no-new-privileges` and the healthcheck

**Notes for review:**

- **No environment variables at all.** cairn is configured by files, never by
  variables, and it needs no secret to run. `environment_variables` is genuinely
  empty rather than trimmed.
- The first run works with an empty config folder: cairn serves a
  getting-started page instead of failing. Dropping a `services.yaml` in makes it
  reload within seconds, no restart. If the file is invalid cairn keeps the
  previous config and logs which key it did not recognise. That is what the
  `after_install` tip says.
- The image is pinned to the `1.19.3` digest, following PodFetch.
- The icon comes from selfh.st, `png/cairn.png`, same form as PodFetch. Happy to
  vendor it into this repo instead if you prefer.
- **One thing about `/config`, for your users rather than for cairn.** cairn only
  ever reads that folder, so the compose mounts it `:ro`. Five of your six
  converters carry the flag through: Portainer, Dockge and Cosmos emit
  `…_config:/config:ro`, and Runtipi and Umbrel emit
  `${APP_DATA_DIR}/cairn/config:/config:ro` while still remapping to a host path.
  The CasaOS branch is the only one that drops it: it builds
  `casaos_path="${custom_mapping}:${container_path}"` and then replaces the whole
  volume entry with that string, so the mode is never carried
  (`scripts/convert-to-platforms.sh`, around line 878). Putting `:ro` in
  `volume_mappings` gives `…/config:ro:/config`, which Docker reads wrong, and
  long-form volumes get overwritten too, so I left it alone rather than ship
  something broken.

  This is not a blocker for cairn, `read_only: true` still applies to the
  container filesystem. But it means every read-only app loses that guarantee on
  CasaOS and keeps it everywhere else. **Happy to send a small follow-up PR that
  carries the mode through in the CasaOS branch**, if you want it.

- Source: <https://github.com/MorganKryze/cairn> (GPL-3.0)
- Live demo: <https://cairn.libresoftware.cloud>
- Docs: <https://github.com/MorganKryze/cairn/tree/main/docs>

Thanks for keeping the catalogue open to outside submissions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Cairn 1.19.3 to the universal application catalogue as a hardened, file-configured container.
- Defines catalogue metadata and compatibility settings for all six target platforms.
- Adds a digest-pinned Compose service with a read-only filesystem, dropped capabilities, a healthcheck, and read-only configuration mount.
- The configuration workflow is not practically exposed on three generated platforms, and the Umbrel installation tip names the wrong external port.

<h3>Confidence Score: 4/5</h3>

The configuration-volume issue should be fixed before merging because Portainer, Dockge, and Cosmos users otherwise cannot complete Cairn's required file-based setup through their platform data directories.

The service itself is consistently pinned and hardened, but three conversion targets preserve its configuration as a read-only Docker-managed volume while the application requires users to add services.yaml; Umbrel guidance also points to the wrong host port.

**Files Needing Attention:** apps/cairn/docker-compose.yml and apps/cairn/app.json

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/cairn/app.json | Adds complete Cairn metadata and platform settings, but the shared installation URL is incorrect for Umbrel and its configuration instruction is unusable on platforms retaining the named volume. |
| apps/cairn/docker-compose.yml | Adds a hardened, digest-pinned service, but using a read-only Docker-managed volume for user-authored configuration leaves several platform installations without a practical configuration path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Source["Cairn universal definition"] --> Convert["Platform conversion"]
  Convert --> Bind["CasaOS / Runtipi / Umbrel<br/>host app-data path"]
  Convert --> Named["Portainer / Dockge / Cosmos<br/>Docker named volume"]
  Bind --> Config["User adds services.yaml"]
  Named --> Blocked["No platform app-data path<br/>for services.yaml"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/cairn/docker-compose.yml:10
**Read-only named volume blocks configuration**

When Cairn is installed through Portainer, Dockge, or Cosmos, this remains a read-only Docker-managed named volume instead of becoming a platform app-data path, so users cannot place the required `services.yaml` through their platform data directory and the app remains on its getting-started page.

### Issue 2
apps/cairn/app.json:67
**Umbrel tip names wrong port**

This shared installation tip always directs users to port 8080, while the Umbrel definition exposes Cairn on host port 18080, so Umbrel users following the supplied URL cannot reach the application.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add cairn"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/3dd5850b179cfe192c98f06f5690f0c973634192) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54749181)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Universal App Format](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/universal-app-format.md)

<!-- /greptile_comment -->