### PR TITLE
fix: replace nonexistent image tags in 3 apps

### DIFF
--- a/apps/immich-aio-alpine/app.json
+++ b/apps/immich-aio-alpine/app.json
@@ -5,7 +5,7 @@
     "name": "Immich AIO Alpine",
     "description": "AIO Alpine. Self-hosted photo and video storage.",
     "tagline": "Immich All In One Alpine",
-    "version": "2.0.0-alpine",
+    "version": "2.7.5",
     "author": "BigBearTechWorld",
     "developer": "imagegenius",
     "category": "BigBearCasaOS",

--- a/apps/immich-aio-alpine/docker-compose.yml
+++ b/apps/immich-aio-alpine/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Immich Server service configuration
   big-bear-immich-aio-alpine:
     container_name: big-bear-immich-aio-alpine # Name of the running container
-    image: ghcr.io/imagegenius/immich:2.0.0-alpine # Image to be used
+    image: ghcr.io/imagegenius/immich:2.7.5@sha256:4012699ba6c1b2c2ec4f4b50eb8e50b1c3af040d1ae2fb5dedcabebe055776ad # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 2283:8080
     volumes: # Mounting directories for persistent data storage

--- a/apps/rocket-chat-v8/docker-compose.yml
+++ b/apps/rocket-chat-v8/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   # Service: db
   # This service runs the MongoDB 8.2 database required by Rocket.Chat v8.
   db:
-    image: mongo:8.2.0
+    image: mongo:8.2.12@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
     container_name: big-bear-rocketchat-v8-db
     volumes:
       # Persistent storage for MongoDB

--- a/apps/warracker/app.json
+++ b/apps/warracker/app.json
@@ -5,7 +5,7 @@
     "name": "Warracker",
     "description": "A self-hosted warranty tracker",
     "tagline": "A self-hosted warranty tracker",
-    "version": "9.9.3",
+    "version": "1.0.2",
     "author": "BigBearTechWorld",
     "developer": "sassanix",
     "category": "BigBearCasaOS",

--- a/apps/warracker/docker-compose.yml
+++ b/apps/warracker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # Name of the container
     container_name: big-bear-warracker
     # Image to be used for the container specifies the btop version and source
-    image: ghcr.io/sassanix/warracker/main:9.9.3
+    image: ghcr.io/sassanix/warracker/main:1.0.2@sha256:9a0aa0e57a4635e0955cea4d13abe89fd65d10625ee95836ec14ae0789884f22
     # Container restart policy - restarts the container unless manually stopped
     restart: unless-stopped
     # Run the container in privileged mode to allow access to system metrics

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -82,10 +82,10 @@ assert_eq "$(resolve_runtipi_main_image "$UNIT_DIR/buildonly.yml" "louislam/upti
 cat > "$UNIT_DIR/unpinned.yml" <<'YAML'
 services:
   app:
-    image: ghcr.io/imagegenius/immich:2.0.0-alpine
+    image: ghcr.io/imagegenius/immich:2.7.5
 YAML
-UNPINNED_OUT="$(resolve_runtipi_main_image "$UNIT_DIR/unpinned.yml" "ghcr.io/imagegenius/immich" immich-aio-alpine "ghcr.io/imagegenius/immich:2.0.0")"
-assert_eq "$UNPINNED_OUT" "ghcr.io/imagegenius/immich:2.0.0-alpine" "unpinned match verbatim"
+UNPINNED_OUT="$(resolve_runtipi_main_image "$UNIT_DIR/unpinned.yml" "ghcr.io/imagegenius/immich" immich-aio-alpine "ghcr.io/imagegenius/immich:2.7.5")"
+assert_eq "$UNPINNED_OUT" "ghcr.io/imagegenius/immich:2.7.5" "unpinned match verbatim"
 
 WARN_ON_MATCH="$(resolve_runtipi_main_image "$UNIT_DIR/unpinned.yml" "ghcr.io/imagegenius/immich" immich-aio-alpine "x:1" 2>&1 | grep -c 'WARNING' || true)"
 assert_eq "$WARN_ON_MATCH" "0" "no warning on successful match"
@@ -175,11 +175,16 @@ rm -rf "$TMP_NM"
 section "e2e: legitimately unpinned upstream, no warning, no error"
 TMP_IM="$(mktemp -d)"
 IM_LOG="$TMP_IM/run.log"
-bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a immich-aio-alpine -o "$TMP_IM/out" > "$IM_LOG" 2>&1
+cp -R "$REPO/apps/." "$TMP_IM/apps/"
+export IM_UNPINNED="ghcr.io/imagegenius/immich:2.7.5"
+yq eval -i ".services.\"big-bear-immich-aio-alpine\".image = strenv(IM_UNPINNED) | .services.\"big-bear-immich-aio-alpine\".image style=\"\"" \
+  "$TMP_IM/apps/immich-aio-alpine/docker-compose.yml"
+bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a immich-aio-alpine -i "$TMP_IM/apps" -o "$TMP_IM/out" > "$IM_LOG" 2>&1
 IM_EXIT=$?
 assert_eq "$IM_EXIT" "0" "immich-aio-alpine run exits 0"
+assert_eq "$(printf '%s' "$IM_UNPINNED" | grep -c '@' || true)" "0" "immich-aio-alpine fixture is genuinely unpinned"
 assert_eq "$(jq -r '.services[0].image' "$TMP_IM/out/runtipi/immich-aio-alpine/docker-compose.json")" \
-  "ghcr.io/imagegenius/immich:2.0.0-alpine" "immich-aio-alpine unpinned image copied verbatim"
+  "$IM_UNPINNED" "immich-aio-alpine unpinned image copied verbatim"
 assert_eq "$(grep -c 'WARNING' "$IM_LOG" || true)" "0" "immich-aio-alpine emits no warning"
 rm -rf "$TMP_IM"
 


### PR DESCRIPTION
Fixes #2493

Three image tags returned 404, making each app uninstallable at pull. Bumped each to a verified-existing tag and digest-pinned it.

| App | Was | Now |
|---|---|---|
| immich-aio-alpine | `2.0.0-alpine` (no such variant upstream) | `2.7.5@sha256:4012699b…` |
| warracker | `9.9.3` (no 9.x line) | `1.0.2@sha256:9a0aa0e5…` |
| rocket-chat-v8 (db) | `mongo:8.2.0` (8.2 starts at 8.2.1) | `8.2.12@sha256:e0ce8c35…` |

Pinning removed the repo's last unpinned main image, which the runtipi converter test used as its "legitimately unpinned upstream" fixture — that case now builds a synthetic fixture, guarded so it can't silently go vacuous.

Verified: all 3 refs resolve live; casaos/umbrel/runtipi suites 61/17/46 pass; 248/248 apps validate; 0 version mismatches.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces three unavailable container image tags with digest-pinned releases and aligns the affected catalog metadata. It also converts the Runtipi unpinned-image test into an isolated synthetic fixture with checks that the fixture remains unpinned and uses the successful match path.

- Updates Immich AIO Alpine to 2.7.5 and Warracker to 1.0.2, keeping metadata versions aligned with their Compose images.
- Updates Rocket.Chat v8’s MongoDB service to a pinned 8.2.12 image.
- Preserves Runtipi coverage for legitimately unpinned upstream images without relying on an unpinned production catalog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the corrected image references and revised Runtipi fixture remaining consistent with the catalog and conversion contracts.

The metadata versions match the updated main image tags, the MongoDB change remains within Rocket.Chat v8’s documented 8.2 line, and the synthetic Runtipi fixture verifies both unpinned-image preservation and absence of fallback warnings.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/immich-aio-alpine/app.json | Aligns the displayed application version with the new 2.7.5 Compose image. |
| apps/immich-aio-alpine/docker-compose.yml | Replaces the nonexistent Alpine-tagged image with a digest-pinned 2.7.5 release while retaining the existing runtime configuration. |
| apps/warracker/app.json | Aligns catalog metadata with the corrected Warracker 1.0.2 image. |
| apps/warracker/docker-compose.yml | Replaces the unavailable 9.9.3 reference with a digest-pinned 1.0.2 release. |
| apps/rocket-chat-v8/docker-compose.yml | Replaces the unavailable MongoDB patch tag with a digest-pinned 8.2.12 image without changing service configuration or storage. |
| scripts/tests/test-convert-runtipi.sh | Builds a temporary unpinned Immich fixture and verifies conversion preserves it without invoking the warning-producing fallback. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace nonexistent image tags in 3..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/e39d4d51c160a7d54b06bba0ad3b7b19c71023f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56818660)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)
- Knowledge Base — [Catalog quality controls](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/catalog-quality-controls.md)
- Knowledge Base — [Conversion test suite](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/conversion-test-suite.md)
- Knowledge Base — [Application version management](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-version-management.md)
</details>


<!-- /greptile_comment -->