### PR TITLE
feat: add KitchenOwl app

### DIFF
--- a/apps/kitchenowl/app.json
+++ b/apps/kitchenowl/app.json
@@ -1,0 +1,139 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "kitchenowl",
+    "name": "KitchenOwl",
+    "description": "KitchenOwl is a self-hosted grocery list and recipe manager. Track what you need to buy, add recipes, plan meals, and sync your household shopping lists across all your devices in real time.",
+    "tagline": "Self-hosted grocery list and recipe manager",
+    "version": "v0.7.10",
+    "author": "BigBearTechWorld",
+    "developer": "TomBursch",
+    "category": "BigBearCasaOS",
+    "license": "AGPL-3.0",
+    "homepage": "https://kitchenowl.org",
+    "source": "big-bear-universal",
+    "created": "2026-08-23T00:00:00Z",
+    "updated": "2026-08-23T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/kitchenowl.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/kitchenowl.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://docs.kitchenowl.org/",
+    "repository": "https://github.com/TomBursch/kitchenowl",
+    "issues": "https://github.com/TomBursch/kitchenowl/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "app",
+    "default_port": "9287",
+    "main_image": "tombursch/kitchenowl",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "JWT_SECRET_KEY",
+        "default": "7c7884a9-f13a-4e01-a2f0-310add0acf60",
+        "description": "Secret key used for signing authentication tokens",
+        "required": true
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Application data directory"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8080",
+        "host": "9287",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": {
+        "en_us": "Create your account on first launch, then share the household list by inviting members from the settings."
+      },
+      "after_install": {
+        "en_us": "Access the web UI at http://your-server:9287"
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "9287",
+      "volume_mappings": {
+        "kitchenowl_data": "/DATA/AppData/$AppID/data"
+      },
+      "port": "9287",
+      "category": "Others"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "9287"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "kitchenowl_data": "data"
+      },
+      "port": "9287"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "9287"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "9287"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "kitchenowl_data": "data"
+      },
+      "port": "10287"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "recipes",
+    "grocery-list",
+    "meal-planner"
+  ]
+}

--- a/apps/kitchenowl/docker-compose.yml
+++ b/apps/kitchenowl/docker-compose.yml
@@ -1,0 +1,18 @@
+name: big-bear-kitchenowl
+
+services:
+  app:
+    container_name: big-bear-kitchenowl
+    image: tombursch/kitchenowl:v0.7.10@sha256:bd821a41b8cb27fd7fcf429acd1fc67e9f889485a2cd1193d68c2d804a8e1bef
+    restart: unless-stopped
+    ports:
+      - "9287:8080"
+    environment:
+      - JWT_SECRET_KEY=7c7884a9-f13a-4e01-a2f0-310add0acf60
+    volumes:
+      - kitchenowl_data:/data
+
+volumes:
+  kitchenowl_data:
+    name: kitchenowl_data
+    driver: local


### PR DESCRIPTION
Closes #2902

Adds KitchenOwl v0.7.10 (self-hosted grocery list and recipe manager) using the official all-in-one image, pinned with digest. Validated via `validate-apps.sh`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds KitchenOwl v0.7.10 as a new universal catalog application using a digest-pinned all-in-one container.

- Defines catalog metadata, platform compatibility, UI access, persistent storage, and supported architectures.
- Adds a single-service Compose deployment exposing KitchenOwl on port 9287.
- The supplied deployment configuration uses one publicly disclosed JWT signing key across installations.

<h3>Confidence Score: 3/5</h3>

This PR is not safe to merge until the fixed public JWT signing key is replaced with a unique secret generated for each installation.

Every deployment currently receives a known symmetric authentication key, enabling attackers who can reach an instance to forge accepted tokens and bypass its authentication boundary.

**Files Needing Attention:** apps/kitchenowl/docker-compose.yml and apps/kitchenowl/app.json

<details open><summary><h3>Security Review</h3></summary>

The deployment publishes and installs a fixed JWT signing key, allowing reachable KitchenOwl instances to accept attacker-forged authentication tokens. **How this was verified:** The same literal signing key appears in the manifest and Compose environment, and the CasaOS conversion copies that Compose definition without replacing the value.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/kitchenowl/app.json | Adds aligned KitchenOwl catalog and platform metadata, but publishes a fixed authentication-token signing key as the deployment default. |
| apps/kitchenowl/docker-compose.yml | Adds the digest-pinned KitchenOwl service, persistence, and port mapping while hard-coding the shared JWT signing key used at runtime. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Catalog[KitchenOwl catalog package] --> Convert[Platform conversion]
  Convert --> Deploy[KitchenOwl container]
  PublicKey[Repository-visible JWT key] --> Deploy
  Attacker[Attacker signs token with public key] --> Request[Authenticated request]
  Request --> Deploy
  Deploy --> ProtectedData[Household and planning data]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/kitchenowl/docker-compose.yml:11
**Shared JWT signing key**

When an attacker can reach an installation, this repository-visible `JWT_SECRET_KEY` lets them sign authentication tokens that KitchenOwl accepts, causing unauthorized access to or modification of protected household, grocery-list, recipe, and meal-planning data.

**How this was verified:** The manifest and Compose file publish the same signing key, and the CasaOS conversion copies the Compose definition without replacing it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add KitchenOwl app (#2902)"](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/bb70b9c87513b09b66783e7e7f47b2c48d04253e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55972813)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)

<!-- /greptile_comment -->