### PR TITLE
Add Popcornn - Modern Torrent Streaming Platform

### DIFF
--- a/apps/popcornn/app.json
+++ b/apps/popcornn/app.json
@@ -3,17 +3,17 @@
   "metadata": {
     "id": "popcornn",
     "name": "Popcornn",
-    "description": "Modern torrent streaming platform with HLS transcoding, library management, and hardware acceleration support. Stream movies and TV shows directly from torrents.",
+    "description": "Modern torrent streaming platform with web client (bobdivx/popcorn-frontend:1.3.56) and Rust server (bobdivx/popcorn-backend:1.2.51). Includes HLS transcoding, library management, hardware acceleration support, and FlareSolverr for Cloudflare bypass. Stream movies and TV shows directly from torrents with a beautiful React interface.",
     "tagline": "Self-hosted torrent streaming & library manager",
-    "version": "0.1.0",
+    "version": "1.2.51",
     "author": "BigBearTechWorld",
     "developer": "bobdivx",
     "category": "BigBearCasaOS",
     "license": "MIT",
-    "homepage": "https://github.com/bobdivx/popcorn-server",
+    "homepage": "https://popcornn.app",
     "source": "big-bear-universal",
     "created": "2026-08-25T08:25:00Z",
-    "updated": "2026-08-25T08:25:00Z"
+    "updated": "2026-08-26T13:19:00Z"
   },
   "visual": {
     "icon": "https://raw.githubusercontent.com/bobdivx/popcorn-server/main/assets/logo.png",
@@ -24,7 +24,7 @@
   "resources": {
     "youtube": "",
     "documentation": "https://github.com/bobdivx/popcorn-server/blob/main/README.md",
-    "repository": "https://github.com/bobdivx/popcorn-server",
+    "repository": "https://github.com/bobdivx/popcorn-client,https://github.com/bobdivx/popcorn-server",
     "issues": "https://github.com/bobdivx/popcorn-server/issues",
     "support": "https://community.bigbeartechworld.com/"
   },
@@ -33,23 +33,47 @@
       "amd64"
     ],
     "platform": "linux",
-    "main_service": "popcornn-client",
-    "default_port": "3001",
+    "main_service": "big-bear-popcornn-client",
+    "default_port": "4325",
     "main_image": "bobdivx/popcorn-frontend",
     "compose_file": "docker-compose.yml"
   },
   "deployment": {
     "environment_variables": [
       {
+        "name": "PUBLIC_BACKEND_URL",
+        "default": "",
+        "description": "Public backend URL (e.g., https://popcornn.example.com/api) - leave empty for local access",
+        "required": false
+      },
+      {
+        "name": "API_USERNAME",
+        "default": "admin",
+        "description": "Backend API username for authentication",
+        "required": true
+      },
+      {
+        "name": "API_PASSWORD",
+        "default": "popcorn_password_secure",
+        "description": "Backend API password - CHANGE THIS AFTER INSTALLATION",
+        "required": true
+      },
+      {
         "name": "BACKEND_URL",
         "default": "http://big-bear-popcornn-server:3000",
-        "description": "Backend API URL",
+        "description": "Internal backend API URL",
         "required": true
       },
       {
         "name": "FLARESOLVERR_URL",
         "default": "http://big-bear-popcornn-flaresolverr:8191",
         "description": "FlareSolverr URL for Cloudflare bypass",
+        "required": true
+      },
+      {
+        "name": "DOWNLOAD_DIR",
+        "default": "/app/downloads",
+        "description": "Download directory for torrents",
         "required": true
       },
       {
@@ -61,22 +85,18 @@
     ],
     "volumes": [
       {
-        "container": "/app/config",
-        "description": "Configuration files"
+        "container": "/app/.data",
+        "description": "Application data and database"
       },
       {
-        "container": "/app/cache",
-        "description": "Cache directory for torrents"
-      },
-      {
-        "container": "/app/data",
-        "description": "Data directory for media library"
+        "container": "/app/downloads",
+        "description": "Downloaded torrents and media files"
       }
     ],
     "ports": [
       {
-        "container": "3001",
-        "host": "3001",
+        "container": "80",
+        "host": "4325",
         "protocol": "tcp",
         "description": "Frontend web interface"
       },
@@ -87,10 +107,16 @@
         "description": "Backend API"
       },
       {
-        "container": "8191",
-        "host": "8191",
+        "container": "4240",
+        "host": "4240",
         "protocol": "tcp",
-        "description": "FlareSolverr service"
+        "description": "Torrent TCP port"
+      },
+      {
+        "container": "4240",
+        "host": "4240",
+        "protocol": "udp",
+        "description": "Torrent UDP port"
       }
     ]
   },
