### PR TITLE
Add Domainlocker app from issue #2900

### DIFF
--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -9,17 +9,17 @@
     "author": "BigBearTechWorld",
     "developer": "lissy93",
     "category": "BigBearCasaOS",
-    "license": "",
+    "license": "MIT",
     "homepage": "https://hub.docker.com/r/lissy93/domain-locker",
     "source": "big-bear-universal",
     "created": "2026-08-23T00:00:00Z",
     "updated": "2026-08-23T00:00:00Z"
   },
   "visual": {
-    "icon": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png",
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/domain-locker.png",
     "thumbnail": "",
     "screenshots": [],
-    "logo": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png"
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/domain-locker.png"
   },
   "resources": {
     "youtube": "",
@@ -34,7 +34,7 @@
       "arm64"
     ],
     "platform": "linux",
-    "main_service": "domain-locker",
+    "main_service": "app",
     "default_port": "8083",
     "main_image": "ghcr.io/lissy93/domain-locker",
     "compose_file": "docker-compose.yml"
@@ -42,30 +42,54 @@
   "deployment": {
     "environment_variables": [
       {
-        "name": "TZ",
-        "default": "",
-        "description": "Timezone",
+        "name": "DL_ENV_TYPE",
+        "default": "selfHosted",
+        "description": "Environment type",
         "required": false
       },
       {
-        "name": "DOMAIN_LOCKER_PORT",
-        "default": "8083",
-        "description": "Port for Domain Locker",
+        "name": "DL_PG_HOST",
+        "default": "postgres",
+        "description": "Postgres host",
+        "required": false
+      },
+      {
+        "name": "DL_PG_PORT",
+        "default": "5432",
+        "description": "Postgres port",
+        "required": false
+      },
+      {
+        "name": "DL_PG_USER",
+        "default": "postgres",
+        "description": "Postgres user",
+        "required": false
+      },
+      {
+        "name": "DL_PG_PASSWORD",
+        "default": "changeme2420",
+        "description": "Postgres password",
+        "required": false
+      },
+      {
+        "name": "DL_PG_NAME",
+        "default": "domain_locker",
+        "description": "Postgres database name",
         "required": false
       }
     ],
     "volumes": [
       {
-        "container": "/data",
-        "description": "Container Path: /data"
+        "container": "/var/lib/postgresql/data",
+        "description": "Postgres data directory"
       }
     ],
     "ports": [
       {
-        "container": "8080",
+        "container": "3000",
         "host": "8083",
         "protocol": "tcp",
-        "description": "Container Port: 8080"
+        "description": "Web UI"
       }
     ]
   },
@@ -79,7 +103,7 @@
       "supported": true,
       "port_map": "8083",
       "volume_mappings": {
-        "domainlocker_data": "/DATA/AppData/$AppID/data"
+        "domainlocker_postgres_data": "/DATA/AppData/$AppID/postgres_data"
       }
     },
     "portainer": {
@@ -99,7 +123,7 @@
         "arm64"
       ],
       "volume_mappings": {
-        "domainlocker_data": "data"
+        "domainlocker_postgres_data": "postgres_data"
       }
     },
     "dockge": {
@@ -115,7 +139,7 @@
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "domainlocker_data": "data"
+        "domainlocker_postgres_data": "postgres_data"
       },
       "port": "8083"
     }

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -5,7 +5,7 @@
     "name": "Domain Locker",
     "description": "🌐 The all-in-one tool, for keeping track of your domain name portfolio. Got domain names? Get Domain Locker!",
     "tagline": "Domain Locker",
-    "version": "v0.2.4",
+    "version": "0.2.4",
     "author": "BigBearTechWorld",
     "developer": "lissy93",
     "category": "BigBearCasaOS",
@@ -80,9 +80,7 @@
       "port_map": "8083",
       "volume_mappings": {
         "domainlocker_data": "/DATA/AppData/$AppID/data"
-      },
-      "port": "8083",
-      "category": "Tools"
+      }
     },
     "portainer": {
       "supported": true,
@@ -91,8 +89,7 @@
         "BigBearCasaOS",
         "selfhosted"
       ],
