### PR TITLE
Add Domainlocker and fix Runtipi main-service promotion

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run Umbrel converter test suite
         run: bash scripts/tests/test-convert-umbrel.sh
 
+      - name: Run Runtipi converter test suite
+        run: bash scripts/tests/test-convert-runtipi.sh
+
   validate-apps:
     name: Validate App Definitions
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq
+          sudo apt-get install -y jq imagemagick
           sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,6 +11,8 @@ jobs:
   converter-tests:
     name: Converter Test Suite
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -9,17 +9,17 @@
     "author": "BigBearTechWorld",
     "developer": "lissy93",
     "category": "BigBearCasaOS",
-    "license": "",
+    "license": "MIT",
     "homepage": "https://hub.docker.com/r/lissy93/domain-locker",
     "source": "big-bear-universal",
     "created": "2026-08-23T00:00:00Z",
     "updated": "2026-08-23T00:00:00Z"
   },
   "visual": {
-    "icon": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png",
+    "icon": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/domain-locker.png",
     "thumbnail": "",
     "screenshots": [],
-    "logo": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png"
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/domain-locker.png"
   },
   "resources": {
     "youtube": "",
@@ -34,7 +34,7 @@
       "arm64"
     ],
     "platform": "linux",
-    "main_service": "domain-locker",
+    "main_service": "app",
     "default_port": "8083",
     "main_image": "ghcr.io/lissy93/domain-locker",
     "compose_file": "docker-compose.yml"
@@ -42,30 +42,54 @@
   "deployment": {
     "environment_variables": [
       {
-        "name": "TZ",
-        "default": "",
-        "description": "Timezone",
+        "name": "DL_ENV_TYPE",
+        "default": "selfHosted",
+        "description": "Environment type",
         "required": false
       },
       {
-        "name": "DOMAIN_LOCKER_PORT",
-        "default": "8083",
-        "description": "Port for Domain Locker",
+        "name": "DL_PG_HOST",
+        "default": "postgres",
+        "description": "Postgres host",
+        "required": false
+      },
+      {
+        "name": "DL_PG_PORT",
+        "default": "5432",
+        "description": "Postgres port",
+        "required": false
+      },
+      {
+        "name": "DL_PG_USER",
+        "default": "postgres",
+        "description": "Postgres user",
+        "required": false
+      },
+      {
+        "name": "DL_PG_PASSWORD",
+        "default": "changeme2420",
+        "description": "Postgres password",
+        "required": false
+      },
+      {
+        "name": "DL_PG_NAME",
+        "default": "domain_locker",
+        "description": "Postgres database name",
         "required": false
       }
     ],
     "volumes": [
       {
-        "container": "/data",
-        "description": "Container Path: /data"
+        "container": "/var/lib/postgresql/data",
+        "description": "Postgres data directory"
       }
     ],
     "ports": [
       {
-        "container": "8080",
+        "container": "3000",
         "host": "8083",
         "protocol": "tcp",
-        "description": "Container Port: 8080"
+        "description": "Web UI"
       }
     ]
   },
@@ -79,7 +103,7 @@
       "supported": true,
       "port_map": "8083",
       "volume_mappings": {
-        "domainlocker_data": "/DATA/AppData/$AppID/data"
+        "domainlocker_postgres_data": "/DATA/AppData/$AppID/postgres_data"
       }
     },
     "portainer": {
@@ -99,7 +123,7 @@
         "arm64"
       ],
       "volume_mappings": {
-        "domainlocker_data": "data"
+        "domainlocker_postgres_data": "postgres_data"
       }
     },
     "dockge": {
@@ -115,7 +139,7 @@
       "supported": true,
       "manifest_version": 1,
       "volume_mappings": {
-        "domainlocker_data": "data"
+        "domainlocker_postgres_data": "postgres_data"
       },
       "port": "8083"
     }

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -5,7 +5,7 @@
     "name": "Domain Locker",
     "description": "🌐 The all-in-one tool, for keeping track of your domain name portfolio. Got domain names? Get Domain Locker!",
     "tagline": "Domain Locker",
-    "version": "v0.2.4",
+    "version": "0.2.4",
     "author": "BigBearTechWorld",
     "developer": "lissy93",
     "category": "BigBearCasaOS",
@@ -80,9 +80,7 @@
       "port_map": "8083",
       "volume_mappings": {
         "domainlocker_data": "/DATA/AppData/$AppID/data"
-      },
-      "port": "8083",
-      "category": "Tools"
+      }
     },
     "portainer": {
       "supported": true,
@@ -91,8 +89,7 @@
         "BigBearCasaOS",
         "selfhosted"
       ],
-      "administrator_only": false,
-      "port": "8083"
+      "administrator_only": false
     },
     "runtipi": {
       "supported": true,
@@ -103,19 +100,16 @@
       ],
       "volume_mappings": {
         "domainlocker_data": "data"
-      },
-      "port": "8083"
+      }
     },
     "dockge": {
       "supported": true,
-      "file_based": true,
-      "port": "8083"
+      "file_based": true
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
-      "routes_required": true,
-      "port": "8083"
+      "routes_required": true
     },
     "umbrel": {
       "supported": true,

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -35,7 +35,7 @@
     ],
     "platform": "linux",
     "main_service": "domain-locker",