@@ -99,23 +125,25 @@
     "path": "",
     "tips": {
       "before_install": [
+        "This package installs BOTH the web client (React frontend) and the Rust server backend, plus FlareSolverr for Cloudflare bypass",
+        "Access the web interface on port 4325, backend API on port 3000",
+        "Default login: admin / popcorn_password_secure - CHANGE THIS PASSWORD after installation",
+        "Forward ports 4240 TCP and 4240 UDP for optimal torrent connectivity",
         "Popcornn requires at least 2GB RAM for smooth operation",
-        "GPU passthrough is optional but recommended for hardware acceleration",
-        "FlareSolverr service is required to bypass Cloudflare protection on torrent sites"
+        "GPU passthrough is optional but recommended for hardware acceleration"
       ]
     }
   },
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "3001",
+      "port_map": "4325",
       "volume_mappings": {
-        "popcornn_config": "/DATA/AppData/$AppID/config",
-        "popcornn_cache": "/DATA/AppData/$AppID/cache",
-        "popcornn_data": "/DATA/AppData/$AppID/data"
+        "popcornn_data": "/DATA/AppData/$AppID/data",
+        "popcornn_downloads": "/DATA/AppData/$AppID/downloads"
       },
       "youtube": "",
-      "port": "3001",
+      "port": "4325",
       "category": "Media"
     },
     "portainer": {
@@ -128,7 +156,7 @@
         "Streaming"
       ],
       "administrator_only": false,
-      "port": "3001"
+      "port": "4325"
     },
     "runtipi": {
       "supported": true,
@@ -137,32 +165,30 @@
         "amd64"
       ],
       "volume_mappings": {
-        "popcornn_config": "config",
-        "popcornn_cache": "cache",
-        "popcornn_data": "data"
+        "popcornn_data": "data",
+        "popcornn_downloads": "downloads"
       },
-      "port": "3001"
+      "port": "4325"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "3001"
+      "port": "4325"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "3001"
+      "port": "4325"
     },
     "umbrel": {
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "popcornn_config": "config",
-        "popcornn_cache": "cache",
-        "popcornn_data": "data"
+        "popcornn_data": "data",
+        "popcornn_downloads": "downloads"
       },
