### PR TITLE
feat(nightlio): add Nightlio mood tracker and journal

### DIFF
--- a/apps/nightlio/app.json
+++ b/apps/nightlio/app.json
@@ -1,0 +1,161 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "nightlio",
+    "name": "Nightlio",
+    "description": "Nightlio is a privacy-first mood tracker and daily journal designed for effortless self-hosting. Log your daily mood on a simple five-point scale, write rich Markdown journal entries with customizable tags, and view insightful analytics including mood history calendars, average mood trends, and journaling streaks. All data is stored in a local SQLite database on your own server with no telemetry, ads, or subscriptions.",
+    "tagline": "Privacy-first mood tracker and daily journal",
+    "version": "0.1.7",
+    "author": "BigBearTechWorld",
+    "developer": "shirsakm",
+    "category": "BigBearCasaOS",
+    "license": "AGPL-3.0",
+    "homepage": "https://github.com/shirsakm/nightlio",
+    "source": "big-bear-universal",
+    "created": "2026-08-23T00:00:00Z",
+    "updated": "2026-08-23T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nightlio.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/nightlio.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/shirsakm/nightlio#readme",
+    "repository": "https://github.com/shirsakm/nightlio",
+    "issues": "https://github.com/shirsakm/nightlio/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "big-bear-nightlio-frontend",
+    "default_port": "5173",
+    "main_image": "ghcr.io/shirsakm/nightlio-frontend",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "SECRET_KEY",
+        "default": "changeme",
+        "description": "Secret key used by the API for session signing. Change to a long random string",
+        "required": false
+      },
+      {
+        "name": "JWT_SECRET",
+        "default": "changeme-too",
+        "description": "Secret used to sign JWT authentication tokens. Change to a different long random string",
+        "required": false
+      },
+      {
+        "name": "CORS_ORIGINS",
+        "default": "http://localhost:5173",
+        "description": "Comma-separated list of origins allowed to call the API directly. Add your public domain when exposing the app",
+        "required": false
+      },
+      {
+        "name": "ENABLE_GOOGLE_OAUTH",
+        "default": "0",
+        "description": "Enables Google OAuth for multi-user support (1 to enable, 0 to disable)",
+        "required": false
+      },
+      {
+        "name": "ENABLE_MOOD_MUSIC",
+        "default": "0",
+        "description": "Enables the mood music feature powered by Jamendo (1 to enable, 0 to disable)",
+        "required": false
+      },
+      {
+        "name": "DEFAULT_SELF_HOST_ID",
+        "default": "selfhost_default_user",
+        "description": "Identifier of the default single-user account in self-hosted mode",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/app/data",
+        "description": "SQLite database storage for moods, journal entries, and achievements"
+      }
+    ],
+    "ports": [
+      {
+        "container": "80",
+        "host": "5173",
+        "protocol": "tcp",
+        "description": "Web UI served by nginx, which proxies /api requests to the Flask backend"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "5173",
+      "volume_mappings": {
+        "nightlio_data": "/DATA/AppData/$AppID/data"
+      },
+      "port": "5173",
+      "category": "Others"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "5173"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "nightlio_data": "data"
+      },
+      "port": "8016"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "5173"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "nightlio_data": "data"
+      },
+      "port": "10012"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "mood-tracker",
+    "journal",
+    "privacy"
+  ]
+}

--- a/apps/nightlio/docker-compose.yml
+++ b/apps/nightlio/docker-compose.yml
@@ -1,0 +1,41 @@
+name: big-bear-nightlio
+
+services:
+  big-bear-nightlio-api:
+    container_name: big-bear-nightlio-api
+    image: ghcr.io/shirsakm/nightlio-api:0.1.7@sha256:4f9b88a3eba36b67457052d08b0a71bb3210b72276da0b6432235ce5372e3cb4
+    restart: unless-stopped
+    environment:
+      - SECRET_KEY=changeme
+      - JWT_SECRET=changeme-too
+      - CORS_ORIGINS=http://localhost:5173
+      - ENABLE_GOOGLE_OAUTH=0
+      - ENABLE_MOOD_MUSIC=0
+      - DEFAULT_SELF_HOST_ID=selfhost_default_user
+      - DATABASE_PATH=/app/data/nightlio.db
+      - PORT=5000
+    volumes:
+      - nightlio_data:/app/data
+    networks:
+      - big_bear_nightlio_network
+  big-bear-nightlio-frontend:
+    container_name: big-bear-nightlio-frontend
+    image: ghcr.io/shirsakm/nightlio-frontend:0.1.7@sha256:0a2bd8ec3eefe6adfa79f4809bc57c9ef2d3094dcece13f7d3c5309bacfcc117
+    restart: unless-stopped
+    environment:
+      - API_URL=http://big-bear-nightlio-api:5000
+    ports:
+      - "5173:80"
+    depends_on:
+      - big-bear-nightlio-api
+    networks:
+      - big_bear_nightlio_network
+
+networks:
+  big_bear_nightlio_network:
+    driver: bridge
+
+volumes:
+  nightlio_data:
+    name: nightlio_data
+    driver: local


### PR DESCRIPTION
Adds Nightlio (https://github.com/shirsakm/nightlio) per #3030 — privacy-first mood tracker and journal, two-container stack (Flask API + nginx frontend) on port 5173.

- app.json passes validate-apps.sh; images pinned to 0.1.7 digests, amd64+arm64
- Stack live-tested: UI 200, /api proxied healthy, SQLite persisted in named volume

Closes #3030

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Nightlio as a new two-container catalog application with a Flask API, nginx frontend, and persistent SQLite storage.

- Defines catalog metadata, deployment inputs, and compatibility settings for six supported platforms.
- Pins the API and frontend images to Nightlio 0.1.7 digests.
- Exposes the frontend on port 5173 and proxies API traffic over a private Compose network.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the advertised Portainer deployment inputs are wired into the API container instead of being silently ignored.

Portainer exposes configuration fields generated from app.json, but the copied Compose stack fixes the corresponding environment variables to literals, so user-supplied secrets and feature settings do not affect the deployed service.

**Files Needing Attention:** apps/nightlio/docker-compose.yml and apps/nightlio/app.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/nightlio/app.json | Adds Nightlio’s catalog metadata, deployment inputs, ports, persistence declaration, and platform compatibility settings. |
| apps/nightlio/docker-compose.yml | Adds the API/frontend stack and persistent data volume, but hard-coded environment assignments prevent generated Portainer inputs from configuring the API. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  User[User browser] -->|HTTP :5173| Frontend[nginx frontend]
  Frontend -->|/api via :5000| API[Flask API]
  API -->|SQLite| Volume[(nightlio_data)]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/nightlio/docker-compose.yml:9-14
**Deployment inputs remain hard-coded**

When a Portainer user changes a secret, CORS origin, feature flag, or account identity through the generated template form, this copied Compose file still assigns the bundled literals because it contains no variable references, causing the submitted configuration to be silently ignored and the API to retain the default values.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(nightlio): add Nightlio mood tracke..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/442416cd3c545f153b14a83d3092976f2d4e6af4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55973840)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)

<!-- /greptile_comment -->