### PR TITLE
feat: add BookOrbit app

### DIFF
--- a/apps/bookorbit/app.json
+++ b/apps/bookorbit/app.json
@@ -1,0 +1,202 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "bookorbit",
+    "name": "BookOrbit",
+    "description": "BookOrbit is a self-hosted library and reading platform for ebooks, PDFs, audiobooks, and comics. It syncs progress and highlights across the web reader, Kobo, and KOReader, with metadata lookup, reading stats, OPDS, and multi-user OIDC support.",
+    "tagline": "Your self-hosted reading space for books, audiobooks, and comics",
+    "version": "2.7.0",
+    "author": "BigBearTechWorld",
+    "developer": "bookorbit",
+    "category": "BigBearCasaOS",
+    "license": "AGPL-3.0",
+    "homepage": "https://bookorbit.app",
+    "source": "big-bear-universal",
+    "created": "2026-08-23T00:00:00Z",
+    "updated": "2026-08-23T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/bookorbit.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/bookorbit.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://bookorbit.app/installation",
+    "repository": "https://github.com/bookorbit/bookorbit",
+    "issues": "https://github.com/bookorbit/bookorbit/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "app",
+    "default_port": "3000",
+    "main_image": "ghcr.io/bookorbit/bookorbit",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "APP_URL",
+        "default": "http://[YOUR_CASAOS_LAN_IP]:3000",
+        "description": "Public URL used by emails and Kobo endpoints - replace [YOUR_CASAOS_LAN_IP] with your server IP (required)",
+        "required": true
+      },
+      {
+        "name": "POSTGRES_USER",
+        "default": "bookorbit",
+        "description": "PostgreSQL username (required)",
+        "required": true
+      },
+      {
+        "name": "POSTGRES_PASSWORD",
+        "default": "7b0aee8dc43c518eef646e2d",
+        "description": "PostgreSQL password - CHANGE THIS IN PRODUCTION (required)",
+        "required": true
+      },
+      {
+        "name": "POSTGRES_DB",
+        "default": "bookorbit",
+        "description": "PostgreSQL database name (required)",
+        "required": true
+      },
+      {
+        "name": "JWT_SECRET",
+        "default": "cd94b64e8c98c7e5cab21ebc9c1e82e739c770d0f00f2626def2987942167c4e",
+        "description": "Secret used to sign login tokens - CHANGE THIS IN PRODUCTION (required)",
+        "required": true
+      },
+      {
+        "name": "SETUP_BOOTSTRAP_TOKEN",
+        "default": "1ba75f44baee64b32d1af876cc38e2b6",
+        "description": "One-time token required to complete the setup wizard (required)",
+        "required": true
+      },
+      {
+        "name": "PUID",
+        "default": "1000",
+        "description": "Runtime UID for files written to app data folders - match your books folder owner on NAS (optional)",
+        "required": false
+      },
+      {
+        "name": "PGID",
+        "default": "1000",
+        "description": "Runtime GID for files written to app data folders - match your books folder owner on NAS (optional)",
+        "required": false
+      },
+      {
+        "name": "LIBRARY_BROWSE_ROOT",
+        "default": "/books",
+        "description": "Container folder where the library picker starts instead of / (optional)",
+        "required": false
+      },
+      {
+        "name": "BOOK_DOCK_PATH",
+        "default": "",
+        "description": "Container path for the automated ingestion drop folder (optional)",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/books",
+        "description": "Book library folder - point this at your existing book files"
+      },
+      {
+        "container": "/data",
+        "description": "Application data directory"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Web UI"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": {
+        "en_us": "📚 BOOKORBIT SETUP\n\n1. Place your book files in the ./books folder next to the compose file, or point the bind mount at an existing library path.\n2. Update APP_URL to your server's actual address after install so Kobo sync and emails work.\n3. After starting, open http://your-server-ip:3000 and complete setup using SETUP_BOOTSTRAP_TOKEN from docker-compose.yml.\n\nThe app container runs read-only with dropped capabilities for security."
+      },
+      "after_install": {
+        "en_us": "Access the web UI at http://your-server-ip:3000. Create libraries from your /books folder and add users in Settings."
+      }
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3000",
+      "volume_mappings": {
+        "bookorbit_data": "/DATA/AppData/$AppID/data",
+        "bookorbit_postgresql": "/DATA/AppData/$AppID/postgresql"
+      },
+      "port": "3000",
+      "category": "Others"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "3000"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "bookorbit_data": "data",
+        "bookorbit_postgresql": "postgresql"
+      },
+      "port": "3000"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3000"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "3000"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "bookorbit_data": "data",
+        "bookorbit_postgresql": "postgresql"
+      },
+      "port": "10301"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "books",
+    "ebooks",
+    "audiobooks",
+    "comics",
+    "reading",
+    "library"
+  ]
+}