-      "port": "3001"
+      "port": "4325"
     }
   },
   "tags": [

--- a/apps/popcornn/app.json
+++ b/apps/popcornn/app.json
@@ -1,0 +1,183 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "popcornn",
+    "name": "Popcornn",
+    "description": "Modern torrent streaming platform with HLS transcoding, library management, and hardware acceleration support. Stream movies and TV shows directly from torrents.",
+    "tagline": "Self-hosted torrent streaming & library manager",
+    "version": "0.1.0",
+    "author": "BigBearTechWorld",
+    "developer": "bobdivx",
+    "category": "BigBearCasaOS",
+    "license": "MIT",
+    "homepage": "https://github.com/bobdivx/popcorn-server",
+    "source": "big-bear-universal",
+    "created": "2026-08-25T08:25:00Z",
+    "updated": "2026-08-25T08:25:00Z"
+  },
+  "visual": {
+    "icon": "https://raw.githubusercontent.com/bobdivx/popcorn-server/main/assets/logo.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://raw.githubusercontent.com/bobdivx/popcorn-server/main/assets/logo.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/bobdivx/popcorn-server/blob/main/README.md",
+    "repository": "https://github.com/bobdivx/popcorn-server",
+    "issues": "https://github.com/bobdivx/popcorn-server/issues",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64"
+    ],
+    "platform": "linux",
+    "main_service": "popcornn-client",
+    "default_port": "3001",
+    "main_image": "bobdivx/popcorn-frontend",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "BACKEND_URL",
+        "default": "http://big-bear-popcornn-server:3000",
+        "description": "Backend API URL",
+        "required": true
+      },
+      {
+        "name": "FLARESOLVERR_URL",
+        "default": "http://big-bear-popcornn-flaresolverr:8191",
+        "description": "FlareSolverr URL for Cloudflare bypass",
+        "required": true
+      },
+      {
+        "name": "RUST_LOG",
+        "default": "info",
+        "description": "Log level (error, warn, info, debug, trace)",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/app/config",
+        "description": "Configuration files"
+      },
+      {
+        "container": "/app/cache",
+        "description": "Cache directory for torrents"
+      },
+      {
+        "container": "/app/data",
+        "description": "Data directory for media library"
+      }
+    ],
+    "ports": [
+      {
+        "container": "3001",
+        "host": "3001",
+        "protocol": "tcp",
+        "description": "Frontend web interface"
+      },
+      {
+        "container": "3000",
+        "host": "3000",
+        "protocol": "tcp",
+        "description": "Backend API"
+      },
+      {
+        "container": "8191",
+        "host": "8191",
+        "protocol": "tcp",
+        "description": "FlareSolverr service"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {
+      "before_install": [
+        "Popcornn requires at least 2GB RAM for smooth operation",
+        "GPU passthrough is optional but recommended for hardware acceleration",
+        "FlareSolverr service is required to bypass Cloudflare protection on torrent sites"
+      ]
+    }
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "3001",
+      "volume_mappings": {
+        "popcornn_config": "/DATA/AppData/$AppID/config",
+        "popcornn_cache": "/DATA/AppData/$AppID/cache",
+        "popcornn_data": "/DATA/AppData/$AppID/data"
+      },
+      "youtube": "",
+      "port": "3001",
+      "category": "Media"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "Media",
+        "Video",
+        "Streaming"
+      ],
+      "administrator_only": false,
+      "port": "3001"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64"
+      ],
+      "volume_mappings": {
+        "popcornn_config": "config",
+        "popcornn_cache": "cache",
+        "popcornn_data": "data"
+      },
+      "port": "3001"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "3001"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "3001"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "popcornn_config": "config",
+        "popcornn_cache": "cache",
+        "popcornn_data": "data"
+      },
+      "port": "3001"
+    }
+  },
+  "tags": [
+    "media",
+    "streaming",
+    "torrent",
+    "movies",
+    "tv-shows",
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "container",
+    "hls",
+    "transcoding",
+    "rust"
+  ]
+}

--- a/apps/popcornn/docker-compose.yml
+++ b/apps/popcornn/docker-compose.yml
@@ -8,64 +8,68 @@ services:
   # Frontend service - React web interface
   popcornn-client:
     container_name: big-bear-popcornn-client
-    image: bobdivx/popcorn-frontend:latest
+    image: bobdivx/popcorn-frontend:1.3.56
     restart: unless-stopped
     ports:
-      - "3001:3001"
-    network_mode: bridge
+      - "4325:80"
     environment:
       - BACKEND_URL=http://big-bear-popcornn-server:3000
+      - PUBLIC_BACKEND_URL=
+      - HOST=0.0.0.0
+      - NODE_ENV=production
+      - PORT=80
     depends_on:
       - popcornn-server