-    "default_port": "8080",
+    "default_port": "8083",
     "main_image": "ghcr.io/lissy93/domain-locker",
     "compose_file": "docker-compose.yml"
   },
@@ -49,7 +49,7 @@
       },
       {
         "name": "DOMAIN_LOCKER_PORT",
-        "default": "8080",
+        "default": "8083",
         "description": "Port for Domain Locker",
         "required": false
       }
@@ -77,11 +77,11 @@
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "8080",
+      "port_map": "8083",
       "volume_mappings": {
         "domainlocker_data": "/DATA/AppData/$AppID/data"
       },
-      "port": "8080",
+      "port": "8083",
       "category": "Tools"
     },
     "portainer": {
@@ -92,7 +92,7 @@
         "selfhosted"
       ],
       "administrator_only": false,
-      "port": "8080"
+      "port": "8083"
     },
     "runtipi": {
       "supported": true,
@@ -104,18 +104,18 @@
       "volume_mappings": {
         "domainlocker_data": "data"
       },
-      "port": "8080"
+      "port": "8083"
     },
     "dockge": {
       "supported": true,
       "file_based": true,
-      "port": "8080"
+      "port": "8083"
     },
     "cosmos": {
       "supported": true,
       "servapp": true,
       "routes_required": true,
-      "port": "8080"
+      "port": "8083"
     },
     "umbrel": {
       "supported": true,
@@ -123,7 +123,7 @@
       "volume_mappings": {
         "domainlocker_data": "data"
       },
-      "port": "8080"
+      "port": "8083"
     }
   },
   "tags": [

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -35,7 +35,7 @@
     ],
     "platform": "linux",
     "main_service": "app",
-    "default_port": "8083",
+    "default_port": "8180",
     "main_image": "ghcr.io/lissy93/domain-locker",
     "compose_file": "docker-compose.yml"
   },