-      "administrator_only": false,
-      "port": "8083"
+      "administrator_only": false
     },
     "runtipi": {
       "supported": true,
@@ -103,19 +100,16 @@
       ],
       "volume_mappings": {
         "domainlocker_data": "data"
-      },
-      "port": "8083"
+      }
     },
     "dockge": {
       "supported": true,
-      "file_based": true,
-      "port": "8083"
+      "file_based": true
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
-      "routes_required": true,
-      "port": "8083"
+      "routes_required": true
     },
     "umbrel": {
       "supported": true,

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -35,7 +35,7 @@
     ],
     "platform": "linux",
     "main_service": "domain-locker",
-    "default_port": "8080",
+    "default_port": "8083",
     "main_image": "ghcr.io/lissy93/domain-locker",
     "compose_file": "docker-compose.yml"
   },
@@ -49,7 +49,7 @@
       },
       {
         "name": "DOMAIN_LOCKER_PORT",
-        "default": "8080",
+        "default": "8083",
         "description": "Port for Domain Locker",
         "required": false
       }
@@ -77,11 +77,11 @@
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "8080",
+      "port_map": "8083",
       "volume_mappings": {
         "domainlocker_data": "/DATA/AppData/$AppID/data"
       },
-      "port": "8080",
+      "port": "8083",
       "category": "Tools"
     },
     "portainer": {
@@ -92,7 +92,7 @@
         "selfhosted"
       ],
       "administrator_only": false,