+    networks:
+      - big_bear_popcornn_network
 
   # Backend service - Rust streaming server
   popcornn-server:
     container_name: big-bear-popcornn-server
-    image: bobdivx/popcorn-backend:dev
+    image: bobdivx/popcorn-backend:1.2.51
     restart: unless-stopped
     ports:
       - "3000:3000"
-    network_mode: bridge
-    volumes:
-      - popcornn_config:/app/config
-      - popcornn_cache:/app/cache
-      - popcornn_data:/app/data
+      - "4240:4240"
+      - "4240:4240/udp"
     environment:
+      - API_USERNAME=admin
+      - API_PASSWORD=popcorn_password_secure
+      - DOWNLOAD_DIR=/app/downloads
       - FLARESOLVERR_URL=http://big-bear-popcornn-flaresolverr:8191
+      - SERVER_HOST=0.0.0.0
+      - SERVER_PORT=3000
       - RUST_LOG=info
+      - RUN_AS_ROOT=1
+    volumes:
+      - popcornn_data:/app/.data
+      - popcornn_downloads:/app/downloads
     depends_on:
       - popcornn-flaresolverr
-    # Uncomment for NVIDIA GPU support
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [compute, video]
+    networks:
+      - big_bear_popcornn_network
 
   # FlareSolverr service - Bypass Cloudflare protection
   popcornn-flaresolverr:
     container_name: big-bear-popcornn-flaresolverr
-    image: ghcr.io/flaresolverr/flaresolverr:latest
+    image: ghcr.io/flaresolverr/flaresolverr:v3.4.6
     restart: unless-stopped
-    ports:
-      - "8191:8191"
-    network_mode: bridge
     environment:
       - LOG_LEVEL=info
-      - LOG_HTML=false
-      - CAPTCHA_SOLVER=none
-      - TZ=Europe/London
+    networks:
+      - big_bear_popcornn_network
+
+# Networks
+networks:
+  big_bear_popcornn_network:
+    name: big_bear_popcornn_network
+    driver: bridge
 
 # Volumes for persistent data
 volumes:
-  popcornn_config:
-    name: popcornn_config
-    driver: local
-  popcornn_cache:
-    name: popcornn_cache
-    driver: local
   popcornn_data:
     name: popcornn_data
+    driver: local
+  popcornn_downloads:
+    name: popcornn_downloads
     driver: local

--- a/apps/popcornn/docker-compose.yml
+++ b/apps/popcornn/docker-compose.yml
@@ -1,0 +1,71 @@
+# Configuration for Popcornn - Modern Torrent Streaming Platform
+
+# Application Name
+name: big-bear-popcornn
+
+# Services used in the application
+services:
+  # Frontend service - React web interface
+  popcornn-client:
+    container_name: big-bear-popcornn-client
+    image: bobdivx/popcorn-frontend:latest
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    network_mode: bridge
+    environment:
+      - BACKEND_URL=http://big-bear-popcornn-server:3000
+    depends_on:
+      - popcornn-server
+
+  # Backend service - Rust streaming server
+  popcornn-server:
+    container_name: big-bear-popcornn-server
+    image: bobdivx/popcorn-backend:dev
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    network_mode: bridge
+    volumes:
+      - popcornn_config:/app/config
+      - popcornn_cache:/app/cache
+      - popcornn_data:/app/data
+    environment:
+      - FLARESOLVERR_URL=http://big-bear-popcornn-flaresolverr:8191
+      - RUST_LOG=info
+    depends_on:
+      - popcornn-flaresolverr
+    # Uncomment for NVIDIA GPU support
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [compute, video]
+
+  # FlareSolverr service - Bypass Cloudflare protection
+  popcornn-flaresolverr:
+    container_name: big-bear-popcornn-flaresolverr
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    restart: unless-stopped
+    ports:
+      - "8191:8191"
+    network_mode: bridge
+    environment:
+      - LOG_LEVEL=info
+      - LOG_HTML=false
+      - CAPTCHA_SOLVER=none
+      - TZ=Europe/London
+
+# Volumes for persistent data
+volumes:
+  popcornn_config:
+    name: popcornn_config
+    driver: local
+  popcornn_cache:
+    name: popcornn_cache
+    driver: local
+  popcornn_data:
+    name: popcornn_data
+    driver: local


