### PR TITLE
fix(libretranslate): run as root so container can write its data dirs

### DIFF
--- a/apps/libretranslate/docker-compose.yml
+++ b/apps/libretranslate/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     image: libretranslate/libretranslate:v1.9.6@sha256:1de2d7056bb8ad607a412f4563d9abe324ff632b43b5be9428bcc8e213aebb32
     # Container restart policy
     restart: unless-stopped
+    # Required: image's non-root user cannot write platform-created data dirs
+    user: root
     environment:
       - LT_API_KEYS=true # Enables API key authentication for the LibreTranslate service.
       - LT_API_KEYS_DB_PATH=/app/db/api_keys.db # Specifies the path within the container where API keys are stored.


### PR DESCRIPTION
Image runs as non-root uid 1032, but platforms create the mounted data dirs root-owned — so model downloads and Prometheus setup failed, which left `LT_THREADS` unset and made gunicorn exit on `-w/--workers`.

Verified with `docker compose up`: healthy, `/translate` returns `hola mundo`, both error strings gone. `validate-apps.sh` 248/248.

Note: Runtipi installs are still broken — its converter drops `user`/`environment`/`volumes`. Pre-existing, affects 10 apps, tracked separately.

Closes #1277

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes LibreTranslate run as root so platform-created persistent directories remain writable and model/metrics initialization can complete.

- Adds a service-level `user: root` override to the canonical Compose definition.
- The override propagates to supported platform conversions.
- Permanent root execution leaves a non-blocking containment concern after initialization.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to drop root privileges after initializing persistent-directory ownership.

The configuration fixes the documented startup failure and is preserved by platform conversion, but the network-facing process remains root for its full lifetime and can modify persistent application data with elevated privileges.

**Files Needing Attention:** apps/libretranslate/docker-compose.yml

<details open><summary><h3>Security Review</h3></summary>

The network-facing service now runs permanently as root without compensating containment. No concrete host-escape or authorization exploit is established, but dropping privileges after correcting volume ownership would reduce the impact of an application compromise.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/libretranslate/docker-compose.yml | Adds the root runtime override needed for writable persistent directories, while retaining elevated privileges longer than initialization requires. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/libretranslate/docker-compose.yml:17
**Root persists beyond initialization**

The network-facing LibreTranslate process now runs as root for its entire lifetime, so a process compromise gains elevated access to the writable API-key and model-data volumes. Restricting root to initialization and then dropping to UID 1032 would preserve the directory-ownership fix while reducing the blast radius.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(libretranslate): run as root so cont..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/966705030d3cf2eacee0c636b485b8e33e5fd2dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56818942)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Universal application catalog](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-catalog.md)
- Knowledge Base — [Application package structure](https://app.greptile.com/bigbeartechworld/-/custom-context/knowledge-base/bigbeartechworld/big-bear-universal-apps/-/docs/application-package-structure.md)

<!-- /greptile_comment -->