### PR TITLE
fix: deduplicate Umbrel host ports (10204-10212)

### DIFF
--- a/apps/dashy-v4/app.json
+++ b/apps/dashy-v4/app.json
@@ -122,7 +122,7 @@
       "volume_mappings": {
         "dashy-v4_user-data": "user-data"
       },
-      "port": "10032"
+      "port": "10205"
     }
   },
   "tags": [

--- a/apps/discopanel/app.json
+++ b/apps/discopanel/app.json
@@ -139,7 +139,7 @@
     "umbrel": {
       "supported": true,
       "manifest_version": 1,
-      "port": "10080"
+      "port": "10204"
     }
   },
   "tags": [

--- a/apps/eufy-security-ws/app.json
+++ b/apps/eufy-security-ws/app.json
@@ -142,7 +142,7 @@
       "volume_mappings": {
         "eufy-security-ws_data": "data"
       },
-      "port": "3000"
+      "port": "10211"
     }
   },
   "tags": [

--- a/apps/netalertx-v26/app.json
+++ b/apps/netalertx-v26/app.json
@@ -118,7 +118,7 @@
         "netalertx-v26_config": "config",
         "netalertx-v26_db": "db"
       },
-      "port": "10444"
+      "port": "10212"
     }
   },
   "tags": [

--- a/apps/odysseus/app.json
+++ b/apps/odysseus/app.json
@@ -145,7 +145,7 @@
         "odysseus_searxng": "searxng",
         "odysseus_ntfy": "ntfy"
       },
-      "port": "10070",
+      "port": "10207",
       "app_port": "7000"
     }
   },

--- a/apps/planka-v2/app.json
+++ b/apps/planka-v2/app.json
@@ -314,7 +314,7 @@
         "planka-v2_project-background-images": "project-background-images",
         "planka-v2_user-avatars": "user-avatars"
       },
-      "port": "10139"
+      "port": "10206"
     }
   },
   "tags": [

--- a/apps/rocket-chat-v8/app.json
+++ b/apps/rocket-chat-v8/app.json
@@ -126,7 +126,7 @@
       "volume_mappings": {
         "rocket-chat-v8_db": "db"
       },
-      "port": "10157"
+      "port": "10209"
     }
   },
   "tags": [

--- a/apps/rustfs/app.json
+++ b/apps/rustfs/app.json
@@ -150,7 +150,7 @@
         "rustfs_data": "data",
         "rustfs_logs": "logs"
       },
-      "port": "10170"
+      "port": "10210"
     }
   },
   "tags": [

--- a/apps/vikunja-v2/app.json
+++ b/apps/vikunja-v2/app.json
@@ -154,7 +154,7 @@
         "vikunja-v2_files": "files",
         "vikunja-v2_mysql": "mysql"
       },
-      "port": "8082"
+      "port": "10208"
     }
   },
   "tags": [


### PR DESCRIPTION
9 apps had conflicting `compatibility.umbrel.port` values. Umbrel uses explicit host ports (unlike CasaOS/Runtipi which remap), so these must be globally unique.

| App | Old Port | New Port |
|-----|----------|----------|
| discopanel | 10080 | 10204 |
| dashy-v4 | 10032 | 10205 |
| planka-v2 | 10139 | 10206 |
| odysseus | 10070 | 10207 |
| vikunja-v2 | 8082 | 10208 |
| rocket-chat-v8 | 10157 | 10209 |
| rustfs | 10170 | 10210 |
| eufy-security-ws | 3000 | 10211 |
| netalertx-v26 | 10444 | 10212 |

244 apps now have 0 Umbrel port duplicates. All validated with `validate-apps.sh`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR assigns distinct Umbrel host ports 10204-10212 to nine catalog entries to eliminate duplicate explicit port assignments.
- Updates only `compatibility.umbrel.port` metadata.
- Uses a unique value for each changed entry.
- Leaves application runtime and non-Umbrel platform configuration unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new Umbrel host ports are unique within the catalog, and the conversion path consumes these overrides consistently when generating supported Umbrel packages.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashy-v4/app.json | Reassigns the Umbrel host port from 10032 to the unique value 10205. |
| apps/discopanel/app.json | Reassigns the Umbrel host port from 10080 to the unique value 10204. |
| apps/eufy-security-ws/app.json | Changes the configured Umbrel port from 3000 to 10211; the setting remains inert while Umbrel support is disabled. |
| apps/netalertx-v26/app.json | Reassigns the Umbrel host port from 10444 to the unique value 10212. |
| apps/odysseus/app.json | Reassigns the Umbrel host port from 10070 to 10207 while preserving the separate internal app port. |
| apps/planka-v2/app.json | Reassigns the Umbrel host port from 10139 to the unique value 10206. |
| apps/rocket-chat-v8/app.json | Reassigns the Umbrel host port from 10157 to the unique value 10209. |
| apps/rustfs/app.json | Reassigns the Umbrel host port from 10170 to the unique value 10210. |
| apps/vikunja-v2/app.json | Reassigns the Umbrel host port from 8082 to the unique value 10208. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: deduplicate Umbrel host ports (1020..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/11abb5d5deee23310c4bfb1dc5e422bdbef1e94c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56058290)</sub>

<!-- /greptile_comment -->