### PR DESCRIPTION
## Description

This PR adds **Popcornn** to the Big Bear Universal Apps catalog.

Popcornn is a modern, self-hosted media streaming platform that combines torrent streaming capabilities with a beautiful library manager. It's a complete rewrite of Popcorn Time in Rust, optimized for home server deployments.

## App Features

- 🎬 **Torrent Streaming**: Stream movies and TV shows directly from torrents without waiting for downloads
- 📚 **Library Management**: Beautiful interface to browse and organize your media collection
- 🔍 **Content Discovery**: Search across multiple torrent providers (YTS, 1337x, TPB, RARBG)
- 🎯 **Multi-language Support**: Content available in multiple languages
- 🚀 **Hardware Acceleration**: NVIDIA GPU support for HLS transcoding (NVDEC/NVENC)
- 📱 **Modern UI**: Clean, responsive interface built with React
- 🔐 **Privacy First**: Self-hosted, no data collection, full control over your content

## Technical Details

- **Backend**: Rust-based streaming server with librqbit torrent engine
- **Frontend**: React-based web interface
- **FlareSolverr Integration**: Bypass Cloudflare protection on torrent sites
- **Docker Compose**: Three-service architecture (frontend, backend, flaresolverr)
- **GPU Support**: Optional NVIDIA GPU acceleration for transcoding
- **Persistence**: Separate volumes for config, cache, and data

## Docker Images

- **Frontend**: `bobdivx/popcorn-frontend:latest`
- **Backend**: `bobdivx/popcorn-backend:dev` (includes latest CUDA fixes)
- **FlareSolverr**: `ghcr.io/flaresolverr/flaresolverr:latest`

## Links

- **GitHub**: https://github.com/bobdivx/popcorn-server
- **Documentation**: https://github.com/bobdivx/popcorn-server/blob/main/README.md
- **Docker Hub**: https://hub.docker.com/r/bobdivx/popcorn-frontend

## Validation

✅ Validation passed: `./scripts/validate-apps.sh -a popcornn`
✅ Platform conversion successful: `./scripts/convert-to-platforms.sh -a popcornn`

Platforms supported:
- CasaOS
- Portainer
- Runtipi
- Dockge
- Cosmos
- Umbrel

## Testing

The app has been tested on:
- CasaOS 0.4.x
- ZimaOS
- Docker 20.10+
- With and without NVIDIA GPU

## License

MIT License

---

**Ready for review!** This app fills a gap in the Big Bear catalog for torrent streaming and media library management.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the Popcornn catalog package and updates the original proposal by pinning all three container images and placing the services on a shared Compose network.
- Defines frontend, backend, and FlareSolverr services with persistent application and download volumes.
- Adds catalog metadata and compatibility declarations for six deployment platforms.
- Replaces the previously mutable image tags with explicit release tags.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because supported platform conversion can still break the internal backend and FlareSolverr connections.

The shared network repairs native Compose service connectivity, but the internal URLs remain tied to container names that Umbrel conversion removes without rewriting those URLs.

**Files Needing Attention:** apps/popcornn/docker-compose.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/popcornn/app.json | Adds Popcornn’s catalog metadata, deployment settings, and platform compatibility declarations. |
| apps/popcornn/docker-compose.yml | Pins the three service images and adds a shared network, but converted deployments can still lose the container-name DNS aliases referenced by the internal URLs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Popcornn package: pin image versions..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/9f6897c1ebaf1d1a0752615cb3a66fa41e91f3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56575839)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)
- Knowledge Base — [Application version management](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-version-management.md)
</details>


<!-- /greptile_comment -->