@@ -87,7 +87,7 @@
     "ports": [
       {
         "container": "3000",
-        "host": "8083",
+        "host": "8180",
         "protocol": "tcp",
         "description": "Web UI"
       }
@@ -101,7 +101,7 @@
   "compatibility": {
     "casaos": {
       "supported": true,
-      "port_map": "8083",
+      "port_map": "8180",
       "volume_mappings": {
         "domainlocker_postgres_data": "/DATA/AppData/$AppID/postgres_data"
       },

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -141,7 +141,8 @@
       "volume_mappings": {
         "domainlocker_postgres_data": "postgres_data"
       },
-      "port": "8083"
+      "port": "10203",
+      "app_port": "3000"
     }
   },
   "tags": [

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -1,0 +1,137 @@
+{
+  "spec_version": "1.0",
+  "metadata": {
+    "id": "domainlocker",
+    "name": "Domain Locker",
+    "description": "🌐 The all-in-one tool, for keeping track of your domain name portfolio. Got domain names? Get Domain Locker!",
+    "tagline": "Domain Locker",
+    "version": "v0.2.4",
+    "author": "BigBearTechWorld",
+    "developer": "lissy93",
+    "category": "BigBearCasaOS",
+    "license": "",
+    "homepage": "https://hub.docker.com/r/lissy93/domain-locker",
+    "source": "big-bear-universal",
+    "created": "2026-08-23T00:00:00Z",
+    "updated": "2026-08-23T00:00:00Z"
+  },
+  "visual": {
+    "icon": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png",
+    "thumbnail": "",
+    "screenshots": [],
+    "logo": "https://cdn.jsdelivr.net/gh/lissy93/icons/png/domain-locker.png"
+  },
+  "resources": {
+    "youtube": "",
+    "documentation": "https://github.com/Lissy93/domain-locker",
+    "repository": "https://github.com/Lissy93/domain-locker",
+    "issues": "https://github.com/bigbeartechworld/big-bear-universal-apps/issues/2900",
+    "support": "https://community.bigbeartechworld.com/"
+  },
+  "technical": {
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "platform": "linux",
+    "main_service": "domain-locker",
+    "default_port": "8080",
+    "main_image": "ghcr.io/lissy93/domain-locker",
+    "compose_file": "docker-compose.yml"
+  },
+  "deployment": {
+    "environment_variables": [
+      {
+        "name": "TZ",
+        "default": "",
+        "description": "Timezone",
+        "required": false
+      },
+      {
+        "name": "DOMAIN_LOCKER_PORT",
+        "default": "8080",
+        "description": "Port for Domain Locker",
+        "required": false
+      }
+    ],
+    "volumes": [
+      {
+        "container": "/data",
+        "description": "Container Path: /data"
+      }
+    ],
+    "ports": [
+      {
+        "container": "8080",
+        "host": "8080",
+        "protocol": "tcp",
+        "description": "Container Port: 8080"
+      }
+    ]
+  },
+  "ui": {
+    "scheme": "http",
+    "path": "",
+    "tips": {}
+  },
+  "compatibility": {
+    "casaos": {
+      "supported": true,
+      "port_map": "8080",
+      "volume_mappings": {
+        "domainlocker_data": "/DATA/AppData/$AppID/data"
+      },
+      "port": "8080",
+      "category": "Tools"
+    },
+    "portainer": {
+      "supported": true,
+      "template_type": 2,
+      "categories": [
+        "BigBearCasaOS",
+        "selfhosted"
+      ],
+      "administrator_only": false,
+      "port": "8080"
+    },
+    "runtipi": {
+      "supported": true,
+      "tipi_version": 1,
+      "supported_architectures": [
+        "amd64",
+        "arm64"
+      ],
+      "volume_mappings": {
+        "domainlocker_data": "data"
+      },
+      "port": "8080"
+    },
+    "dockge": {
+      "supported": true,
+      "file_based": true,
+      "port": "8080"
+    },
+    "cosmos": {
+      "supported": true,
+      "servapp": true,
+      "routes_required": true,
+      "port": "8080"
+    },
+    "umbrel": {
+      "supported": true,
+      "manifest_version": 1,
+      "volume_mappings": {
+        "domainlocker_data": "data"
+      },
+      "port": "8080"
+    }
+  },
+  "tags": [
+    "selfhosted",
+    "docker",
+    "bigbear",
+    "bigbearcasaos",
+    "container",
+    "domain"
+  ]
+}

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -63,7 +63,7 @@
     "ports": [
       {
         "container": "8080",
-        "host": "8080",
+        "host": "8180",
         "protocol": "tcp",
         "description": "Container Port: 8080"
       }

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -63,7 +63,7 @@
     "ports": [
       {
         "container": "8080",
-        "host": "8180",
+        "host": "8083",
         "protocol": "tcp",
         "description": "Container Port: 8080"
       }

--- a/apps/domainlocker/app.json
+++ b/apps/domainlocker/app.json
@@ -104,7 +104,8 @@
       "port_map": "8083",
       "volume_mappings": {
         "domainlocker_postgres_data": "/DATA/AppData/$AppID/postgres_data"
-      }
+      },
+      "category": "Others"
     },
     "portainer": {
       "supported": true,

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -51,15 +51,16 @@ services:
         condition: service_healthy
     networks:
       - big_bear_domainlocker_network
-    command: >
-      /bin/sh -c "
+    command:
+      - /bin/sh
+      - -c
+      - |
         apk add --no-cache curl &&
-        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo \"ERROR: domain-updater failed at $$(date)\" >&2' > /etc/crontabs/root &&
-        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo \"ERROR: expiration-reminders failed at $$(date)\" >&2' >> /etc/crontabs/root &&
-        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo \"ERROR: domain-monitor failed at $$(date)\" >&2' >> /etc/crontabs/root &&
-        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo \"ERROR: cleanup-monitor-data failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo "ERROR: domain-updater failed at $(date)" >&2' > /etc/crontabs/root &&
+        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo "ERROR: expiration-reminders failed at $(date)" >&2' >> /etc/crontabs/root &&
+        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo "ERROR: domain-monitor failed at $(date)" >&2' >> /etc/crontabs/root &&
+        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo "ERROR: cleanup-monitor-data failed at $(date)" >&2' >> /etc/crontabs/root &&
         crond -f -L /dev/stdout
-      "
 networks:
   big_bear_domainlocker_network:
     driver: bridge

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: domain-locker # Name of the running container
     image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 8080:8080
+      - 8180:8080
     volumes: # Mounting directories for persistent data storage
       - domainlocker_data:/data
     restart: unless-stopped # Policy to restart unless stopped

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: domain-locker # Name of the running container
     image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 8180:8080
+      - 8083:8080
     volumes: # Mounting directories for persistent data storage
       - domainlocker_data:/data
     restart: unless-stopped # Policy to restart unless stopped

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -1,25 +1,69 @@
 # Configuration for big-bear-domainlocker setup
 name: big-bear-domainlocker
-# Service definitions for the big-bear-domainlocker application
 services:
-  # Main Domain Locker service configuration
-  domain-locker:
-    container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
-    ports: # Mapping ports from the host OS to the container
-      - 8083:8080
-    volumes: # Mounting directories for persistent data storage
-      - domainlocker_data:/data
-    restart: unless-stopped # Policy to restart unless stopped
-    # Networks to be attached to the container
+  postgres:
+    container_name: domain-locker-db
+    image: postgres:15-alpine@sha256:fe0737ba566a2c5b2a28f34433c0a423261900ec17b9bf7ad115e1aae7e57f1b
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: domain_locker
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeme2420
+    volumes:
+      - domainlocker_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d domain_locker"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - big_bear_domainlocker_network
-  # Networks to be attached to the container
+  app:
+    container_name: domain-locker-app
+    image: ghcr.io/lissy93/domain-locker:0.2.4@sha256:883716e301b7353327cc82d6bd8e4c5f5d2a93d7f8175e0c10e1d0855f5c4094
+    restart: unless-stopped
+    environment:
+      DL_ENV_TYPE: selfHosted
+      DL_PG_HOST: postgres
+      DL_PG_PORT: 5432
+      DL_PG_USER: postgres
+      DL_PG_PASSWORD: changeme2420
+      DL_PG_NAME: domain_locker
+    ports:
+      - 8083:3000
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+    networks:
+      - big_bear_domainlocker_network
+  updater:
+    container_name: domain-locker-updater
+    image: alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - big_bear_domainlocker_network
+    command: >
+      /bin/sh -c "
+        apk add --no-cache curl &&
+        echo '0 3 * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-updater || echo \"ERROR: domain-updater failed at $$(date)\" >&2' > /etc/crontabs/root &&
+        echo '0 4 * * * /usr/bin/curl -f -X POST http://app:3000/api/expiration-reminders || echo \"ERROR: expiration-reminders failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '*/15 * * * * /usr/bin/curl -f -X POST http://app:3000/api/domain-monitor || echo \"ERROR: domain-monitor failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        echo '0 2 * * 0 /usr/bin/curl -f -X POST http://app:3000/api/cleanup-monitor-data || echo \"ERROR: cleanup-monitor-data failed at $$(date)\" >&2' >> /etc/crontabs/root &&
+        crond -f -L /dev/stdout
+      "
 networks:
-  # Defines network configurations for the services
   big_bear_domainlocker_network:
-    driver: bridge # Uses bridge network driver
+    driver: bridge
 volumes:
-  domainlocker_data:
-    name: domainlocker_data
+  domainlocker_postgres_data:
+    name: domainlocker_postgres_data
     driver: local

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Domain Locker service configuration
   domain-locker:
     container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker:v0.2.4@sha256:latest # Image to be used
+    image: ghcr.io/lissy93/domain-locker@v0.2.4 # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 8080:8080
     volumes: # Mounting directories for persistent data storage

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -1,0 +1,25 @@
+# Configuration for big-bear-domainlocker setup
+name: big-bear-domainlocker
+# Service definitions for the big-bear-domainlocker application
+services:
+  # Main Domain Locker service configuration
+  domain-locker:
+    container_name: domain-locker # Name of the running container
+    image: ghcr.io/lissy93/domain-locker:v0.2.4@sha256:latest # Image to be used
+    ports: # Mapping ports from the host OS to the container
+      - 8080:8080
+    volumes: # Mounting directories for persistent data storage
+      - domainlocker_data:/data
+    restart: unless-stopped # Policy to restart unless stopped
+    # Networks to be attached to the container
+    networks:
+      - big_bear_domainlocker_network
+  # Networks to be attached to the container
+networks:
+  # Defines network configurations for the services
+  big_bear_domainlocker_network:
+    driver: bridge # Uses bridge network driver
+volumes:
+  domainlocker_data:
+    name: domainlocker_data
+    driver: local

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Main Domain Locker service configuration
   domain-locker:
     container_name: domain-locker # Name of the running container
-    image: ghcr.io/lissy93/domain-locker@v0.2.4 # Image to be used
+    image: ghcr.io/lissy93/domain-locker@v0.2.4@sha256:7a3ade47e8187193f92ea1ea5b913d699cc09635 # Image to be used
     ports: # Mapping ports from the host OS to the container
       - 8080:8080
     volumes: # Mounting directories for persistent data storage

--- a/apps/domainlocker/docker-compose.yml
+++ b/apps/domainlocker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       DL_PG_PASSWORD: changeme2420
       DL_PG_NAME: domain_locker
     ports:
-      - 8083:3000
+      - 8180:3000
     depends_on:
       postgres:
         condition: service_healthy

--- a/scripts/casaos-category-map.json
+++ b/scripts/casaos-category-map.json
@@ -46,6 +46,7 @@
   "dockhand": "Developer",
   "dockpeek": "Developer",
   "docmost": "Productivity",
+  "domainlocker": "Others",
   "dozzle": "Developer",
   "ejbca-ce": "Social",
   "ente": "Media",

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1154,9 +1154,31 @@ convert_to_runtipi() {
     yq eval 'del(.name)' -i "$compose_file"
     
     # Rename main service to app_name
-    local services=$(yq eval '.services | keys | .[0]' "$compose_file")
+    local services="${APP_MAIN_SERVICE:-}"
+    if [[ -z "$services" || "$services" == "null" ]] || [[ "$(yq eval ".services | has(\"$services\")" "$compose_file")" != "true" ]]; then
+        services=$(yq eval '.services | keys | .[0]' "$compose_file")
+    fi
     if [[ "$services" != "$app_name" ]]; then
         yq eval ".services.\"$app_name\" = .services.\"$services\" | del(.services.\"$services\")" -i "$compose_file"
+        local dep_svcs
+        dep_svcs=$(yq eval '.services | keys | .[]' "$compose_file")
+        while IFS= read -r dep_svc; do
+            [[ -z "$dep_svc" ]] && continue
+            local dep_type
+            dep_type=$(yq eval ".services[\"$dep_svc\"].depends_on | type" "$compose_file" 2>/dev/null || echo "null")
+            if [[ "$dep_type" == "!!map" ]] && [[ "$(yq eval ".services[\"$dep_svc\"].depends_on | has(\"$services\")" "$compose_file")" == "true" ]]; then
+                yq eval ".services[\"$dep_svc\"].depends_on.\"$app_name\" = .services[\"$dep_svc\"].depends_on.\"$services\" | del(.services[\"$dep_svc\"].depends_on.\"$services\")" -i "$compose_file"
+            elif [[ "$dep_type" == "!!seq" ]]; then
+                local dep_len
+                dep_len=$(yq eval ".services[\"$dep_svc\"].depends_on | length" "$compose_file")
+                local di
+                for ((di=0; di<dep_len; di++)); do
+                    if [[ "$(yq eval ".services[\"$dep_svc\"].depends_on[$di]" "$compose_file")" == "$services" ]]; then
+                        yq eval ".services[\"$dep_svc\"].depends_on[$di] = \"$app_name\"" -i "$compose_file"
+                    fi
+                done
+            fi
+        done <<< "$dep_svcs"
     fi
     
     # Set container name
@@ -1231,6 +1253,9 @@ convert_to_runtipi() {
         
         # Remove all custom networks and add only tipi_main_network
         yq eval 'del(.networks) | .networks.tipi_main_network.external = true' -i "$compose_file"
+        if [[ "$services" != "$app_name" ]]; then
+            yq eval ".services[\"$app_name\"].networks = {\"tipi_main_network\": {\"aliases\": [\"$services\"]}}" -i "$compose_file"
+        fi
     fi
     
     # Convert named volumes to ${APP_DATA_DIR} bind mounts for Runtipi

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1157,8 +1157,12 @@ runtipi_follow_service_rename() {
         if [[ "$link_type" == "!!seq" ]]; then
             dep_len=$(yq eval ".services[\"$dep_svc\"].links | length" "$compose_file")
             for ((di=0; di<dep_len; di++)); do
-                if [[ "$(yq eval ".services[\"$dep_svc\"].links[$di]" "$compose_file")" == "$old_name" ]]; then
+                local link_item
+                link_item=$(yq eval ".services[\"$dep_svc\"].links[$di]" "$compose_file")
+                if [[ "$link_item" == "$old_name" ]]; then
                     yq eval ".services[\"$dep_svc\"].links[$di] = \"$new_name\"" -i "$compose_file"
+                elif [[ "$link_item" == "$old_name:"* ]]; then
+                    yq eval ".services[\"$dep_svc\"].links[$di] = \"${new_name}:${link_item#"$old_name:"}\"" -i "$compose_file"
                 fi
             done
         fi

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1152,10 +1152,23 @@ runtipi_follow_service_rename() {
                 fi
             done
         fi
+        local link_type
+        link_type=$(yq eval ".services[\"$dep_svc\"].links | type" "$compose_file" 2>/dev/null || echo "null")
+        if [[ "$link_type" == "!!seq" ]]; then
+            dep_len=$(yq eval ".services[\"$dep_svc\"].links | length" "$compose_file")
+            for ((di=0; di<dep_len; di++)); do
+                if [[ "$(yq eval ".services[\"$dep_svc\"].links[$di]" "$compose_file")" == "$old_name" ]]; then
+                    yq eval ".services[\"$dep_svc\"].links[$di] = \"$new_name\"" -i "$compose_file"
+                fi
+            done
+        fi
     done <<< "$dep_svcs"
 
-    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"http://${old_name}:\"; \"http://${new_name}:\")" -i "$compose_file"
-    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"https://${old_name}:\"; \"https://${new_name}:\")" -i "$compose_file"
+    local old_re
+    old_re=$(printf '%s' "$old_name" | sed 's/[][(){}.^$|*+?\\]/\\&/g')
+    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"(https?://)${old_re}(:|/|$)\"; \"\${1}${new_name}\${2}\")" -i "$compose_file"
+    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"=${old_re}$\"; \"=${new_name}\")" -i "$compose_file"
+    yq eval "(.. | select(tag == \"!!str\" and . == \"${old_name}\")) |= \"${new_name}\"" -i "$compose_file"
 }
 
 # Convert to Runtipi format

--- a/scripts/convert-to-platforms.sh
+++ b/scripts/convert-to-platforms.sh
@@ -1131,6 +1131,33 @@ resolve_runtipi_main_image() {
     return 0
 }
 
+runtipi_follow_service_rename() {
+    local compose_file="$1"
+    local old_name="$2"
+    local new_name="$3"
+    [[ -z "$old_name" || "$old_name" == "null" || "$old_name" == "$new_name" ]] && return 0
+
+    local dep_svcs dep_svc dep_type dep_len di
+    dep_svcs=$(yq eval '.services | keys | .[]' "$compose_file")
+    while IFS= read -r dep_svc; do
+        [[ -z "$dep_svc" ]] && continue
+        dep_type=$(yq eval ".services[\"$dep_svc\"].depends_on | type" "$compose_file" 2>/dev/null || echo "null")
+        if [[ "$dep_type" == "!!map" ]] && [[ "$(yq eval ".services[\"$dep_svc\"].depends_on | has(\"$old_name\")" "$compose_file")" == "true" ]]; then
+            yq eval ".services[\"$dep_svc\"].depends_on.\"$new_name\" = .services[\"$dep_svc\"].depends_on.\"$old_name\" | del(.services[\"$dep_svc\"].depends_on.\"$old_name\")" -i "$compose_file"
+        elif [[ "$dep_type" == "!!seq" ]]; then
+            dep_len=$(yq eval ".services[\"$dep_svc\"].depends_on | length" "$compose_file")
+            for ((di=0; di<dep_len; di++)); do
+                if [[ "$(yq eval ".services[\"$dep_svc\"].depends_on[$di]" "$compose_file")" == "$old_name" ]]; then
+                    yq eval ".services[\"$dep_svc\"].depends_on[$di] = \"$new_name\"" -i "$compose_file"
+                fi
+            done
+        fi
+    done <<< "$dep_svcs"
+
+    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"http://${old_name}:\"; \"http://${new_name}:\")" -i "$compose_file"
+    yq eval "(.. | select(tag == \"!!str\")) |= sub(\"https://${old_name}:\"; \"https://${new_name}:\")" -i "$compose_file"
+}
+
 # Convert to Runtipi format
 convert_to_runtipi() {
     local app_name="$1"
@@ -1160,25 +1187,7 @@ convert_to_runtipi() {
     fi
     if [[ "$services" != "$app_name" ]]; then
         yq eval ".services.\"$app_name\" = .services.\"$services\" | del(.services.\"$services\")" -i "$compose_file"
-        local dep_svcs
-        dep_svcs=$(yq eval '.services | keys | .[]' "$compose_file")
-        while IFS= read -r dep_svc; do
-            [[ -z "$dep_svc" ]] && continue
-            local dep_type
-            dep_type=$(yq eval ".services[\"$dep_svc\"].depends_on | type" "$compose_file" 2>/dev/null || echo "null")
-            if [[ "$dep_type" == "!!map" ]] && [[ "$(yq eval ".services[\"$dep_svc\"].depends_on | has(\"$services\")" "$compose_file")" == "true" ]]; then
-                yq eval ".services[\"$dep_svc\"].depends_on.\"$app_name\" = .services[\"$dep_svc\"].depends_on.\"$services\" | del(.services[\"$dep_svc\"].depends_on.\"$services\")" -i "$compose_file"
-            elif [[ "$dep_type" == "!!seq" ]]; then
-                local dep_len
-                dep_len=$(yq eval ".services[\"$dep_svc\"].depends_on | length" "$compose_file")
-                local di
-                for ((di=0; di<dep_len; di++)); do
-                    if [[ "$(yq eval ".services[\"$dep_svc\"].depends_on[$di]" "$compose_file")" == "$services" ]]; then
-                        yq eval ".services[\"$dep_svc\"].depends_on[$di] = \"$app_name\"" -i "$compose_file"
-                    fi
-                done
-            fi
-        done <<< "$dep_svcs"
+        runtipi_follow_service_rename "$compose_file" "$services" "$app_name"
     fi
     
     # Set container name
@@ -1253,9 +1262,6 @@ convert_to_runtipi() {
         
         # Remove all custom networks and add only tipi_main_network
         yq eval 'del(.networks) | .networks.tipi_main_network.external = true' -i "$compose_file"
-        if [[ "$services" != "$app_name" ]]; then
-            yq eval ".services[\"$app_name\"].networks = {\"tipi_main_network\": {\"aliases\": [\"$services\"]}}" -i "$compose_file"
-        fi
     fi
     
     # Convert named volumes to ${APP_DATA_DIR} bind mounts for Runtipi

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -221,4 +221,83 @@ else
   echo "ok: full-run case skipped (set RUNTIPI_FULL_RUN=1 to enable)"
 fi
 
+section "e2e: main_service not first in compose is the promoted service"
+TMP_MS="$(mktemp -d)"
+bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a domainlocker -o "$TMP_MS/out" > "$TMP_MS/run.log" 2>&1
+assert_eq "$?" "0" "domainlocker run exits 0"
+MS_COMPOSE="$TMP_MS/out/runtipi/domainlocker/docker-compose.yml"
+assert_eq "$(yq eval '.services.domainlocker.image' "$MS_COMPOSE" | cut -d: -f1)" \
+  "ghcr.io/lissy93/domain-locker" "promoted service carries the app image, not the db"
+assert_eq "$(yq eval '.services.domainlocker.ports | length' "$MS_COMPOSE")" "1" \
+  "promoted service owns the host port"
+assert_eq "$(yq eval '.services.domainlocker.ports[0]' "$MS_COMPOSE")" '${APP_PORT}:3000' \
+  "promoted service port is rewritten to APP_PORT"
+assert_eq "$(yq eval '.services.postgres.ports // "none"' "$MS_COMPOSE")" "none" \
+  "non-main service keeps no host port"
+assert_eq "$(yq eval '[.services[] | select(.image | test("^postgres:"))] | length' "$MS_COMPOSE")" "1" \
+  "db service survives under its own name"
+assert_eq "$(yq eval '.services.updater.depends_on | has("domainlocker")' "$MS_COMPOSE")" "true" \
+  "updater depends_on follows the renamed main service"
+assert_eq "$(yq eval '.services.updater.depends_on | has("app")' "$MS_COMPOSE")" "false" \
+  "updater does not depend on the pre-rename service name"
+assert_eq "$(yq eval '.services.domainlocker.networks.tipi_main_network.aliases[0]' "$MS_COMPOSE")" "app" \
+  "renamed service keeps old name as a network alias"
+rm -rf "$TMP_MS"
+
+section "e2e: synthetic reordered compose still promotes main_service"
+TMP_RO="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_RO/apps/"
+cat > "$TMP_RO/apps/uptime-kuma/docker-compose.yml" <<'YAML'
+name: big-bear-uptime-kuma
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+  app:
+    image: louislam/uptime-kuma:2
+    restart: unless-stopped
+    ports:
+      - 9099:3001
+  worker:
+    image: alpine:3.20
+    restart: unless-stopped
+    depends_on:
+      - app
+YAML
+jq '.technical.main_service = "app" | .technical.main_image = "louislam/uptime-kuma"' \
+  "$TMP_RO/apps/uptime-kuma/app.json" > "$TMP_RO/apps/uptime-kuma/app.json.tmp" \
+  && mv "$TMP_RO/apps/uptime-kuma/app.json.tmp" "$TMP_RO/apps/uptime-kuma/app.json"
+bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a uptime-kuma -i "$TMP_RO/apps" -o "$TMP_RO/out" > "$TMP_RO/run.log" 2>&1
+RO_COMPOSE="$TMP_RO/out/runtipi/uptime-kuma/docker-compose.yml"
+assert_eq "$(yq eval '.services.uptime-kuma.image' "$RO_COMPOSE")" \
+  "louislam/uptime-kuma:2" "reordered compose promotes main_service, not first service"
+assert_eq "$(yq eval '.services.uptime-kuma.ports[0]' "$RO_COMPOSE")" '${APP_PORT}:3001' \
+  "reordered compose rewrites the promoted service port"
+assert_eq "$(yq eval '.services.db.image' "$RO_COMPOSE")" "postgres:15-alpine" \
+  "first service keeps its own name and image"
+assert_eq "$(yq eval '.services.worker.depends_on[0]' "$RO_COMPOSE")" "uptime-kuma" \
+  "list-form depends_on follows the renamed main service"
+rm -rf "$TMP_RO"
+
+section "e2e: absent main_service still falls back to first service"
+TMP_FB="$(mktemp -d)"
+cp -R "$REPO/apps/." "$TMP_FB/apps/"
+cat > "$TMP_FB/apps/uptime-kuma/docker-compose.yml" <<'YAML'
+name: big-bear-uptime-kuma
+services:
+  solo:
+    image: louislam/uptime-kuma:2
+    restart: unless-stopped
+    ports:
+      - 9099:3001
+YAML
+jq 'del(.technical.main_service) | .technical.main_image = "louislam/uptime-kuma"' \
+  "$TMP_FB/apps/uptime-kuma/app.json" > "$TMP_FB/apps/uptime-kuma/app.json.tmp" \
+  && mv "$TMP_FB/apps/uptime-kuma/app.json.tmp" "$TMP_FB/apps/uptime-kuma/app.json"
+bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a uptime-kuma -i "$TMP_FB/apps" -o "$TMP_FB/out" > "$TMP_FB/run.log" 2>&1
+FB_COMPOSE="$TMP_FB/out/runtipi/uptime-kuma/docker-compose.yml"
+assert_eq "$(yq eval '.services.uptime-kuma.image' "$FB_COMPOSE")" \
+  "louislam/uptime-kuma:2" "absent main_service falls back to the only service"
+rm -rf "$TMP_FB"
+
 exit $fail

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -246,7 +246,20 @@ assert_eq "$(yq eval '.services.updater.command[-1]' "$MS_COMPOSE" | grep -c 'ht
   "updater command host follows the renamed main service"
 assert_eq "$(yq eval '.services.updater.command[-1]' "$MS_COMPOSE" | grep -c 'http://app:3000' || true)" "0" \
   "updater command does not keep the pre-rename hostname"
+assert_eq "$(yq eval '.services.updater.depends_on.domainlocker.condition' "$MS_COMPOSE")" "service_healthy" \
+  "map-form depends_on keeps the health condition"
 rm -rf "$TMP_MS"
+
+section "e2e: invoice-ninja portless APP_URL follows renamed main_service"
+TMP_IN="$(mktemp -d)"
+bash "$REPO/scripts/convert-to-platforms.sh" -p runtipi -a invoice-ninja -o "$TMP_IN/out" > "$TMP_IN/run.log" 2>&1
+assert_eq "$?" "0" "invoice-ninja run exits 0"
+IN_COMPOSE="$TMP_IN/out/runtipi/invoice-ninja/docker-compose.yml"
+assert_eq "$(grep -c 'APP_URL=http://invoice-ninja$' "$IN_COMPOSE" || true)" "1" \
+  "portless APP_URL follows the renamed main service"
+assert_eq "$(grep -c 'APP_URL=http://big-bear-invoice-ninja-web' "$IN_COMPOSE" || true)" "0" \
+  "portless APP_URL does not keep the pre-rename hostname"
+rm -rf "$TMP_IN"
 
 section "e2e: synthetic reordered compose still promotes main_service"
 TMP_RO="$(mktemp -d)"
@@ -267,6 +280,11 @@ services:
     restart: unless-stopped
     depends_on:
       - app
+    environment:
+      APP_URL: http://app
+      HOST: app
+    links:
+      - app
 YAML
 jq '.technical.main_service = "app" | .technical.main_image = "louislam/uptime-kuma"' \
   "$TMP_RO/apps/uptime-kuma/app.json" > "$TMP_RO/apps/uptime-kuma/app.json.tmp" \
@@ -281,6 +299,12 @@ assert_eq "$(yq eval '.services.db.image' "$RO_COMPOSE")" "postgres:15-alpine" \
   "first service keeps its own name and image"
 assert_eq "$(yq eval '.services.worker.depends_on[0]' "$RO_COMPOSE")" "uptime-kuma" \
   "list-form depends_on follows the renamed main service"
+assert_eq "$(yq eval '.services.worker.environment.APP_URL' "$RO_COMPOSE")" "http://uptime-kuma" \
+  "portless APP_URL follows the renamed main service"
+assert_eq "$(yq eval '.services.worker.environment.HOST' "$RO_COMPOSE")" "uptime-kuma" \
+  "bare hostname env follows the renamed main service"
+assert_eq "$(yq eval '.services.worker.links[0]' "$RO_COMPOSE")" "uptime-kuma" \
+  "links follows the renamed main service"
 rm -rf "$TMP_RO"
 
 section "e2e: absent main_service still falls back to first service"

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -285,6 +285,7 @@ services:
       HOST: app
     links:
       - app
+      - app:database
 YAML
 jq '.technical.main_service = "app" | .technical.main_image = "louislam/uptime-kuma"' \
   "$TMP_RO/apps/uptime-kuma/app.json" > "$TMP_RO/apps/uptime-kuma/app.json.tmp" \
@@ -305,6 +306,8 @@ assert_eq "$(yq eval '.services.worker.environment.HOST' "$RO_COMPOSE")" "uptime
   "bare hostname env follows the renamed main service"
 assert_eq "$(yq eval '.services.worker.links[0]' "$RO_COMPOSE")" "uptime-kuma" \
   "links follows the renamed main service"
+assert_eq "$(yq eval '.services.worker.links[1]' "$RO_COMPOSE")" "uptime-kuma:database" \
+  "aliased links keep the alias and rewrite the service prefix"
 rm -rf "$TMP_RO"
 
 section "e2e: absent main_service still falls back to first service"

--- a/scripts/tests/test-convert-runtipi.sh
+++ b/scripts/tests/test-convert-runtipi.sh
@@ -240,8 +240,12 @@ assert_eq "$(yq eval '.services.updater.depends_on | has("domainlocker")' "$MS_C
   "updater depends_on follows the renamed main service"
 assert_eq "$(yq eval '.services.updater.depends_on | has("app")' "$MS_COMPOSE")" "false" \
   "updater does not depend on the pre-rename service name"
-assert_eq "$(yq eval '.services.domainlocker.networks.tipi_main_network.aliases[0]' "$MS_COMPOSE")" "app" \
-  "renamed service keeps old name as a network alias"
+assert_eq "$(yq eval '.services.domainlocker.networks | type' "$MS_COMPOSE")" "!!seq" \
+  "renamed service does not publish a shared-network alias"
+assert_eq "$(yq eval '.services.updater.command[-1]' "$MS_COMPOSE" | grep -c 'http://domainlocker:3000' || true)" "4" \
+  "updater command host follows the renamed main service"
+assert_eq "$(yq eval '.services.updater.command[-1]' "$MS_COMPOSE" | grep -c 'http://app:3000' || true)" "0" \
+  "updater command does not keep the pre-rename hostname"
 rm -rf "$TMP_MS"
 
 section "e2e: synthetic reordered compose still promotes main_service"


### PR DESCRIPTION
## Summary
- Added Domain Locker (`ghcr.io/lissy93/domain-locker`) as a universal app (issue #2900)
- Fixed `convert_to_runtipi()` so it promotes `technical.main_service` instead of the first compose service (Postgres was getting the web UI on domainlocker, guacamole, nightlio, and invoice-ninja)
- Rewrites sibling `depends_on` and `http(s)://<old>:` hostnames after rename; does not publish a shared-network DNS alias
- Set CasaOS category `Others` on domainlocker so convert/migrate stop failing

## Changes
- `apps/domainlocker/app.json` and `docker-compose.yml` — new app
- `scripts/convert-to-platforms.sh` — Runtipi main-service rename follow-up
- `scripts/tests/test-convert-runtipi.sh` — regression coverage for promote, depends_on, hostname rewrite
- `scripts/casaos-category-map.json` — `domainlocker: Others`

## Test Plan
- [x] `scripts/tests/test-convert-runtipi.sh` exit 0
- [x] `scripts/tests/test-convert-casaos.sh` exit 0
- [x] `scripts/tests/test-convert-umbrel.sh` exit 0
- [x] `scripts/validate-apps.sh` 247/247 passed
- [x] Converted Runtipi compose booted locally: HTTP 200, `/api/health` ok, Postgres tables created, updater reaches `domainlocker:3000`, `app` hostname does not resolve

Closes #2900









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Domain Locker to the universal app catalog and updates Runtipi conversion to promote the declared main service while following its rename through service references.
- Adds Domain Locker metadata, Compose services, platform compatibility, and CasaOS category mapping.
- Promotes `technical.main_service` rather than the first Compose service during Runtipi conversion.
- Rewrites dependencies, links, and internal hostname references after promotion.
- Adds Runtipi regression coverage and runs that suite in pull-request validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains established.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/convert-to-platforms.sh | Promotes the declared Runtipi main service and updates references after renaming; the prior regex-escaping concern cannot be conclusively reclassified from repository evidence. |
| scripts/tests/test-convert-runtipi.sh | Adds end-to-end coverage for main-service promotion, dependency forms, links, and hostname rewrites. |
| apps/domainlocker/app.json | Defines Domain Locker metadata, deployment inputs, and platform compatibility. |
| apps/domainlocker/docker-compose.yml | Adds the Domain Locker application, PostgreSQL database, and scheduled updater service. |
| .github/workflows/validate-pr.yml | Adds the required test dependency and runs the Runtipi converter suite in CI. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Fix: rewrite aliased links; pin converte..."](https://github.com/bigbeartechworld/big-bear-universal-apps/commit/4d9b5fcca52c6564ba95cf24fd4f0f6550e68828) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56843430)</sub>

<!-- /greptile_comment -->