-      "port": "8080"
+      "port": "8083"
     },
     "runtipi": {
       "supported": true,
@@ -104,18 +104,18 @@
       "volume_mappings": {
         "domainlocker_data": "data"
       },
-      "port": "8080"
+      "port": "8083"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "8080"
+      "port": "8083"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "8080"
+      "port": "8083"
     },
     "umbrel": {
       "supported": true,
@@ -123,7 +123,7 @@
       "volume_mappings": {
         "domainlocker_data": "data"
       },
-      "port": "8080"
+      "port": "8083"
     }
   },
   "tags": [

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -141,7 +141,8 @@
       "volume_mappings": {
         "domainlocker_postgres_data": "postgres_data"
       },
-      "port": "8083"
+      "port": "10203",
+      "app_port": "3000"
     }
   },
   "tags": [

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -1,0 +1,137 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "domainlocker",
+    "name": "Domain Locker",
+    "description": "🌐 The all-in-one tool, for keeping track of your domain name portfolio. Got domain names? Get Domain Locker!",
+    "tagline": "Domain Locker",
+    "version": "v0.2.4",
+    "author": "BigBearTechWorld",
+    "developer": "lissy93",
+    "category": "BigBearCasaOS",
+    "license": "",
+    "homepage": "https://hub.docker.com/r/lissy93/domain-locker",
+    "source": "big-bear-universal",
+    "created": "2026-08-23T00:00:00Z",
+    "updated": "2026-08-23T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/Lissy93/domain-locker",
+    "repository": "https://github.com/Lissy93/domain-locker",
+    "issues": "https://github.com/bigbeartechworld/big-bear-universal-apps/issues/2900",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "domain-locker",
+    "default_port": "8080",
+    "main_image": "ghcr.io/lissy93/domain-locker",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "TZ",
+        "default": "",
+        "description": "Timezone",
+        "required": false
+      },
+      {
+        "name": "DOMAIN_LOCKER_PORT",
+        "default": "8080",
+        "description": "Port for Domain Locker",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Container Path: /data"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8080",
+        "host": "8080",
+        "protocol": "tcp",
+        "description": "Container Port: 8080"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8080",
+      "volume_mappings": {
+        "domainlocker_data": "/DATA/AppData/$AppID/data"
+      },
+      "port": "8080",
+      "category": "Tools"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "8080"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "domainlocker_data": "data"
+      },
+      "port": "8080"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8080"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8080"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "domainlocker_data": "data"
+      },
+      "port": "8080"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "container",
+    "domain"
+  ]
+}

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -63,7 +63,7 @@
     "ports": [
       {
         "container": "8080",
-        "host": "8080",
+        "host": "8180",
         "protocol": "tcp",
         "description": "Container Port: 8080"
       }

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -63,7 +63,7 @@
     "ports": [
       {
         "container": "8080",
-        "host": "8180",
+        "host": "8083",
         "protocol": "tcp",
         "description": "Container Port: 8080"
       }

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -51,15 +51,16 @@ services:
         condition: service_healthy
     networks:
       - big_bear_domainlocker_network
-    command: >
-      /bin/sh -c "
+    command:
+      - /bin/sh
+      - -c
+      - |
         apk add --no-cache curl &&
-        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo \"ERROR: domain-updater failed at $$(date)\" >&2' > /etc/crontabs/root &&
-        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo \"ERROR: expiration-reminders failed at $$(date)\" >&2' >> /etc/crontabs/root &&
-        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo \"ERROR: domain-monitor failed at $$(date)\" >&2' >> /etc/crontabs/root &&
-        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo \"ERROR: cleanup-monitor-data failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo "ERROR: domain-updater failed at $(date)" >&2' > /etc/crontabs/root &&
+        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo "ERROR: expiration-reminders failed at $(date)" >&2' >> /etc/crontabs/root &&
+        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo "ERROR: domain-monitor failed at $(date)" >&2' >> /etc/crontabs/root &&
+        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo "ERROR: cleanup-monitor-data failed at $(date)" >&2' >> /etc/crontabs/root &&
         crond -f -L /dev/stdout
-      "
 networks:
   big_bear_domainlocker_network:
     driver: bridge

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: domain-locker # Name of the running container
     image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 8080:8080
+      - 8180:8080
     volumes: # Mounting directories for persistent data storage
       - domainlocker_data:/data
     restart: unless-stopped # Policy to restart unless stopped

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: domain-locker # Name of the running container
     image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 8180:8080
+      - 8083:8080
     volumes: # Mounting directories for persistent data storage
       - domainlocker_data:/data
     restart: unless-stopped # Policy to restart unless stopped

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -1,25 +1,69 @@
 # Configuration for big-bear-domainlocker setup
 name: big-bear-domainlocker
-# Service definitions for the big-bear-domainlocker application
 services:
-  # Main Domain Locker service configuration
-  domain-locker:
-    container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
-    ports: # Mapping ports from the host OS to the container
-      - 8083:8080
-    volumes: # Mounting directories for persistent data storage
-      - domainlocker_data:/data
-    restart: unless-stopped # Policy to restart unless stopped
-    # Networks to be attached to the container
+  postgres:
+    container_name: domain-locker-db
+    image: postgres:15-alpine@sha256:fe0737ba566a2c5b2a28f34433c0a423261900ec17b9bf7ad115e1aae7e57f1b
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: domain_locker
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeme2420
+    volumes:
+      - domainlocker_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d domain_locker"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - big_bear_domainlocker_network
-  # Networks to be attached to the container
+  app:
+    container_name: domain-locker-app
+    image: ghcr.io/lissy93/domain-locker:0.2.4@sha256:883716e301b7353327cc82d6bd8e4c5f5d2a93d7f8175e0c10e1d0855f5c4094
+    restart: unless-stopped
+    environment:
+      DL_ENV_TYPE: selfHosted
+      DL_PG_HOST: postgres
+      DL_PG_PORT: 5432
+      DL_PG_USER: postgres
+      DL_PG_PASSWORD: changeme2420
+      DL_PG_NAME: domain_locker
+    ports:
+      - 8083:3000
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+    networks:
+      - big_bear_domainlocker_network
+  updater:
+    container_name: domain-locker-updater
+    image: alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - big_bear_domainlocker_network
+    command: >
+      /bin/sh -c "
+        apk add --no-cache curl &&
+        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo \"ERROR: domain-updater failed at $$(date)\" >&2' > /etc/crontabs/root &&
+        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo \"ERROR: expiration-reminders failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo \"ERROR: domain-monitor failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo \"ERROR: cleanup-monitor-data failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        crond -f -L /dev/stdout
+      "
 networks:
-  # Defines network configurations for the services
   big_bear_domainlocker_network:
-    driver: bridge # Uses bridge network driver
+    driver: bridge
 volumes:
-  domainlocker_data:
-    name: domainlocker_data
+  domainlocker_postgres_data:
+    name: domainlocker_postgres_data
     driver: local

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Domain Locker service configuration
   domain-locker:
     container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker:v0.2.4@sha256:latest # Image to be used
+    image: ghcr.io/lissy93/domain-locker@v0.2.4 # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 8080:8080
     volumes: # Mounting directories for persistent data storage

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -1,0 +1,25 @@
+# Configuration for big-bear-domainlocker setup
+name: big-bear-domainlocker
+# Service definitions for the big-bear-domainlocker application
+services:
+  # Main Domain Locker service configuration
+  domain-locker:
+    container_name: domain-locker # Name of the running container
+    image: ghcr.io/lissy93/domain-locker:v0.2.4@sha256:latest # Image to be used
+    ports: # Mapping ports from the host OS to the container
+      - 8080:8080
+    volumes: # Mounting directories for persistent data storage
+      - domainlocker_data:/data
+    restart: unless-stopped # Policy to restart unless stopped
+    # Networks to be attached to the container
+    networks:
+      - big_bear_domainlocker_network
+  # Networks to be attached to the container
+networks:
+  # Defines network configurations for the services
+  big_bear_domainlocker_network:
+    driver: bridge # Uses bridge network driver
+volumes:
+  domainlocker_data:
+    name: domainlocker_data
+    driver: local

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Domain Locker service configuration
   domain-locker:
     container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker@v0.2.4 # Image to be used
+    image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 8080:8080
     volumes: # Mounting directories for persistent data storage


### PR DESCRIPTION
Adds Domain Locker app from issue #2900 (PLS Add Domainlocker)















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Domain Locker as a multi-service catalog application with PostgreSQL, scheduled maintenance tasks, persistent storage, and support for all catalog targets. The latest changes correct the source image references, database service, and Compose listener mapping, but generated Runtipi and proxy configurations remain inconsistent.
- Adds Domain Locker metadata and platform compatibility declarations.
- Defines the application, PostgreSQL, and scheduled updater services.
- Pins all container images by tag and digest.
- Configures persistent database storage and health-gated startup.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because its generated Runtipi stack has an undefined database dependency and Runtipi/Cosmos route to the wrong internal port.

Runtipi conversion renames the first `postgres` service without rewriting `app.depends_on`, preventing that stack from starting, while Runtipi and Cosmos derive internal routing from host port 8083 instead of Domain Locker's container listener on port 3000.

**Files Needing Attention:** apps/domainlocker/docker-compose.yml and apps/domainlocker/app.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/domainlocker/app.json | Adds catalog and platform metadata, but using host port 8083 as the default causes Runtipi and Cosmos to target the wrong internal listener. |
| apps/domainlocker/docker-compose.yml | Adds a complete multi-service deployment, but placing PostgreSQL first causes Runtipi conversion to rename it and leave a dangling application dependency. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/domainlocker/docker-compose.yml:4
**Runtipi leaves undefined database dependency**

When Domain Locker is converted for Runtipi, the converter renames the first declared service, `postgres`, to the application ID without updating `app`'s `depends_on: postgres` reference. The generated Compose stack therefore depends on a nonexistent service and fails validation before startup.

### Issue 2
apps/domainlocker/app.json:38
**Platform proxies target host port**

When Domain Locker is converted for Runtipi or Cosmos, `technical.default_port` supplies internal port 8083 even though the container listens on port 3000. Those platforms route requests to a port with no listener, leaving the generated UI unreachable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Fix: convert updater command to YAML arr..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/ae89d18069b66ca293fe8d9acdf798f919109895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56031434)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)

<!-- /greptile_comment -->