--- a/apps/bookorbit/docker-compose.yml
+++ b/apps/bookorbit/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       SETUP_BOOTSTRAP_TOKEN: 1ba75f44baee64b32d1af876cc38e2b6
       PUID: "1000"
       PGID: "1000"
+      LIBRARY_BROWSE_ROOT: /books
+      BOOK_DOCK_PATH: ""
     depends_on:
       postgres:
         condition: service_healthy

--- a/apps/bookorbit/docker-compose.yml
+++ b/apps/bookorbit/docker-compose.yml
@@ -1,0 +1,81 @@
+name: big-bear-bookorbit
+
+services:
+  app:
+    container_name: big-bear-bookorbit
+    image: ghcr.io/bookorbit/bookorbit:2.7.0@sha256:0f46241c54ba7cd07ddf7dc519386a29c98dd0f3679cebc9ca35f3305dc79e69
+    restart: unless-stopped
+    init: true
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+      APP_URL: http://[YOUR_CASAOS_LAN_IP]:3000
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: bookorbit
+      POSTGRES_PASSWORD: 7b0aee8dc43c518eef646e2d
+      POSTGRES_DB: bookorbit
+      JWT_SECRET: cd94b64e8c98c7e5cab21ebc9c1e82e739c770d0f00f2626def2987942167c4e
+      SETUP_BOOTSTRAP_TOKEN: 1ba75f44baee64b32d1af876cc38e2b6
+      PUID: "1000"
+      PGID: "1000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./books:/books
+      - bookorbit_data:/data
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    stop_grace_period: 30s
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "const p=process.env.PORT||3000;fetch('http://127.0.0.1:'+p+'/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  postgres:
+    container_name: big-bear-bookorbit-postgres
+    image: pgvector/pgvector:pg18@sha256:2ba9ca5f2e7daa0f0e7723cba1ee9167bab54efd3640516a44ac1a928dd67e7a
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: bookorbit
+      POSTGRES_PASSWORD: 7b0aee8dc43c518eef646e2d
+      POSTGRES_DB: bookorbit
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - bookorbit_postgresql:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bookorbit -d bookorbit"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+volumes:
+  bookorbit_data:
+    name: bookorbit_data
+    driver: local
+  bookorbit_postgresql:
+    name: bookorbit_postgresql
+    driver: local


### PR DESCRIPTION
Closes #2901

- Adds BookOrbit v2.7.0 universal app definition (ebooks, PDFs, audiobooks, comics)
- Schema validation passes; converts cleanly to all 6 platforms
- Image digests pinned and verified



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a BookOrbit 2.7.0 universal catalog package for deployment across six supported platforms.
- Defines BookOrbit metadata, installation inputs, storage, ports, and platform compatibility.
- Adds the application and PostgreSQL services with pinned images, persistent volumes, health checks, and container hardening.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until installations stop sharing the publicly disclosed authentication and setup secrets.

Current HEAD still publishes BookOrbit on host port 3000 with fixed JWT_SECRET and SETUP_BOOTSTRAP_TOKEN values that conversion preserves across distributed platform definitions, leaving the previously reported authentication boundary failure outstanding.

**Files Needing Attention:** apps/bookorbit/docker-compose.yml, apps/bookorbit/app.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/bookorbit/app.json | Defines BookOrbit catalog metadata, deployment inputs, UI guidance, and compatibility settings for six platforms. |
| apps/bookorbit/docker-compose.yml | Defines the BookOrbit and PostgreSQL runtime services, persistence, health checks, and security settings. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Catalog[BookOrbit universal package] --> Metadata[app.json]
    Catalog --> Compose[docker-compose.yml]
    Compose --> App[BookOrbit service :3000]
    Compose --> DB[(PostgreSQL with pgvector)]
    App --> DB
    Metadata --> Platforms[CasaOS / Portainer / Runtipi / Dockge / Cosmos / Umbrel]
```

<sub>Reviews (2): Last reviewed commit: ["fix: pass LIBRARY\_BROWSE\_ROOT and BOOK\_D..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/944a25fe212bf2a276f1dd5f9173022ebc325909) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56030209)</sub>

<!-- /greptile_comment -->